### PR TITLE
Drop metadata column from secrets table

### DIFF
--- a/server/src/main/resources/db/migration/V2.11__drop_metadata_secret.sql
+++ b/server/src/main/resources/db/migration/V2.11__drop_metadata_secret.sql
@@ -1,0 +1,1 @@
+ALTER TABLE secrets DROP COLUMN IF EXISTS metadata;


### PR DESCRIPTION
R: @sul3n3t 

We can tag for a new release just before this commit -- this will finally drop the metadata column from the secret series table, thus binding metadata to individual versions of secrets.