### PR TITLE
speedup keywhiz.cli list action

### DIFF
--- a/cli/src/main/java/keywhiz/cli/Printing.java
+++ b/cli/src/main/java/keywhiz/cli/Printing.java
@@ -39,7 +39,7 @@ public class Printing {
     this.keywhizClient = keywhizClient;
   }
 
-  public void printClient(Client client, List<String> options) {
+  public void printClientWithDetails(Client client, List<String> options) {
     System.out.println(client.getName());
     ClientDetailResponse clientDetails;
     try {
@@ -63,7 +63,7 @@ public class Printing {
     }
   }
 
-  public void printGroup(Group group, List<String> options) {
+  public void printGroupWithDetails(Group group, List<String> options) {
     System.out.println(group.getName());
     GroupDetailResponse groupDetails;
     try {
@@ -87,7 +87,7 @@ public class Printing {
     }
   }
 
-  public void printSanitizedSecret(SanitizedSecret secret, List<String> options) {
+  public void printSanitizedSecretWithDetails(SanitizedSecret secret, List<String> options) {
     System.out.println(SanitizedSecret.displayName(secret));
     SecretDetailResponse secretDetails;
     try {
@@ -118,21 +118,21 @@ public class Printing {
     }
   }
 
-  public void printAllClients(List<Client> clients, List<String> options) {
+  public void printAllClients(List<Client> clients) {
     clients.stream()
         .sorted(Comparator.comparing(Client::getName))
-        .forEach(c -> printClient(c, options));
+        .forEach(c -> System.out.println(c.getName()));
   }
 
-  public void printAllGroups(List<Group> groups, List<String> options) {
+  public void printAllGroups(List<Group> groups) {
     groups.stream()
         .sorted(Comparator.comparing(Group::getName))
-        .forEach(g -> printGroup(g, options));
+        .forEach(g -> System.out.println(g.getName()));
   }
 
-  public void printAllSanitizedSecrets(List<SanitizedSecret> secrets, List<String> options) {
+  public void printAllSanitizedSecrets(List<SanitizedSecret> secrets) {
     secrets.stream()
         .sorted(Comparator.comparing(SanitizedSecret::name))
-        .forEach(s -> printSanitizedSecret(s, options));
+        .forEach(s -> System.out.println(SanitizedSecret.displayName(s)));
   }
 }

--- a/cli/src/main/java/keywhiz/cli/commands/DescribeAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/DescribeAction.java
@@ -66,7 +66,7 @@ public class DescribeAction implements Runnable {
       case "group":
         try {
           Group group = keywhizClient.getGroupByName(name);
-          printing.printGroup(group, Arrays.asList("clients", "secrets"));
+          printing.printGroupWithDetails(group, Arrays.asList("clients", "secrets"));
         } catch (NotFoundException e) {
           throw new AssertionError("Group not found.");
         } catch (IOException e) {
@@ -77,7 +77,7 @@ public class DescribeAction implements Runnable {
       case "client":
         try {
           Client client = keywhizClient.getClientByName(name);
-          printing.printClient(client, Arrays.asList("groups", "secrets"));
+          printing.printClientWithDetails(client, Arrays.asList("groups", "secrets"));
         } catch (NotFoundException e) {
           throw new AssertionError("Client not found.");
         } catch (IOException e) {
@@ -91,7 +91,7 @@ public class DescribeAction implements Runnable {
           String[] parts = splitNameAndVersion(name);
           sanitizedSecret = keywhizClient.getSanitizedSecretByNameAndVersion(parts[0], parts[1]);
 
-          printing.printSanitizedSecret(sanitizedSecret,
+          printing.printSanitizedSecretWithDetails(sanitizedSecret,
               Arrays.asList("groups", "clients", "metadata"));
         } catch (NotFoundException e) {
           throw new AssertionError("Secret not found.");

--- a/cli/src/main/java/keywhiz/cli/commands/ListAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/ListAction.java
@@ -40,8 +40,7 @@ public class ListAction implements Runnable {
     List<String> listOptions = listActionConfig.listOptions;
     if (listOptions == null) {
       try {
-        printing.printAllSanitizedSecrets(keywhizClient.allSecrets(),
-            Arrays.asList("groups", "clients", "metadata"));
+        printing.printAllSanitizedSecrets(keywhizClient.allSecrets());
       } catch (IOException e) {
         throw Throwables.propagate(e);
       }
@@ -54,15 +53,15 @@ public class ListAction implements Runnable {
     try {
       switch (firstOption) {
         case "groups":
-          printing.printAllGroups(keywhizClient.allGroups(), options);
+          printing.printAllGroups(keywhizClient.allGroups());
           break;
 
         case "clients":
-          printing.printAllClients(keywhizClient.allClients(), options);
+          printing.printAllClients(keywhizClient.allClients());
           break;
 
         case "secrets":
-          printing.printAllSanitizedSecrets(keywhizClient.allSecrets(), options);
+          printing.printAllSanitizedSecrets(keywhizClient.allSecrets());
           break;
 
         default:

--- a/cli/src/main/java/keywhiz/cli/configs/ListActionConfig.java
+++ b/cli/src/main/java/keywhiz/cli/configs/ListActionConfig.java
@@ -20,10 +20,9 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import java.util.List;
 
-@Parameters(commandDescription = "List information about groups, clients, or secrets." +
-    "Use multiple comma-separated values to see nested details.")
+@Parameters(commandDescription = "List groups, clients, or secrets.")
 public class ListActionConfig {
 
-  @Parameter(description = "[<groups|clients|secrets>,...]")
+  @Parameter(description = "[<groups|clients|secrets>]")
   public List<String> listOptions;
 }

--- a/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
@@ -66,7 +66,7 @@ public class DescribeActionTest {
     when(keywhizClient.getGroupByName(anyString())).thenReturn(group);
 
     describeAction.run();
-    verify(printing).printGroup(group, Arrays.asList("clients", "secrets"));
+    verify(printing).printGroupWithDetails(group, Arrays.asList("clients", "secrets"));
   }
 
   @Test
@@ -78,7 +78,7 @@ public class DescribeActionTest {
     when(keywhizClient.getClientByName(describeActionConfig.name)).thenReturn(client);
 
     describeAction.run();
-    verify(printing).printClient(client, Arrays.asList("groups", "secrets"));
+    verify(printing).printClientWithDetails(client, Arrays.asList("groups", "secrets"));
   }
 
   @Test
@@ -90,7 +90,7 @@ public class DescribeActionTest {
         .thenReturn(sanitizedSecret);
 
     describeAction.run();
-    verify(printing).printSanitizedSecret(sanitizedSecret,
+    verify(printing).printSanitizedSecretWithDetails(sanitizedSecret,
         Arrays.asList("groups", "clients", "metadata"));
   }
 

--- a/cli/src/test/java/keywhiz/cli/commands/ListActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/ListActionTest.java
@@ -47,7 +47,7 @@ public class ListActionTest {
   public void listCallsPrintForListAll() throws Exception {
     listActionConfig.listOptions = null;
     listAction.run();
-    verify(printing).printAllSanitizedSecrets(keywhizClient.allSecrets(), Arrays.asList("groups", "clients", "metadata"));
+    verify(printing).printAllSanitizedSecrets(keywhizClient.allSecrets());
   }
 
   @Test
@@ -55,7 +55,7 @@ public class ListActionTest {
     listActionConfig.listOptions = Arrays.asList("groups");
     listAction.run();
 
-    verify(printing).printAllGroups(keywhizClient.allGroups(), listActionConfig.listOptions);
+    verify(printing).printAllGroups(keywhizClient.allGroups());
   }
 
   @Test
@@ -63,7 +63,7 @@ public class ListActionTest {
     listActionConfig.listOptions = Arrays.asList("clients");
     listAction.run();
 
-    verify(printing).printAllClients(keywhizClient.allClients(), listActionConfig.listOptions);
+    verify(printing).printAllClients(keywhizClient.allClients());
   }
 
   @Test
@@ -71,7 +71,7 @@ public class ListActionTest {
     listActionConfig.listOptions = Arrays.asList("secrets");
     listAction.run();
 
-    verify(printing).printAllSanitizedSecrets(keywhizClient.allSecrets(), listActionConfig.listOptions);
+    verify(printing).printAllSanitizedSecrets(keywhizClient.allSecrets());
   }
 
   @Test(expected = AssertionError.class)


### PR DESCRIPTION
R: @sul3n3t 

Before this change, keywhiz.cli was making unnecessary api calls when no options were provided.  This change explicitly removes options from the keywhiz.cli list command.