### PR TITLE
add explicit exclusions to remove duplicate jars, remove warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,16 @@
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-client</artifactId>
         <version>${dropwizard.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>javax.inject</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>aopalliance-repackaged</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.dropwizard</groupId>
@@ -153,6 +163,12 @@
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-testing</artifactId>
         <version>${dropwizard.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>javax.inject</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.dropwizard</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
             <artifactId>javax.inject</artifactId>
           </exclusion>
           <exclusion>
+            <!-- Already included in com.google.inject -->
             <groupId>org.glassfish.hk2.external</groupId>
             <artifactId>aopalliance-repackaged</artifactId>
           </exclusion>


### PR DESCRIPTION
R: @sul3n3t 

Add exclusions to the pom so that we don't pick up duplicate jars, this removes the warnings from running mvn package