### PR TITLE
move all references for metadata from series to content

### DIFF
--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -66,7 +66,7 @@ public abstract class SanitizedSecret {
         content.createdBy(),
         content.updatedAt(),
         content.updatedBy(),
-        series.getMetadata(),
+        content.metadata(),
         series.getType().orElse(null),
         series.getGenerationOptions());
   }

--- a/api/src/main/java/keywhiz/api/model/SecretContent.java
+++ b/api/src/main/java/keywhiz/api/model/SecretContent.java
@@ -16,8 +16,10 @@
 
 package keywhiz.api.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -30,9 +32,9 @@ import javax.annotation.Nullable;
 public abstract class SecretContent {
   public static SecretContent of(long id, long secretSeriesId, String encryptedContent,
       @Nullable String version, OffsetDateTime createdAt, @Nullable String createdBy,
-      OffsetDateTime updatedAt, @Nullable String updatedBy) {
+      OffsetDateTime updatedAt, @Nullable String updatedBy, ImmutableMap<String, String> metadata) {
     return new AutoValue_SecretContent(id, secretSeriesId, encryptedContent,
-        Optional.ofNullable(version), createdAt, createdBy, updatedAt, updatedBy);
+        Optional.ofNullable(version), createdAt, createdBy, updatedAt, updatedBy, metadata);
   }
 
   public abstract long id();
@@ -43,6 +45,7 @@ public abstract class SecretContent {
   @Nullable public abstract String createdBy();
   public abstract OffsetDateTime updatedAt();
   @Nullable public abstract String updatedBy();
+  @JsonAnyGetter public abstract  ImmutableMap<String, String> metadata();
 
   @Override public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -54,6 +57,7 @@ public abstract class SecretContent {
         .add("createdBy", createdBy())
         .add("updatedAt", updatedAt())
         .add("updatedBy", updatedBy())
+        .add("metadata", metadata())
         .omitNullValues().toString();
   }
 }

