### PR TITLE
Update dropwizard version and configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <dropwizard.version>0.8.0</dropwizard.version>
+    <dropwizard.version>0.8.1</dropwizard.version>
     <guice.version>4.0-beta5</guice.version>
     <jackson.version>2.5.0</jackson.version>
     <jooq.version>3.5.1</jooq.version>

--- a/server/src/main/resources/keywhiz-development.yaml
+++ b/server/src/main/resources/keywhiz-development.yaml
@@ -32,10 +32,6 @@ server:
         - TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
         - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
         - TLS_DHE_RSA_WITH_AES_128_CBC_SHA
-        - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
-        - TLS_ECDHE_RSA_WITH_RC4_128_SHA
-        - TLS_ECDH_ECDSA_WITH_RC4_128_SHA
-        - TLS_ECDH_RSA_WITH_RC4_128_SHA
   adminConnectors:
     - type: http
       bindHost: localhost

--- a/server/src/main/resources/keywhiz-development.yaml
+++ b/server/src/main/resources/keywhiz-development.yaml
@@ -49,7 +49,8 @@ database:
   url: jdbc:postgresql://localhost/keywhizdb_development
   properties:
     charSet: UTF-8
-  minSize: 5
+  initialSize: 10
+  minSize: 10
   maxSize: 10
   # There is explicitly no password. Do not uncomment.
   # password:
@@ -59,7 +60,9 @@ readonlyDatabase:
   url: jdbc:postgresql://127.0.0.1/keywhizdb_development
   properties:
     charSet: UTF-8
-  minSize: 5
+  readOnlyByDefault: true
+  initialSize: 32
+  minSize: 32
   maxSize: 32
   # There is explicitly no password. Do not uncomment.
   # password:

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -30,10 +30,6 @@ server:
         - TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
         - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
         - TLS_DHE_RSA_WITH_AES_128_CBC_SHA
-        - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
-        - TLS_ECDHE_RSA_WITH_RC4_128_SHA
-        - TLS_ECDH_ECDSA_WITH_RC4_128_SHA
-        - TLS_ECDH_RSA_WITH_RC4_128_SHA
   adminConnectors:
     - type: http
       bindHost: localhost

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -46,7 +46,8 @@ database:
   url: jdbc:postgresql://localhost/keywhizdb_test
   properties:
     charSet: UTF-8
-  minSize: 1
+  initialSize: 5
+  minSize: 5
   maxSize: 5
   # There is explicitly no password. Do not uncomment.
   # password:
@@ -56,7 +57,9 @@ readonlyDatabase:
   url: jdbc:postgresql://localhost/keywhizdb_test
   properties:
     charSet: UTF-8
-  minSize: 1
+  readOnlyByDefault: true
+  initialSize: 5
+  minSize: 5
   maxSize: 5
   # There is explicitly no password. Do not uncomment.
   # password:


### PR DESCRIPTION
Updates dropwizard from 0.8.0 -> 0.8.1
Removes RC4 cipher suites
Updates DB config for constant size pools and default readonly on readonly config