### PR TITLE
Justin/maven

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -11,10 +11,6 @@
   <artifactId>keywhiz-cli</artifactId>
   <name>Keywhiz CLI</name>
 
-  <properties>
-    <project.mainclass>keywhiz.cli.CliMain</project.mainclass>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -65,6 +61,30 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Class-Path>lib-signed/bcprov-jdk15on.jar</Class-Path>
+                    <Main-Class>keywhiz.cli.CliMain</Main-Class>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.skife.maven</groupId>
         <artifactId>really-executable-jar-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -315,51 +315,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>1.7.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>shaded</shadedClassifierName>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <manifestEntries>
-                    <Class-Path>lib-signed/bcprov-jdk15on.jar</Class-Path>
-                    <Main-Class>${project.mainclass}</Main-Class>
-                  </manifestEntries>
-                </transformer>
-              </transformers>
-
-              <!-- signatures from foreign jars are bad news -->
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-
-              <artifactSet>
-                <excludes>
-                  <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
-                </excludes>
-              </artifactSet>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>2.8</version>
         <executions>
@@ -395,6 +350,35 @@
 
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <!-- Updating blocked on MSHADE-183 -->
+          <version>1.7.1</version>
+          <configuration>
+            <shadedArtifactAttached>true</shadedArtifactAttached>
+            <shadedClassifierName>shaded</shadedClassifierName>
+
+            <!-- signatures from foreign jars are bad news -->
+            <filters>
+              <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                  <exclude>META-INF/*.SF</exclude>
+                  <exclude>META-INF/*.DSA</exclude>
+                  <exclude>META-INF/*.RSA</exclude>
+                </excludes>
+              </filter>
+            </filters>
+
+            <artifactSet>
+              <excludes>
+                <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
+              </excludes>
+            </artifactSet>
+          </configuration>
+        </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
             <effort>Max</effort>
             <threshold>Default</threshold>
             <xmlOutput>true</xmlOutput>
-            <excludeFilterFile>${project.parent.basedir}/findbugs-exclude.xml</excludeFilterFile>
+            <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
           </configuration>
           <executions>
             <execution>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -11,10 +11,6 @@
   <artifactId>keywhiz-server</artifactId>
   <name>Keywhiz Server</name>
 
-  <properties>
-    <project.mainclass>keywhiz.KeywhizService</project.mainclass>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.squareup.keywhiz</groupId>
@@ -194,6 +190,30 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Class-Path>lib-signed/bcprov-jdk15on.jar</Class-Path>
+                    <Main-Class>keywhiz.KeywhizService</Main-Class>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
R: @riyazdf 

The attempted release failed because every module was getting shaded. For example, the keywhiz-parent module failed with an empty shaded jar.