--- a/api/src/main/java/keywhiz/api/model/SecretSeries.java
+++ b/api/src/main/java/keywhiz/api/model/SecretSeries.java
@@ -39,7 +39,6 @@ public class SecretSeries {
   private final String createdBy;
   private final OffsetDateTime updatedAt;
   private final String updatedBy;
-  private final ImmutableMap<String, String> metadata;
   private final String type;
   private final ImmutableMap<String, String> generationOptions;
 
@@ -50,7 +49,6 @@ public class SecretSeries {
       String createdBy,
       OffsetDateTime updatedAt,
       String updatedBy,
-      @Nullable Map<String, String> metadata,
       @Nullable String type,
       @Nullable Map<String, String> generationOptions) {
     this.id = id;
@@ -60,8 +58,6 @@ public class SecretSeries {
     this.createdBy = createdBy;
     this.updatedAt = updatedAt;
     this.updatedBy = updatedBy;
-    this.metadata = (metadata == null) ?
-        ImmutableMap.of() : ImmutableMap.copyOf(metadata);
     this.type = type;
     this.generationOptions = (generationOptions == null) ?
         ImmutableMap.of() : ImmutableMap.copyOf(generationOptions);
@@ -95,10 +91,6 @@ public class SecretSeries {
     return updatedBy;
   }
 
-  public ImmutableMap<String, String> getMetadata() {
-    return metadata;
-  }
-
   public Optional<String> getType() {
     return Optional.ofNullable(type);
   }
@@ -109,7 +101,7 @@ public class SecretSeries {
 
   @Override public int hashCode() {
     return Objects.hashCode(id, name, description, createdAt, createdBy, updatedAt, updatedBy,
-        metadata, type, generationOptions);
+        type, generationOptions);
   }
 
   @Override public boolean equals(Object o) {
@@ -123,7 +115,6 @@ public class SecretSeries {
           Objects.equal(this.createdBy, that.createdBy) &&
           Objects.equal(this.updatedAt, that.updatedAt) &&
           Objects.equal(this.updatedBy, that.updatedBy) &&
-          Objects.equal(this.metadata, that.metadata) &&
           Objects.equal(this.type, that.type) &&
           Objects.equal(this.generationOptions, that.generationOptions)) {
         return true;
@@ -141,7 +132,6 @@ public class SecretSeries {
         .add("createdBy", createdBy)
         .add("updatedAt", updatedAt)
         .add("updatedBy", updatedBy)
-        .add("metadata", metadata)
         .add("type", type)
         .add("generationOptions", generationOptions)
         .omitNullValues()

--- a/server/src/main/java/keywhiz/service/crypto/SecretTransformer.java
+++ b/server/src/main/java/keywhiz/service/crypto/SecretTransformer.java
@@ -56,7 +56,7 @@ public class SecretTransformer {
         content.createdBy(),
         content.updatedAt(),
         content.updatedBy(),
-        series.getMetadata(),
+        content.metadata(),
         series.getType().orElse(null),
         series.getGenerationOptions());
   }

--- a/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
@@ -17,6 +17,7 @@
 package keywhiz.service.daos;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Map;
 import java.util.Optional;
 import keywhiz.api.model.SecretContent;
 import org.skife.jdbi.v2.sqlobject.Bind;
@@ -30,24 +31,24 @@ import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 @RegisterMapper(SecretContentMapper.class)
 public interface SecretContentDAO {
   @GetGeneratedKeys
-  @SqlUpdate("INSERT INTO secrets_content (secretId, encrypted_content, version, createdBy, updatedBy) " +
-             "VALUES (:secretId, :encryptedContent, :version, :creator, :creator)")
+  @SqlUpdate("INSERT INTO secrets_content (secretId, encrypted_content, version, createdBy, updatedBy, metadata) " +
+             "VALUES (:secretId, :encryptedContent, :version, :creator, :creator, :metadata)")
   long createSecretContent(@Bind("secretId") long secretId,
       @Bind("encryptedContent") String encryptedContent, @Bind("version") String version,
-      @Bind("creator") String creator);
+      @Bind("creator") String creator, @Bind("metadata") Map<String, String> metadata);
 
   @SingleValueResult(SecretContent.class)
-  @SqlQuery("SELECT id, secretId, encrypted_content, version, createdAt, createdBy, updatedAt, updatedBy " +
+  @SqlQuery("SELECT id, secretId, encrypted_content, version, createdAt, createdBy, updatedAt, updatedBy, metadata " +
             "FROM secrets_content WHERE id = :id")
   Optional<SecretContent> getSecretContentById(@Bind("id") long id);
 
   @SingleValueResult(SecretContent.class)
-  @SqlQuery("SELECT id, secretId, encrypted_content, version, createdAt, createdBy, updatedAt, updatedBy " +
+  @SqlQuery("SELECT id, secretId, encrypted_content, version, createdAt, createdBy, updatedAt, updatedBy, metadata " +
             "FROM secrets_content WHERE secretId = :secretId AND version = :version")
   Optional<SecretContent> getSecretContentBySecretIdAndVersion(
       @Bind("secretId") long secretId, @Bind("version") String version);
 
-  @SqlQuery("SELECT id, secretId, encrypted_content, version, createdAt, createdBy, updatedAt, updatedBy " +
+  @SqlQuery("SELECT id, secretId, encrypted_content, version, createdAt, createdBy, updatedAt, updatedBy, metadata " +
             "FROM secrets_content WHERE secretId = :secretId")
   ImmutableList<SecretContent> getSecretContentsBySecretId(@Bind("secretId") long secretId);
 

--- a/server/src/main/java/keywhiz/service/daos/SecretContentMapper.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentMapper.java
@@ -16,16 +16,29 @@
 
 package keywhiz.service.daos;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.jackson.Jackson;
+import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Map;
+import keywhiz.KeywhizService;
 import keywhiz.api.model.SecretContent;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 
 /** Maps DB query result rows to {@link SecretContent} objects. */
 public class SecretContentMapper implements ResultSetMapper<SecretContent> {
+  private static final TypeReference MAP_STRING_STRING_TYPE =
+      new TypeReference<Map<String, String>>() {};
+  private final ObjectMapper
+      mapper = KeywhizService.customizeObjectMapper(Jackson.newObjectMapper());
+
   @Override
   public SecretContent map(int index, ResultSet r, StatementContext ctx) throws SQLException {
     return SecretContent.of(r.getLong("id"),
@@ -35,6 +48,25 @@ public class SecretContentMapper implements ResultSetMapper<SecretContent> {
                             r.getTimestamp("createdAt").toLocalDateTime().atOffset(UTC),
                             r.getString("createdBy"),
                             r.getTimestamp("updatedAt").toLocalDateTime().atOffset(UTC),
-                            r.getString("updatedBy"));
+                            r.getString("updatedBy"),
+                            tryToReadMetadata(r, "metadata"));
+  }
+
+  private ImmutableMap<String, String> tryToReadMetadata(ResultSet resultSet, String fieldName)
+      throws SQLException {
+    Map<String, String> map = null;
+    String field = resultSet.getString(fieldName);
+    if (!field.isEmpty()) {
+      try {
+        map = mapper.readValue(field, MAP_STRING_STRING_TYPE);
+      } catch (IOException e) {
+        throw new RuntimeException(
+            format("Failed to create a Map from data. Bad json in %s column?", fieldName), e);
+      }
+    }
+    if (map == null) {
+      return ImmutableMap.of();
+    }
+    return ImmutableMap.copyOf(map);
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/SecretController.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretController.java
@@ -115,7 +115,7 @@ public class SecretController {
     checkArgument(!secret.isEmpty());
     checkArgument(!creator.isEmpty());
     String encryptedSecret = cryptographer.encryptionKeyDerivedFrom(name).encrypt(secret);
-    return new SecretBuilder(transformer, secretDAO, name, secret, encryptedSecret, creator);
+    return new SecretBuilder(transformer, secretDAO, name, encryptedSecret, creator);
   }
 
   /** Builder to generate new secret series or versions with. */
@@ -123,7 +123,6 @@ public class SecretController {
     private final SecretTransformer transformer;
     private final SecretDAO secretDAO;
     private final String name;
-    private final String secret;
     private final String encryptedSecret;
     private final String creator;
     private String description = "";
@@ -136,16 +135,14 @@ public class SecretController {
      * @param transformer
      * @param secretDAO
      * @param name of secret series.
-     * @param secret content of secret version.
      * @param encryptedSecret encrypted content of secret version
      * @param creator username responsible for creating this secret version.
      */
-    private SecretBuilder(SecretTransformer transformer, SecretDAO secretDAO, String name, String secret, String encryptedSecret,
+    private SecretBuilder(SecretTransformer transformer, SecretDAO secretDAO, String name, String encryptedSecret,
         String creator) {
       this.transformer = transformer;
       this.secretDAO = secretDAO;
       this.name = name;
-      this.secret = secret;
       this.encryptedSecret = encryptedSecret;
       this.creator = creator;
     }

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -47,17 +47,17 @@ public abstract class SecretDAO implements Transactional<SecretDAO> {
   public long createSecret(String name, String encryptedSecret, String version,
       String creator, Map<String, String> metadata, String description, @Nullable String type,
       @Nullable Map<String, String> generationOptions) {
-    // TODO(jlfwong): Should the metadata and description be updated...?
+    // TODO(jlfwong): Should the description be updated...?
     long secretId;
     Optional<SecretSeries> secretSeries = createSecretSeriesDAO().getSecretSeriesByName(name);
     if (secretSeries.isPresent()) {
       secretId = secretSeries.get().getId();
     } else {
       secretId = createSecretSeriesDAO()
-          .createSecretSeries(name, creator, metadata, description, type, generationOptions);
+          .createSecretSeries(name, creator, description, type, generationOptions);
     }
 
-    createSecretContentDAO().createSecretContent(secretId, encryptedSecret, version, creator);
+    createSecretContentDAO().createSecretContent(secretId, encryptedSecret, version, creator, metadata);
     return secretId;
   }
 

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -32,24 +32,24 @@ import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 @RegisterMapper(SecretSeriesMapper.class)
 public interface SecretSeriesDAO {
   @GetGeneratedKeys
-  @SqlUpdate("INSERT INTO secrets (name, description, createdBy, updatedBy, metadata, type, options) " +
-      "VALUES (:name, :description, :creator, :creator, :metadata, :type, COALESCE(:options,'{}'))")
+  @SqlUpdate("INSERT INTO secrets (name, description, createdBy, updatedBy, type, options) " +
+      "VALUES (:name, :description, :creator, :creator, :type, COALESCE(:options,'{}'))")
   long createSecretSeries(@Bind("name") String name, @Bind("creator") String creator,
-      @Bind("metadata") Map<String, String> metadata, @Bind("description") String description,
+      @Bind("description") String description,
       @Nullable @Bind("type") String type,
       @Nullable @Bind("options") Map<String, String> generationOptions);
 
   @SingleValueResult(SecretSeries.class)
-  @SqlQuery("SELECT id, name, description, createdAt, createdBy, updatedAt, updatedBy, metadata, " +
+  @SqlQuery("SELECT id, name, description, createdAt, createdBy, updatedAt, updatedBy, " +
       "type, options FROM secrets WHERE id = :id")
   Optional<SecretSeries> getSecretSeriesById(@Bind("id") long id);
 
   @SingleValueResult(SecretSeries.class)
-  @SqlQuery("SELECT id, name, description, createdAt, createdBy, updatedAt, updatedBy, metadata, " +
+  @SqlQuery("SELECT id, name, description, createdAt, createdBy, updatedAt, updatedBy, " +
       "type, options FROM secrets WHERE name = :name")
   Optional<SecretSeries> getSecretSeriesByName(@Bind("name") String name);
 
-  @SqlQuery("SELECT id, name, description, createdAt, createdBy, updatedAt, updatedBy, metadata, " +
+  @SqlQuery("SELECT id, name, description, createdAt, createdBy, updatedAt, updatedBy, " +
       "type, options FROM secrets")
   ImmutableList<SecretSeries> getSecretSeries();
 

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesMapper.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesMapper.java
@@ -45,7 +45,6 @@ public class SecretSeriesMapper implements ResultSetMapper<SecretSeries> {
                             r.getString("createdBy"),
                             r.getTimestamp("updatedAt").toLocalDateTime().atOffset(ZoneOffset.UTC),
                             r.getString("updatedBy"),
-                            tryToReadMapValue(r, "metadata"),
                             r.getString("type"),
                             tryToReadMapValue(r, "options"));
   }

--- a/server/src/main/resources/db/migration/V2.10__secret_metadata_null.sql
+++ b/server/src/main/resources/db/migration/V2.10__secret_metadata_null.sql
@@ -1,0 +1,4 @@
+/*
+ * Allow secret metadata column to be NULL for new records, until the column is dropped completely.
+ */
+ALTER TABLE secrets ALTER COLUMN metadata DROP NOT NULL;

--- a/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
@@ -17,6 +17,7 @@
 package keywhiz.service.daos;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -35,8 +36,10 @@ public class SecretContentDAOTest {
   @Rule public final TestDBRule testDBRule = new TestDBRule();
 
   final static OffsetDateTime date = OffsetDateTime.now(ZoneId.of("UTC"));
+  ImmutableMap<String, String> emptyMetadata = ImmutableMap.of();
+
   SecretContent secretContent1 = SecretContent.of(11, 22, "[crypted]", "", date, "creator", date,
-      "creator");
+      "creator", emptyMetadata);
 
   SecretContentDAO secretContentDAO;
 
@@ -62,9 +65,9 @@ public class SecretContentDAOTest {
 
   @Test public void createSecretContent() {
     int before = tableSize();
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator");
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator");
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator");
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator", emptyMetadata);
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator", emptyMetadata);
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator", emptyMetadata);
     assertThat(tableSize()).isEqualTo(before + 3);
   }
 
@@ -75,9 +78,9 @@ public class SecretContentDAOTest {
   }
 
   @Test public void getSecretContentsBySecretId() {
-    long id1 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator");
-    long id2 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator");
-    long id3 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator");
+    long id1 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator", emptyMetadata);
+    long id2 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator", emptyMetadata);
+    long id3 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator", emptyMetadata);
 
     List<Long> actualIds = secretContentDAO.getSecretContentsBySecretId(secretContent1.secretSeriesId())
         .stream()
@@ -88,9 +91,9 @@ public class SecretContentDAOTest {
   }
 
   @Test public void getVersionsBySecretId() {
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator");
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator");
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator");
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator", emptyMetadata);
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator", emptyMetadata);
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator", emptyMetadata);
 
     // We have the empty string as a version from the setUp() call
     assertThat(secretContentDAO.getVersionFromSecretId(secretContent1.secretSeriesId()))

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -44,15 +44,16 @@ public class SecretDAOTest {
   final static ContentCryptographer cryptographer = CryptoFixtures.contentCryptographer();
   final static OffsetDateTime date = OffsetDateTime.now();
   final static String version = VersionGenerator.now().toHex();
+  ImmutableMap<String, String> emptyMetadata = ImmutableMap.of();
 
-  SecretSeries series1 = new SecretSeries(1, "secret1", "desc1", date, "creator", date, "updater", null, null, null);
+  SecretSeries series1 = new SecretSeries(1, "secret1", "desc1", date, "creator", date, "updater", null, null);
   String content = "c2VjcmV0MQ==";
   String encryptedContent = cryptographer.encryptionKeyDerivedFrom(series1.getName()).encrypt(content);
-  SecretContent content1 = SecretContent.of(101, 1, encryptedContent, version, date, "creator", date, "updater");
+  SecretContent content1 = SecretContent.of(101, 1, encryptedContent, version, date, "creator", date, "updater", emptyMetadata);
   SecretSeriesAndContent secret1 = SecretSeriesAndContent.of(series1, content1);
 
-  SecretSeries series2 = new SecretSeries(2, "secret2", "desc2", date, "creator", date, "updater", null, null, null);
-  SecretContent content2 = SecretContent.of(102, 2, encryptedContent, "", date, "creator", date, "updater");
+  SecretSeries series2 = new SecretSeries(2, "secret2", "desc2", date, "creator", date, "updater", null, null);
+  SecretContent content2 = SecretContent.of(102, 2, encryptedContent, "", date, "creator", date, "updater", emptyMetadata);
   SecretSeriesAndContent secret2 = SecretSeriesAndContent.of(series2, content2);
 
   SecretDAO secretDAO;
@@ -71,7 +72,6 @@ public class SecretDAOTest {
         .set(SECRETS.CREATEDAT, secret1.series().getCreatedAt())
         .set(SECRETS.CREATEDBY, secret1.series().getCreatedBy())
         .set(SECRETS.UPDATEDBY, secret1.series().getUpdatedBy())
-        .set(SECRETS.METADATA, objectMapper.writeValueAsString(secret1.series().getMetadata()))
         .execute();
 
     testDBRule.jooqContext().insertInto(SECRETS_CONTENT)
@@ -81,6 +81,7 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.CREATEDAT, secret1.content().createdAt())
         .set(SECRETS_CONTENT.CREATEDBY, secret1.content().createdBy())
         .set(SECRETS_CONTENT.UPDATEDBY, secret1.content().updatedBy())
+        .set(SECRETS_CONTENT.METADATA, objectMapper.writeValueAsString(secret1.content().metadata()))
         .execute();
 
     testDBRule.jooqContext().insertInto(SECRETS)
@@ -90,7 +91,6 @@ public class SecretDAOTest {
         .set(SECRETS.CREATEDAT, secret2.series().getCreatedAt())
         .set(SECRETS.CREATEDBY, secret2.series().getCreatedBy())
         .set(SECRETS.UPDATEDBY, secret2.series().getUpdatedBy())
-        .set(SECRETS.METADATA, objectMapper.writeValueAsString(secret2.series().getMetadata()))
         .execute();
 
     testDBRule.jooqContext().insertInto(SECRETS_CONTENT)
@@ -100,6 +100,7 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.CREATEDAT, secret2.content().createdAt())
         .set(SECRETS_CONTENT.CREATEDBY, secret2.content().createdBy())
         .set(SECRETS_CONTENT.UPDATEDBY, secret2.content().updatedBy())
+        .set(SECRETS_CONTENT.METADATA, objectMapper.writeValueAsString(secret2.content().metadata()))
         .execute();
 
     secretDAO = testDBRule.getDbi().onDemand(SecretDAO.class);

--- a/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
@@ -43,28 +43,26 @@ public class SecretSeriesDAOTest {
     int before = tableSize();
     OffsetDateTime now = OffsetDateTime.now();
 
-    long id = secretSeriesDAO.createSecretSeries("newSecretSeries", "creator",
-        ImmutableMap.of("key1", "value1"), "desc", null, null);
+    long id = secretSeriesDAO.createSecretSeries("newSecretSeries", "creator", "desc", null, null);
     SecretSeries expected = new SecretSeries(id, "newSecretSeries", "desc", now, "creator", now,
-        "creator", ImmutableMap.of("key1", "value1"), null, null);
+        "creator", null, null);
 
     assertThat(tableSize()).isEqualTo(before + 1);
 
     SecretSeries actual = secretSeriesDAO.getSecretSeriesByName("newSecretSeries")
         .orElseThrow(RuntimeException::new);
     assertThat(actual).isEqualToComparingOnlyGivenFields(expected,
-        "name", "description", "metadata", "type", "generationOptions");
+        "name", "description", "type", "generationOptions");
 
     actual = secretSeriesDAO.getSecretSeriesById(id)
         .orElseThrow(RuntimeException::new);
     assertThat(actual).isEqualToComparingOnlyGivenFields(expected,
-        "name", "description", "metadata", "type", "generationOptions");
+        "name", "description", "type", "generationOptions");
   }
 
   @Test
   public void deleteSecretSeriesByName() {
-    secretSeriesDAO.createSecretSeries("toBeDeleted_deleteSecretSeriesByName", "creator",
-        ImmutableMap.of(), "", null, null);
+    secretSeriesDAO.createSecretSeries("toBeDeleted_deleteSecretSeriesByName", "creator", "", null, null);
 
     int secretsBefore = tableSize();
 
@@ -79,8 +77,7 @@ public class SecretSeriesDAOTest {
 
   @Test
   public void deleteSecretSeriesById() {
-    long id = secretSeriesDAO.createSecretSeries("toBeDeleted_deleteSecretSeriesById", "creator",
-        ImmutableMap.of(), "", null, null);
+    long id = secretSeriesDAO.createSecretSeries("toBeDeleted_deleteSecretSeriesById", "creator", "", null, null);
 
     int secretsBefore = tableSize();
 

--- a/server/src/test/java/keywhiz/service/resources/AutomationSecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationSecretResourceTest.java
@@ -113,7 +113,6 @@ public class AutomationSecretResourceTest {
         NOW,
         automation.getName(),
         null,
-        null,
         null);
 
     when(secretSeriesDAO.getSecretSeriesByName(secretSeries.getName()))

--- a/server/src/test/resources/server_test_data.sql
+++ b/server/src/test/resources/server_test_data.sql
@@ -18,25 +18,25 @@ INSERT INTO groups (id, name, createdat, updatedat) VALUES
 -- Data for Name: secrets; Type: TABLE DATA; Schema: public; Owner: square
 --
 
-INSERT INTO secrets (id, name,  createdat, updatedat, metadata) VALUES
-(737, 'Nobody_PgPass','2011-09-29 15:46:00.232',	'2011-09-29 15:46:00.232', '{"mode":"0400","owner":"nobody"}'),
-(738,	'Hacking_Password','2011-09-29 15:46:00.312'	,'2011-09-29 15:46:00.312', ''),
-(739,	'Database_Password','2011-09-29 15:46:00.232',	'2011-09-29 15:46:00.232', ''),
-(740,	'General_Password','2011-09-29 15:46:00.312',	'2011-09-29 15:46:00.312', ''),
-(741,	'NonexistentOwner_Pass','2011-09-29 15:46:00.232',	'2011-09-29 15:46:00.232', '{"owner":"NonExistant","mode":"0400"}'),
-(742,	'Versioned_Password','2011-09-29 15:46:00.232',	'2011-09-29 15:46:00.232', ''),
-(743,	'Multiple_Versioned_Password','2011-09-29 15:46:00.232',	'2011-09-29 15:36:00.232', '');
+INSERT INTO secrets (id, name,  createdat, updatedat) VALUES
+(737, 'Nobody_PgPass','2011-09-29 15:46:00.232',	'2011-09-29 15:46:00.232'),
+(738,	'Hacking_Password','2011-09-29 15:46:00.312'	,'2011-09-29 15:46:00.312'),
+(739,	'Database_Password','2011-09-29 15:46:00.232',	'2011-09-29 15:46:00.232'),
+(740,	'General_Password','2011-09-29 15:46:00.312',	'2011-09-29 15:46:00.312'),
+(741,	'NonexistentOwner_Pass','2011-09-29 15:46:00.232',	'2011-09-29 15:46:00.232'),
+(742,	'Versioned_Password','2011-09-29 15:46:00.232',	'2011-09-29 15:46:00.232'),
+(743,	'Multiple_Versioned_Password','2011-09-29 15:46:00.232',	'2011-09-29 15:36:00.232');
 
-INSERT INTO secrets_content (id, secretid, version, createdat, updatedat, encrypted_content) VALUES
-(937, 737, '', '2011-09-29 15:46:00.232', '2015-01-07 12:00:47.674786', '{"derivationInfo":"Nobody_PgPass","content":"5Eq97Y/6LMLUqH8rlXxEkOeMFmc3cYhQny0eotojNrF3DTFdQPyHVG5HeP5vzaFxqttcZkO56NvIwdD8k2xyIL5YRbCIA5MQ9LOnKN4tpnwb+Q","iv":"jQAFJizi1MKZUcCxb6mTCA"}'),
-(938, 738, '', '2011-09-29 15:46:00.312', '2015-01-07 12:01:59.335018', '{"derivationInfo":"Hacking_Password","content":"jpNVoXZao+b+f591w+CHWTj7D1M","iv":"W+pT37jJP4uDGHmuczXVCA"}'),
-(939, 739, '', '2011-09-29 15:46:00.232', '2015-01-07 12:02:06.73539', '{"derivationInfo":"Database_Password","content":"etQQFqMHQQpGr4aDlj5gDjiABkOb","iv":"ia+YixjAEqp9W3JEjaYLvQ"}'),
-(940, 740, '', '2011-09-29 15:46:00.312', '2015-01-07 12:02:06.758446', '{"derivationInfo":"General_Password","content":"A6kBLXwmx0EVtuIGTzxHiEZ/6yrXgg","iv":"e4I0c3fog0TKqTAC2UxYtQ"}'),
-(941, 741, '', '2011-09-29 15:46:00.232', '2015-01-07 12:02:06.78574', '{"derivationInfo":"NonexistentOwner_Pass","content":"+Pu1B5YgqGRIHzh17s5tPT3AYb+W","iv":"ewRV3RhFfLnbWxY5pr401g"}'),
-(942, 742, '0aae825a73e161d8', '2011-09-29 15:46:00.232', '2015-01-07 12:02:06.806212', '{"derivationInfo":"Versioned_Password","content":"GC8/ZvEfqpxhtAkThgZ8/+vPesh9","iv":"oRf3CMnB7jv63K33dJFeFg"}'),
-(943, 743, '0aae825a73e161e8', '2011-09-29 16:46:00.232', '2011-09-29 16:46:00.232', '{"derivationInfo":"Multiple_Versioned_Password","content":"GC8/ZvEfqpxhtAkThgZ8/+vPesh9","iv":"oRf3CMnB7jv63K33dJFeFg"}'),
-(944, 743, '0aae825a73e161f8', '2011-09-29 17:46:00.232', '2011-09-29 17:46:00.232', '{"derivationInfo":"Multiple_Versioned_Password","content":"GC8/ZvEfqpxhtAkThgZ8/+vPesh9","iv":"oRf3CMnB7jv63K33dJFeFg"}'),
-(945, 743, '0aae825a73e161g8', '2011-09-29 18:46:00.232', '2011-09-29 18:46:00.232', '{"derivationInfo":"Multiple_Versioned_Password","content":"GC8/ZvEfqpxhtAkThgZ8/+vPesh9","iv":"oRf3CMnB7jv63K33dJFeFg"}');
+INSERT INTO secrets_content (id, secretid, version, createdat, updatedat, encrypted_content, metadata) VALUES
+(937, 737, '', '2011-09-29 15:46:00.232', '2015-01-07 12:00:47.674786', '{"derivationInfo":"Nobody_PgPass","content":"5Eq97Y/6LMLUqH8rlXxEkOeMFmc3cYhQny0eotojNrF3DTFdQPyHVG5HeP5vzaFxqttcZkO56NvIwdD8k2xyIL5YRbCIA5MQ9LOnKN4tpnwb+Q","iv":"jQAFJizi1MKZUcCxb6mTCA"}', '{"mode":"0400","owner":"nobody"}'),
+(938, 738, '', '2011-09-29 15:46:00.312', '2015-01-07 12:01:59.335018', '{"derivationInfo":"Hacking_Password","content":"jpNVoXZao+b+f591w+CHWTj7D1M","iv":"W+pT37jJP4uDGHmuczXVCA"}', ''),
+(939, 739, '', '2011-09-29 15:46:00.232', '2015-01-07 12:02:06.73539', '{"derivationInfo":"Database_Password","content":"etQQFqMHQQpGr4aDlj5gDjiABkOb","iv":"ia+YixjAEqp9W3JEjaYLvQ"}', ''),
+(940, 740, '', '2011-09-29 15:46:00.312', '2015-01-07 12:02:06.758446', '{"derivationInfo":"General_Password","content":"A6kBLXwmx0EVtuIGTzxHiEZ/6yrXgg","iv":"e4I0c3fog0TKqTAC2UxYtQ"}', ''),
+(941, 741, '', '2011-09-29 15:46:00.232', '2015-01-07 12:02:06.78574', '{"derivationInfo":"NonexistentOwner_Pass","content":"+Pu1B5YgqGRIHzh17s5tPT3AYb+W","iv":"ewRV3RhFfLnbWxY5pr401g"}', '{"owner":"NonExistant","mode":"0400"}'),
+(942, 742, '0aae825a73e161d8', '2011-09-29 15:46:00.232', '2015-01-07 12:02:06.806212', '{"derivationInfo":"Versioned_Password","content":"GC8/ZvEfqpxhtAkThgZ8/+vPesh9","iv":"oRf3CMnB7jv63K33dJFeFg"}', ''),
+(943, 743, '0aae825a73e161e8', '2011-09-29 16:46:00.232', '2011-09-29 16:46:00.232', '{"derivationInfo":"Multiple_Versioned_Password","content":"GC8/ZvEfqpxhtAkThgZ8/+vPesh9","iv":"oRf3CMnB7jv63K33dJFeFg"}', ''),
+(944, 743, '0aae825a73e161f8', '2011-09-29 17:46:00.232', '2011-09-29 17:46:00.232', '{"derivationInfo":"Multiple_Versioned_Password","content":"GC8/ZvEfqpxhtAkThgZ8/+vPesh9","iv":"oRf3CMnB7jv63K33dJFeFg"}', ''),
+(945, 743, '0aae825a73e161g8', '2011-09-29 18:46:00.232', '2011-09-29 18:46:00.232', '{"derivationInfo":"Multiple_Versioned_Password","content":"GC8/ZvEfqpxhtAkThgZ8/+vPesh9","iv":"oRf3CMnB7jv63K33dJFeFg"}', '');
 
 --
 -- Data for Name: clients; Type: TABLE DATA; Schema: public; Owner: square


### PR DESCRIPTION
R: @sul3n3t 

**Before merging**: will have to run db command to copy pre-existing metadata from secrets to secrets_content table, matching by secret ID: `UPDATE secrets_content SET metadata = secrets.metadata FROM secrets WHERE secrets.id = secretId;`

Changes:
- metadata column in secrets table is now nullable
- all reads and writes of metadata are done on the metadata column in secrets_content
- remove references to plaintext secret in SecretBuilder (column was dropped previously)