### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,15 @@ jdk:
 env:
   - UI_DIR=ui
 
-before_script:
-  - cd $UI_DIR && npm install -g grunt-cli bower && npm install && bower install && grunt build
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - npm install karma && npm install karma-jasmine karma-chrome-launcher
+  - cd $UI_DIR && npm install -g grunt-cli bower
+  - npm install
+  - bower install
+  - grunt build && cd ..
 
 script:
   - mvn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - UI_DIR=ui
 
 before_install:
+  # Extra Chrome setup from: http://stackoverflow.com/questions/19255976
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>1.7.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/ui/karma.conf.js
+++ b/ui/karma.conf.js
@@ -55,6 +55,19 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false
+    singleRun: false,
+
+    //  Custom launcher for Travis-CI
+    customLaunchers: {
+      Chrome_travis_ci: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    }
   });
+
+  if(process.env.TRAVIS){
+    config.browsers = ['Chrome_travis_ci'];
+  }
+
 };


### PR DESCRIPTION
R: @sul3n3t 

Tests both the java code and ui through Travis.  There are a few changes and concerns:

- I had to slightly change a karma conf, because Travis is a little harder to setup with Chrome instead of Firefox.  Inspiration from: http://stackoverflow.com/questions/19255976/how-to-make-travis-execute-angular-tests-on-chrome-please-set-env-variable-chr

- I've temporarily reverted the shade plugin to a previously functioning version (before MSHADE-183).  On version 2.3, Travis fails the mvn install stage.