### PR TITLE
remove last references before dropping secrets metadata column

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -214,7 +214,7 @@ public abstract class AclDAO {
   @SqlUpdate("DELETE FROM memberships WHERE clientId = :clientId AND groupId = :groupId")
   protected abstract void evictClient(@Bind("clientId") long clientId, @Bind("groupId") long groupId);
 
-  @SqlQuery("SELECT secrets.id, secrets.name, secrets.description, secrets.metadata, " +
+  @SqlQuery("SELECT secrets.id, secrets.name, secrets.description, " +
       "secrets.createdAt, secrets.createdBy, secrets.updatedAt, secrets.updatedBy, secrets.type, " +
       "secrets.options " +
       "FROM secrets " +
@@ -223,7 +223,7 @@ public abstract class AclDAO {
       "WHERE groups.name = :name")
   protected abstract ImmutableSet<SecretSeries> getSecretSeriesFor(@BindBean Group group);
 
-  @SqlQuery("SELECT secrets.id, secrets.name, secrets.description, secrets.metadata, " +
+  @SqlQuery("SELECT secrets.id, secrets.name, secrets.description, " +
       "secrets.createdAt, secrets.createdBy, secrets.updatedAt, secrets.updatedBy, secrets.type, " +
       "secrets.options " +
       "FROM secrets " +
@@ -241,7 +241,7 @@ public abstract class AclDAO {
    * table should be used to determine the exception.
    */
   @SingleValueResult(SecretSeries.class)
-  @SqlQuery("SELECT secrets.id, secrets.name, secrets.description, secrets.metadata, " +
+  @SqlQuery("SELECT secrets.id, secrets.name, secrets.description, " +
             "secrets.createdAt, secrets.createdBy, secrets.updatedAt, secrets.updatedBy, " +
             "secrets.type, secrets.options " +
             "FROM secrets JOIN secrets_content on secrets.id = secrets_content.secretId " +

--- a/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
@@ -60,6 +60,7 @@ public class SecretContentDAOTest {
         .set(SECRETS_CONTENT.CREATEDBY, secretContent1.createdBy())
         .set(SECRETS_CONTENT.UPDATEDAT, secretContent1.updatedAt())
         .set(SECRETS_CONTENT.UPDATEDBY, secretContent1.updatedBy())
+        .set(SECRETS_CONTENT.METADATA, "{}")
         .execute();
   }
 

--- a/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
@@ -48,8 +48,8 @@ public class SecretContentDAOTest {
     secretContentDAO = testDBRule.getDbi().onDemand(SecretContentDAO.class);
 
     testDBRule.jooqContext().delete(SECRETS).execute();
-    testDBRule.jooqContext().insertInto(SECRETS, SECRETS.ID, SECRETS.NAME, SECRETS.METADATA)
-        .values((int) secretContent1.secretSeriesId(), "secretName", "{}")
+    testDBRule.jooqContext().insertInto(SECRETS, SECRETS.ID, SECRETS.NAME)
+        .values((int) secretContent1.secretSeriesId(), "secretName")
         .execute();
     testDBRule.jooqContext().insertInto(SECRETS_CONTENT)
         .set(SECRETS_CONTENT.ID, (int) secretContent1.id())


### PR DESCRIPTION
R: @sul3n3t 

Removes last references to the metadata column in the secrets table (unfortunately I missed them).

After this change, there will be no other references to secrets.metadata, and we can add the migration `ALTER TABLE secrets DROP COLUMN IF EXISTS metadata;` on the next version.