### PR TITLE
API for versioned secrets

### DIFF
--- a/server/src/main/java/keywhiz/KeywhizService.java
+++ b/server/src/main/java/keywhiz/KeywhizService.java
@@ -62,6 +62,7 @@ import keywhiz.service.resources.SecretsResource;
 import keywhiz.service.resources.SessionLoginResource;
 import keywhiz.service.resources.SessionLogoutResource;
 import keywhiz.service.resources.SessionMeResource;
+import keywhiz.service.resources.VersionedSecretResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zapodot.jackson.java8.JavaOptionalModule;
@@ -197,6 +198,7 @@ public class KeywhizService extends Application<KeywhizConfig> {
     jersey.register(injector.getInstance(AutomationEnrollClientGroupResource.class));
     jersey.register(injector.getInstance(AutomationSecretAccessResource.class));
     jersey.register(injector.getInstance(AutomationSecretGeneratorsResource.class));
+    jersey.register(injector.getInstance(VersionedSecretResource.class));
     logger.debug("Keywhiz configuration complete");
   }
 

--- a/server/src/main/java/keywhiz/commands/DbSeedCommand.java
+++ b/server/src/main/java/keywhiz/commands/DbSeedCommand.java
@@ -102,11 +102,17 @@ public class DbSeedCommand extends ConfiguredCommand<KeywhizConfig> {
         .insertInto(SECRETS_CONTENT, SECRETS_CONTENT.ID, SECRETS_CONTENT.SECRETID, SECRETS_CONTENT.VERSION, SECRETS_CONTENT.CREATEDAT, SECRETS_CONTENT.UPDATEDAT, SECRETS_CONTENT.ENCRYPTED_CONTENT, SECRETS_CONTENT.METADATA)
         .values(937, 737, "", OffsetDateTime.parse("2011-09-29T15:46:00.232Z"), OffsetDateTime.parse("2015-01-07T12:00:47.674786Z"), "{\"derivationInfo\":\"Nobody_PgPass\",\"content\":\"5Eq97Y/6LMLUqH8rlXxEkOeMFmc3cYhQny0eotojNrF3DTFdQPyHVG5HeP5vzaFxqttcZkO56NvIwdD8k2xyIL5YRbCIA5MQ9LOnKN4tpnwb+Q\",\"iv\":\"jQAFJizi1MKZUcCxb6mTCA\"}", "{\"mode\":\"0400\",\"owner\":\"nobody\"}")
         .values(938, 738, "", OffsetDateTime.parse("2011-09-29T15:46:00.312Z"), OffsetDateTime.parse("2015-01-07T12:01:59.335018Z"), "{\"derivationInfo\":\"Hacking_Password\",\"content\":\"jpNVoXZao+b+f591w+CHWTj7D1M\",\"iv\":\"W+pT37jJP4uDGHmuczXVCA\"}", "")
-        .values(939, 739, "", OffsetDateTime.parse("2011-09-29T15:46:00.232Z"), OffsetDateTime.parse("2015-01-07T12:02:06.73539Z"), "{\"derivationInfo\":\"Database_Password\",\"content\":\"etQQFqMHQQpGr4aDlj5gDjiABkOb\",\"iv\":\"ia+YixjAEqp9W3JEjaYLvQ\"}", "")
-        .values(940, 740, "", OffsetDateTime.parse("2011-09-29T15:46:00.312Z"), OffsetDateTime.parse("2015-01-07T12:02:06.758446Z"), "{\"derivationInfo\":\"General_Password\",\"content\":\"A6kBLXwmx0EVtuIGTzxHiEZ/6yrXgg\",\"iv\":\"e4I0c3fog0TKqTAC2UxYtQ\"}", "")
+        .values(939, 739, "", OffsetDateTime.parse("2011-09-29T15:46:00.232Z"),
+            OffsetDateTime.parse("2015-01-07T12:02:06.73539Z"),
+            "{\"derivationInfo\":\"Database_Password\",\"content\":\"etQQFqMHQQpGr4aDlj5gDjiABkOb\",\"iv\":\"ia+YixjAEqp9W3JEjaYLvQ\"}",
+            "")
+        .values(940, 740, "", OffsetDateTime.parse("2011-09-29T15:46:00.312Z"),
+            OffsetDateTime.parse("2015-01-07T12:02:06.758446Z"),
+            "{\"derivationInfo\":\"General_Password\",\"content\":\"A6kBLXwmx0EVtuIGTzxHiEZ/6yrXgg\",\"iv\":\"e4I0c3fog0TKqTAC2UxYtQ\"}",
+            "")
         .values(941, 741, "", OffsetDateTime.parse("2011-09-29T15:46:00.232Z"), OffsetDateTime.parse("2015-01-07T12:02:06.78574Z"), "{\"derivationInfo\":\"NonexistentOwner_Pass\",\"content\":\"+Pu1B5YgqGRIHzh17s5tPT3AYb+W\",\"iv\":\"ewRV3RhFfLnbWxY5pr401g\"}", "{\"owner\":\"NonExistant\",\"mode\":\"0400\"}")
-        .values(942, 742, "0aae825a73e161d8", OffsetDateTime.parse("2011-09-29T15:46:00.232Z"), OffsetDateTime.parse("2015-01-07T12:02:06.806212Z"), "{\"derivationInfo\":\"Versioned_Password\",\"content\":\"GC8/ZvEfqpxhtAkThgZ8/+vPesh9\",\"iv\":\"oRf3CMnB7jv63K33dJFeFg\"}", "")
-        .values(943, 742, "0aae825a73e161e8", OffsetDateTime.parse("2011-09-29T16:46:00.232Z"), OffsetDateTime.parse("2011-09-29T16:46:00.232Z"), "{\"derivationInfo\":\"Versioned_Password\",\"content\":\"GC8/ZvEfqpxhtAkThgZ8/+vPesh9\",\"iv\":\"oRf3CMnB7jv63K33dJFeFg\"}", "")
+        .values(942, 742, "0aae825a73e161d8", OffsetDateTime.parse("2011-09-29T15:46:00.232Z"), OffsetDateTime.parse("2015-01-07T12:02:06.806212Z"), "{\"derivationInfo\":\"Versioned_Password\",\"content\":\"GC8/ZvEfqpxhtAkThgZ8/+vPesh9\",\"iv\":\"oRf3CMnB7jv63K33dJFeFg\"}", "{\"mode\":\"0400\",\"owner\":\"admin\"}")
+        .values(943, 742, "0aae825a73e161e8", OffsetDateTime.parse("2011-09-29T16:46:00.232Z"), OffsetDateTime.parse("2011-09-29T16:46:00.232Z"), "{\"derivationInfo\":\"Versioned_Password\",\"content\":\"GC8/ZvEfqpxhtAkThgZ8/+vPesh9\",\"iv\":\"oRf3CMnB7jv63K33dJFeFg\"}", "{\"mode\":\"0400\",\"owner\":\"new-admin\"}")
         .values(944, 742, "0aae825a73e161f8", OffsetDateTime.parse("2011-09-29T17:46:00.232Z"), OffsetDateTime.parse("2011-09-29T17:46:00.232Z"), "{\"derivationInfo\":\"Versioned_Password\",\"content\":\"GC8/ZvEfqpxhtAkThgZ8/+vPesh9\",\"iv\":\"oRf3CMnB7jv63K33dJFeFg\"}", "")
         .values(945, 742, "0aae825a73e161g8", OffsetDateTime.parse("2011-09-29T18:46:00.232Z"), OffsetDateTime.parse("2011-09-29T18:46:00.232Z"), "{\"derivationInfo\":\"Versioned_Password\",\"content\":\"GC8/ZvEfqpxhtAkThgZ8/+vPesh9\",\"iv\":\"oRf3CMnB7jv63K33dJFeFg\"}", "")
         .execute();

--- a/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
@@ -56,6 +56,6 @@ public interface SecretContentDAO {
   void deleteSecretContentBySecretIdAndVersion(
       @Bind("secretId") long secretId, @Bind("version") String version);
 
-  @SqlQuery("SELECT version FROM secrets_content WHERE secretId = :secretId")
+  @SqlQuery("SELECT version FROM secrets_content WHERE secretId = :secretId ORDER BY createdAt DESC")
   ImmutableList<String> getVersionFromSecretId(@Bind("secretId") long secretId);
 }

--- a/server/src/main/java/keywhiz/service/daos/SecretController.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretController.java
@@ -97,25 +97,6 @@ public class SecretController {
     return version.get();
   }
 
-  /**
-   * Deletes the series and all associated version of the given secret series name.
-   *
-   * @param name of secret series to delete.
-   */
-  public void deleteSecretsByName(String name) {
-    secretDAO.deleteSecretsByName(name);
-  }
-
-  /**
-   * Deletes a specific version in a secret series.
-   *
-   * @param name of secret series to delete from.
-   * @param version of secret to specifically delete.
-   */
-  public void deleteSecretByNameAndVersion(String name, String version) {
-    secretDAO.deleteSecretByNameAndVersion(name, version);
-  }
-
   public SecretBuilder builder(String name, String secret, String creator) {
     checkArgument(!name.isEmpty());
     checkArgument(!secret.isEmpty());

--- a/server/src/main/java/keywhiz/service/daos/SecretController.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretController.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.ws.rs.NotFoundException;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.api.model.Secret;
 import keywhiz.service.crypto.ContentCryptographer;
@@ -84,6 +85,35 @@ public class SecretController {
   public List<String> getVersionsForName(String name) {
     checkArgument(!name.isEmpty());
     return secretDAO.getVersionsForSecretName(name);
+  }
+
+  /** @return the latest version for this secret name. */
+  public String getLatestVersion(String name) {
+    checkArgument(!name.isEmpty());
+    Optional<String> version = secretDAO.getLatestVersion(name);
+    if (!version.isPresent()) {
+      throw new NotFoundException("No versions found for secret.");
+    }
+    return version.get();
+  }
+
+  /**
+   * Deletes the series and all associated version of the given secret series name.
+   *
+   * @param name of secret series to delete.
+   */
+  public void deleteSecretsByName(String name) {
+    secretDAO.deleteSecretsByName(name);
+  }
+
+  /**
+   * Deletes a specific version in a secret series.
+   *
+   * @param name of secret series to delete from.
+   * @param version of secret to specifically delete.
+   */
+  public void deleteSecretByNameAndVersion(String name, String version) {
+    secretDAO.deleteSecretByNameAndVersion(name, version);
   }
 
   public SecretBuilder builder(String name, String secret, String creator) {

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -118,6 +118,25 @@ public abstract class SecretDAO implements Transactional<SecretDAO> {
   }
 
   /**
+   * @param name external secret series name to look up versions by
+   * @return Latest secret version for secret name.
+   */
+  @Transaction
+  public Optional<String> getLatestVersion(String name) {
+    checkNotNull(name);
+    Optional<SecretSeries> series = createSecretSeriesDAO().getSecretSeriesByName(name);
+    if (!series.isPresent()) {
+      return Optional.empty();
+    }
+
+    ImmutableList<String> versions = createSecretContentDAO().getVersionFromSecretId(series.get().getId());
+    if (versions.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(versions.get(0));
+  }
+
+  /**
    * @param name of secret series to look up secrets by.
    * @param version specific version of secret. May be empty.
    * @return Secret matching input parameters or Optional.absent().
@@ -154,6 +173,12 @@ public abstract class SecretDAO implements Transactional<SecretDAO> {
             (content) -> secretsBuilder.add(SecretSeriesAndContent.of(series, content))));
 
     return secretsBuilder.build();
+  }
+
+  /** @return all existing secrets series (one series shared across versions). */
+  @Transaction
+  public ImmutableList<SecretSeries> getSecretSeries() {
+    return createSecretSeriesDAO().getSecretSeries();
   }
 
   /**

--- a/server/src/main/java/keywhiz/service/resources/VersionedSecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/VersionedSecretResource.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package keywhiz.service.resources;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.dropwizard.auth.Auth;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import keywhiz.api.CreateSecretRequest;
+import keywhiz.api.SecretDetailResponse;
+import keywhiz.api.model.AutomationClient;
+import keywhiz.api.model.Client;
+import keywhiz.api.model.Group;
+import keywhiz.api.model.Secret;
+import keywhiz.api.model.VersionGenerator;
+import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.SecretController;
+import keywhiz.service.daos.SecretDAO;
+import keywhiz.service.daos.SecretSeriesDAO;
+import keywhiz.service.exceptions.ConflictException;
+import org.skife.jdbi.v2.exceptions.StatementException;
+
+import static java.lang.String.format;
+
+/**
+ * @parentEndpointName versioned-secrets
+ *
+ * @resourcePath /v2/secrets
+ * @resourceDescription Create, retrieve, and remove versioned secrets
+ */
+@Path("/v2/secrets")
+@Produces(MediaType.APPLICATION_JSON)
+public class VersionedSecretResource {
+  private final SecretController secretController;
+  private final AclDAO aclDAO;
+  private final SecretSeriesDAO secretSeriesDAO;
+  private final SecretDAO secretDAO;
+
+  private final String LATEST_VERSION = "LATEST";
+
+  @Inject
+  public VersionedSecretResource(SecretController secretController, AclDAO aclDAO,
+      SecretSeriesDAO secretSeriesDAO, SecretDAO secretDAO) {
+    this.secretController = secretController;
+    this.aclDAO = aclDAO;
+    this.secretSeriesDAO = secretSeriesDAO;
+    this.secretDAO = secretDAO;
+  }
+
+  /**
+   * Retrieve all secret names.  Note that this could be an expensive query
+   *
+   * @description Returns a set of all secret names
+   * @responseMessage 200 Found and retrieved secrets
+   */
+  @GET
+  public Response readAllSecrets(@Auth AutomationClient automationClient) {
+    List<String> secretNames = secretSeriesDAO.getSecretSeries()
+        .stream()
+        .map(s -> s.getName())
+        .collect(Collectors.toList());
+
+    return Response.ok().entity(secretNames).build();
+  }
+
+  /**
+   * Retrieve all versions for a secretName
+   *
+   * @param secretName the name of the secret to retrieve versions for
+   * @description Returns a list of versions for the specified secret name
+   * @responseMessage 200 Found and retrieved versions for given secret name
+   * @responseMessage 404 Secret with given name not found
+   */
+  @Path("{secretName}")
+  @GET
+  public Response readSecretById(@Auth AutomationClient automationClient,
+      @PathParam("secretName") String secretName) {
+    List<String> versions = secretController.getVersionsForName(secretName);
+    if (versions.isEmpty()) {
+      throw new NotFoundException("Secret not found.");
+    }
+    return Response.ok().entity(versions).build();
+  }
+
+  /**
+   * Retrieve a secret by name and version
+   *
+   * @param secretName the name of the secret to retrieve
+   * @param version the version of secretName to retrieve.  "LATEST" will retrieve the most recent version
+   * @description Returns a single secret if found
+   * @responseMessage 200 Found and retrieved secret with given name and version
+   * @responseMessage 404 Secret with given name and version not found
+   */
+  @Path("{secretName}/{version}")
+  @GET
+  public SecretDetailResponse readSecretByNameAndVersion(@Auth AutomationClient automationClient,
+      @PathParam("secretName") String secretName,
+      @PathParam("version") String version) {
+    if (version.equals(LATEST_VERSION)) {
+      version = secretController.getLatestVersion(secretName);
+    }
+
+    Optional<Secret> secret = secretController.getSecretByNameAndVersion(secretName, version);
+    if (!secret.isPresent()) {
+      throw new NotFoundException("Secret not found.");
+    }
+
+    ImmutableList<Group> groups = ImmutableList.copyOf(aclDAO.getGroupsFor(secret.get()));
+    ImmutableList<Client> clients = ImmutableList.copyOf(aclDAO.getClientsFor(secret.get()));
+    return SecretDetailResponse.fromSecret(secret.get(), groups, clients);
+  }
+
+  /**
+   * Deletes all versions of a secret series
+   *
+   * @param secretName the name of the secret series to delete
+   *
+   * @description Deletes all versions of a secret series.  This will delete a single secret ID.
+   * @responseMessage 200 Deleted secret series
+   * @responseMessage 404 Secret series not Found
+   */
+  @Path("{secretName}")
+  @DELETE
+  public Response deleteSecretSeries(@Auth AutomationClient automationClient,
+      @PathParam("secretName") String secretName) {
+
+    secretSeriesDAO.getSecretSeriesByName(secretName)
+        .orElseThrow(() -> new NotFoundException("Secret series not found."));
+    secretSeriesDAO.deleteSecretSeriesByName(secretName);
+
+    return Response.ok().build();
+  }
+
+  /**
+   * Deletes a specific version of a secret
+   *
+   * @param secretName the name of the secret to delete
+   * @param version the version of the secret to delete
+   *
+   * @description Deletes a single version of a secret.  Other versions may exist post-deletion.
+   * @responseMessage 200 Deleted secret version.
+   * @responseMessage 404 Secret series or version not Found
+   */
+  @Path("{secretName}/{version}")
+  @DELETE
+  public Response deleteSecretVersion(@Auth AutomationClient automationClient,
+      @PathParam("secretName") String secretName,
+      @PathParam("version") String version) {
+
+    secretSeriesDAO.getSecretSeriesByName(secretName)
+        .orElseThrow(() -> new NotFoundException("Secret series not found."));
+
+    secretDAO.deleteSecretByNameAndVersion(secretName, version);
+
+    return Response.ok().build();
+  }
+
+  /**
+   * Create versioned secret
+   *
+   * @param request the JSON client request used to formulate the secret
+   *
+   * @description Creates a versioned secret with the name from a valid secret request.
+   * If a secret series already exists, simply adds a new version.
+   * @responseMessage 200 Successfully created Secret
+   * @responseMessage 400 Secret with given name already exists
+   */
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Response createSecret(@Auth AutomationClient automationClient,
+      @Valid CreateSecretRequest request) {
+
+    Secret secret;
+    String version;
+    try {
+      SecretController.SecretBuilder builder =
+          secretController.builder(request.name, request.content, automationClient.getName());
+
+      if (request.description != null) {
+        builder.withDescription(request.description);
+      }
+
+      if (request.metadata != null) {
+        builder.withMetadata(request.metadata);
+      }
+
+      // Always creates a versioned secret on this endpoint
+      version = VersionGenerator.now().toHex();
+      builder.withVersion(version);
+
+      secret = builder.build();
+    } catch (StatementException e) {
+      throw new ConflictException(format("Cannot create secret %s.", request.name));
+    }
+
+    URI uri = UriBuilder.fromResource(VersionedSecretResource.class).path("{secretName}/{version}")
+        .build(secret.getName(), secret.getVersion());
+
+    Optional<Secret> createdSecret = secretController
+        .getSecretByNameAndVersion(secret.getName(), secret.getVersion());
+
+    if (!createdSecret.isPresent()) {
+      throw new NotFoundException("Secret creation unsuccessful.");
+    }
+
+    ImmutableList<Group> groups = ImmutableList.copyOf(aclDAO.getGroupsFor(createdSecret.get()));
+    ImmutableList<Client> clients = ImmutableList.copyOf(aclDAO.getClientsFor(createdSecret.get()));
+
+    return Response
+        .created(uri)
+        .entity(SecretDetailResponse.fromSecret(createdSecret.get(), groups, clients))
+        .build();
+  }
+}

--- a/server/src/test/java/keywhiz/service/resources/VersionedSecretResourceIntegrationTest.java
+++ b/server/src/test/java/keywhiz/service/resources/VersionedSecretResourceIntegrationTest.java
@@ -1,0 +1,227 @@
+package keywhiz.service.resources;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.Response;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.List;
+import javax.ws.rs.core.MediaType;
+import keywhiz.IntegrationTestRule;
+import keywhiz.TestClients;
+import keywhiz.api.CreateSecretRequest;
+import keywhiz.client.KeywhizClient;
+import keywhiz.model.OffsetDateTimeConverter;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.mockito.junit.MockitoJUnitRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VersionedSecretResourceIntegrationTest {
+  @Rule public TestRule mockito = new MockitoJUnitRule(this);
+  @ClassRule public static final RuleChain chain = IntegrationTestRule.rule();
+
+  OkHttpClient mutualSslClient;
+  ObjectMapper mapper = new ObjectMapper();
+
+  @Before public void setUp() {
+    mutualSslClient = TestClients.mutualSslClient();
+  }
+
+  @Test public void listsSecretNames() throws IOException {
+    Request get = new Request.Builder()
+        .get()
+        .url("/v2/secrets")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    Response response = mutualSslClient.newCall(get).execute();
+    List<String> secretNames = mapper.readValue(response.body().bytes(), new TypeReference<List<String>>() {});
+    assertThat(secretNames).containsOnly("Nobody_PgPass", "Hacking_Password", "General_Password",
+        "Database_Password", "NonexistentOwner_Pass", "Versioned_Password");
+  }
+
+  @Test public void listSecretVersions() throws IOException {
+    Request get = new Request.Builder()
+        .get()
+        .url("/v2/secrets/Versioned_Password")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    Response response = mutualSslClient.newCall(get).execute();
+    List<String> versionNames = mapper.readValue(response.body().bytes(), new TypeReference<List<String>>() {});
+    assertThat(versionNames).containsOnly("0aae825a73e161d8", "0aae825a73e161e8",
+        "0aae825a73e161f8", "0aae825a73e161g8");
+  }
+
+  @Test public void getsSpecificSecretVersions() throws IOException {
+    Request get = new Request.Builder()
+        .get()
+        .url("/v2/secrets/Versioned_Password/0aae825a73e161d8")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    Response response = mutualSslClient.newCall(get).execute();
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(response.body().string()).contains("{\"mode\":\"0400\",\"owner\":\"admin\"}");
+
+    get = new Request.Builder()
+        .get()
+        .url("/v2/secrets/Versioned_Password/0aae825a73e161e8")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    response = mutualSslClient.newCall(get).execute();
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(response.body().string()).contains("{\"mode\":\"0400\",\"owner\":\"new-admin\"}");
+  }
+
+  @Test public void getLatestSecretVersion() throws IOException {
+    Request get = new Request.Builder()
+        .get()
+        .url("/v2/secrets/Versioned_Password/LATEST")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    Response response = mutualSslClient.newCall(get).execute();
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(response.body().string()).contains(
+        new OffsetDateTimeConverter().from(Timestamp.valueOf("2011-09-29 18:46:00.232")).toString());
+  }
+
+  @Test public void createsSecret() throws IOException {
+    CreateSecretRequest
+        request = new CreateSecretRequest("new-secret", "desc", "c3VwZXJTZWNyZXQK",
+        true, ImmutableMap.of());
+    String body = mapper.writeValueAsString(request);
+    Request post = new Request.Builder()
+        .post(RequestBody.create(KeywhizClient.JSON, body))
+        .url("/v2/secrets")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    Response response = mutualSslClient.newCall(post).execute();
+    assertThat(response.code()).isEqualTo(201);
+
+    Request get = new Request.Builder()
+        .get()
+        .url("/v2/secrets")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    response = mutualSslClient.newCall(get).execute();
+    List<String> secretNames = mapper.readValue(response.body().bytes(), new TypeReference<List<String>>() {});
+    assertThat(secretNames).contains("new-secret");
+  }
+
+  @Test public void createsSecretVersions() throws IOException {
+    CreateSecretRequest
+        request = new CreateSecretRequest("versions", "v1", "c3VwZXJTZWNyZXQK",
+        true, ImmutableMap.of());
+    String body = mapper.writeValueAsString(request);
+    Request post = new Request.Builder()
+        .post(RequestBody.create(KeywhizClient.JSON, body))
+        .url("/v2/secrets")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    Response response = mutualSslClient.newCall(post).execute();
+    assertThat(response.code()).isEqualTo(201);
+
+    // Request a new version
+    request = new CreateSecretRequest("versions", "v2", "c3VwZXJTZWNyZXQK",
+        true, ImmutableMap.of());
+    body = mapper.writeValueAsString(request);
+    post = new Request.Builder()
+        .post(RequestBody.create(KeywhizClient.JSON, body))
+        .url("/v2/secrets")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    response = mutualSslClient.newCall(post).execute();
+    assertThat(response.code()).isEqualTo(201);
+
+    // Verify only one secret series exists
+    Request get = new Request.Builder()
+        .get()
+        .url("/v2/secrets")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    response = mutualSslClient.newCall(get).execute();
+    List<String> secretNames = mapper.readValue(response.body().bytes(), new TypeReference<List<String>>() {});
+    assertThat(secretNames).containsOnlyOnce("versions");
+
+    // Verify that two versions exist
+    get = new Request.Builder()
+        .get()
+        .url("/v2/secrets/versions")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    response = mutualSslClient.newCall(get).execute();
+    List<String> secretVerisons = mapper.readValue(response.body().bytes(), new TypeReference<List<String>>() {});
+    assertThat(secretVerisons.size()).isEqualTo(2);
+  }
+
+  @Test public void deletesSecretSeries() throws IOException {
+    Request delete = new Request.Builder()
+        .delete()
+        .url("/v2/secrets/Database_Password")
+        .build();
+
+    Response response = mutualSslClient.newCall(delete).execute();
+    assertThat(response.code()).isEqualTo(200);
+
+    // Verify that no versions exist
+    Request get = new Request.Builder()
+        .get()
+        .url("/v2/secrets/Database_Password")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    response = mutualSslClient.newCall(get).execute();
+    assertThat(response.code()).isEqualTo(404);
+  }
+
+  @Test public void deletesSecretVersion() throws IOException {
+    Request delete = new Request.Builder()
+        .delete()
+        .url("/v2/secrets/Versioned_Password/0aae825a73e161f8")
+        .build();
+
+    Response response = mutualSslClient.newCall(delete).execute();
+    assertThat(response.code()).isEqualTo(200);
+
+    // Verify that other versions exist
+    Request get = new Request.Builder()
+        .get()
+        .url("/v2/secrets/Versioned_Password")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    response = mutualSslClient.newCall(get).execute();
+    assertThat(response.code()).isEqualTo(200);
+    List<String> secretVerisons = mapper.readValue(response.body().bytes(), new TypeReference<List<String>>() {});
+    assertThat(secretVerisons.size()).isEqualTo(3);
+
+    // Verify that the deleted version does not exist
+    get = new Request.Builder()
+        .get()
+        .url("/v2/secrets/Versioned_Password/0aae825a73e161f8")
+        .addHeader("Content-Type", MediaType.APPLICATION_JSON)
+        .build();
+
+    response = mutualSslClient.newCall(get).execute();
+    assertThat(response.code()).isEqualTo(404);
+  }
+}

--- a/server/src/test/java/keywhiz/service/resources/VersionedSecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/VersionedSecretResourceTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package keywhiz.service.resources;
+
+import com.google.common.collect.ImmutableMap;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Base64;
+import java.util.Optional;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import keywhiz.api.CreateSecretRequest;
+import keywhiz.api.model.AutomationClient;
+import keywhiz.api.model.Client;
+import keywhiz.api.model.Secret;
+import keywhiz.api.model.SecretContent;
+import keywhiz.api.model.SecretSeries;
+import keywhiz.api.model.VersionGenerator;
+import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.SecretController;
+import keywhiz.service.daos.SecretDAO;
+import keywhiz.service.daos.SecretSeriesDAO;
+import keywhiz.service.exceptions.ConflictException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRule;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.exceptions.StatementException;
+import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class VersionedSecretResourceTest {
+  @Rule public TestRule mockito = new MockitoJUnitRule(this);
+
+  private static final OffsetDateTime NOW = OffsetDateTime.now();
+
+  VersionedSecretResource resource;
+
+  AutomationClient automation = AutomationClient.of(
+      new Client(1, "automation", "Automation client", NOW, "test", NOW, "test", true, true));
+
+  @Mock SecretController secretController;
+  @Mock SecretController.SecretBuilder secretBuilder;
+  @Mock AclDAO aclDAO;
+  @Mock SecretSeriesDAO secretSeriesDAO;
+  @Mock SecretDAO secretDAO;
+
+  @Before
+  public void setUp() {
+    resource = new VersionedSecretResource(secretController, aclDAO, secretSeriesDAO, secretDAO);
+
+    when(secretController.builder(anyString(), anyString(), anyString())).thenReturn(secretBuilder);
+  }
+
+  @Test
+  public void addSecret() throws Exception {
+    CreateSecretRequest request = new CreateSecretRequest("mySecret",
+        "some secret",
+        "ponies",
+        true,
+        null);
+
+    Secret secret = new Secret(0, /* Set by DB */
+        request.name,
+        VersionGenerator.now().toHex(),
+        request.description,
+        Base64.getUrlEncoder().encodeToString(request.content.getBytes(UTF_8)),
+        NOW,
+        automation.getName(),
+        NOW, /* updatedAt set by DB */
+        automation.getName(),
+        request.metadata,
+        null,
+        null);
+
+    when(secretBuilder.build()).thenReturn(secret);
+
+    when(secretController.getSecretByNameAndVersion(eq(request.name), anyString()))
+        .thenReturn(Optional.of(secret));
+
+    Response response = resource.createSecret(automation, request);
+    assertThat(response.getStatus()).isEqualTo(201);
+    assertThat(response.getMetadata().get(HttpHeaders.LOCATION))
+        .containsExactly(new URI("/v2/secrets/" + secret.getName() + "/" + secret.getVersion()));
+  }
+
+  @Test
+  public void deleteSecretSeries() throws Exception {
+    SecretSeries secretSeries = new SecretSeries(0, /* Set by DB */
+        "mySecret",
+        null,
+        NOW,
+        automation.getName(),
+        NOW,
+        automation.getName(),
+        null,
+        null);
+
+    when(secretSeriesDAO.getSecretSeriesByName(secretSeries.getName()))
+        .thenReturn(Optional.of(secretSeries));
+
+    resource.deleteSecretSeries(automation, "mySecret");
+    verify(secretSeriesDAO).deleteSecretSeriesByName(secretSeries.getName());
+  }
+
+  @Test
+  public void deleteSecretVersion() throws Exception {
+    SecretSeries secretSeries = new SecretSeries(0, /* Set by DB */
+        "mySecret",
+        null,
+        NOW,
+        automation.getName(),
+        NOW,
+        automation.getName(),
+        null,
+        null);
+
+    SecretContent secretContent = SecretContent.of(0, 0, "[crypted]", "A", NOW,
+        automation.getName(), NOW, automation.getName(), ImmutableMap.of());
+
+    when(secretSeriesDAO.getSecretSeriesByName(secretSeries.getName()))
+        .thenReturn(Optional.of(secretSeries));
+
+    resource.deleteSecretVersion(automation, "mySecret", "A");
+
+    verify(secretDAO).deleteSecretByNameAndVersion(secretSeries.getName(),
+        secretContent.version().get());
+  }
+
+  @Test(expected = ConflictException.class)
+  public void triesToCreateDuplicateSecret() throws Exception {
+    StatementException exception = new UnableToExecuteStatementException("", (StatementContext) null);
+    ImmutableMap<String,String> emptyMap = ImmutableMap.of();
+
+    doThrow(exception).when(secretBuilder).build();
+
+    CreateSecretRequest req = new CreateSecretRequest("name", "desc", "content", false, emptyMap);
+    resource.createSecret(automation, req);
+  }
+}


### PR DESCRIPTION
R: @sul3n3t 

Endpoints for versioned secrets:

GET /v2/secrets - gets a list of all secret names (will only list each name once, regardless of versions)
GET /v2/secrets/{name} - gets a list of all version names for this secret name
GET /v2/secrets/{name}/{version} - gets a SecretDetailResponse for this secret name/version combination.  Using "LATEST" as the version field will fetch the latest version of this secret

POST /v2/secrets - creates a versioned secret using the passed-in JSON

DELETE /v2/secrets/{name} - deletes all versions of this secret (the entire secret series)
DELETE /v2/secrets/{name}/{version} - just deletes this version of the secret