### PR TITLE
Makes sure we are testing json serialization/deserialization for Map<String, String>

### DIFF
--- a/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
@@ -23,6 +23,7 @@ import java.time.ZoneId;
 import java.util.List;
 import keywhiz.TestDBRule;
 import keywhiz.api.model.SecretContent;
+import org.jooq.tools.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,10 +37,10 @@ public class SecretContentDAOTest {
   @Rule public final TestDBRule testDBRule = new TestDBRule();
 
   final static OffsetDateTime date = OffsetDateTime.now(ZoneId.of("UTC"));
-  ImmutableMap<String, String> emptyMetadata = ImmutableMap.of();
+  ImmutableMap<String, String> metadata = ImmutableMap.of("foo", "bar");
 
   SecretContent secretContent1 = SecretContent.of(11, 22, "[crypted]", "", date, "creator", date,
-      "creator", emptyMetadata);
+      "creator", metadata);
 
   SecretContentDAO secretContentDAO;
 
@@ -60,15 +61,18 @@ public class SecretContentDAOTest {
         .set(SECRETS_CONTENT.CREATEDBY, secretContent1.createdBy())
         .set(SECRETS_CONTENT.UPDATEDAT, secretContent1.updatedAt())
         .set(SECRETS_CONTENT.UPDATEDBY, secretContent1.updatedBy())
-        .set(SECRETS_CONTENT.METADATA, "{}")
+        .set(SECRETS_CONTENT.METADATA, JSONObject.toJSONString(secretContent1.metadata()))
         .execute();
   }
 
   @Test public void createSecretContent() {
     int before = tableSize();
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator", emptyMetadata);
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator", emptyMetadata);
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator", emptyMetadata);
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator",
+        metadata);
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator",
+        metadata);
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator",
+        metadata);
     assertThat(tableSize()).isEqualTo(before + 3);
   }
 
@@ -79,9 +83,12 @@ public class SecretContentDAOTest {
   }
 
   @Test public void getSecretContentsBySecretId() {
-    long id1 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator", emptyMetadata);
-    long id2 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator", emptyMetadata);
-    long id3 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator", emptyMetadata);
+    long id1 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator",
+        metadata);
+    long id2 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator",
+        metadata);
+    long id3 = secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator",
+        metadata);
 
     List<Long> actualIds = secretContentDAO.getSecretContentsBySecretId(secretContent1.secretSeriesId())
         .stream()
@@ -92,9 +99,12 @@ public class SecretContentDAOTest {
   }
 
   @Test public void getVersionsBySecretId() {
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator", emptyMetadata);
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator", emptyMetadata);
-    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator", emptyMetadata);
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted", "version", "creator",
+        metadata);
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted2", "version2", "creator",
+        metadata);
+    secretContentDAO.createSecretContent(secretContent1.secretSeriesId(), "encrypted3", "version3", "creator",
+        metadata);
 
     // We have the empty string as a version from the setUp() call
     assertThat(secretContentDAO.getVersionFromSecretId(secretContent1.secretSeriesId()))

--- a/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
@@ -16,7 +16,9 @@
 
 package keywhiz.service.daos;
 
+import com.google.common.collect.ImmutableMap;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.Optional;
 import keywhiz.TestDBRule;
 import keywhiz.api.model.SecretSeries;
@@ -42,9 +44,10 @@ public class SecretSeriesDAOTest {
     int before = tableSize();
     OffsetDateTime now = OffsetDateTime.now();
 
-    long id = secretSeriesDAO.createSecretSeries("newSecretSeries", "creator", "desc", null, null);
+    long id = secretSeriesDAO.createSecretSeries("newSecretSeries", "creator", "desc", null,
+        ImmutableMap.of("foo", "bar"));
     SecretSeries expected = new SecretSeries(id, "newSecretSeries", "desc", now, "creator", now,
-        "creator", null, null);
+        "creator", null, ImmutableMap.of("foo", "bar"));
 
     assertThat(tableSize()).isEqualTo(before + 1);
 


### PR DESCRIPTION
Some Map<String, String> fields are stored as json by the DAO layer. When working on the alok/jooq branch, I noticed the tests were passing even though I hadn't implemented the json serialization/deserialization so I figured it might be worth testing for.