### PR TITLE
Replaces exec-maven-plugin with sql-maven-plugin.

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -11,11 +11,6 @@
   <artifactId>keywhiz-model</artifactId>
   <name>Keywhiz Model</name>
 
-  <properties>
-    <db.url>jdbc:postgresql:keywhizdb_test</db.url>
-    <db.migration>db/postgres/migration</db.migration>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.jooq</groupId>
@@ -38,30 +33,28 @@
 
   <build>
     <plugins>
-      <!-- Creates a keywhizdb_test postgres database if it doesn't exist. -->
+      <!-- Creates (or re-creates) a keywhizdb_test postgres database. -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-
+        <artifactId>sql-maven-plugin</artifactId>
         <executions>
           <execution>
             <phase>initialize</phase>
             <goals>
-              <goal>exec</goal>
+              <goal>execute</goal>
             </goals>
           </execution>
         </executions>
 
         <configuration>
-          <executable>createdb</executable>
-          <arguments>
-            <argument>keywhizdb_test</argument>
-          </arguments>
-          <!-- Exits 1 if db exists. That's OK. -->
-          <successCodes>
-            <successCode>0</successCode>
-            <successCode>1</successCode>
-          </successCodes>
+          <driver>org.postgresql.Driver</driver>
+          <url>jdbc:postgresql:postgres</url>
+          <username>${user.name}</username>
+          <autocommit>true</autocommit>
+          <sqlCommand>
+            DROP DATABASE IF EXISTS keywhizdb_test;
+            CREATE DATABASE keywhizdb_test;
+          </sqlCommand>
         </configuration>
       </plugin>
 
@@ -79,10 +72,10 @@
         </executions>
 
         <configuration>
-          <url>${db.url}</url>
+          <url>jdbc:postgresql:keywhizdb_test</url>
           <user>${user.name}</user>
           <locations>
-            <location>filesystem:../server/src/main/resources/${db.migration}</location>
+            <location>filesystem:../server/src/main/resources/db/postgres/migration</location>
           </locations>
         </configuration>
       </plugin>
@@ -104,7 +97,7 @@
         <configuration>
           <jdbc>
             <driver>org.postgresql.Driver</driver>
-            <url>${db.url}</url>
+            <url>jdbc:postgresql:keywhizdb_test</url>
             <user>${user.name}</user>
           </jdbc>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <jooq.version>3.5.1</jooq.version>
     <powermock.version>1.6.1</powermock.version>
     <slf4j.version>1.7.7</slf4j.version>
+    <postgres.version>9.1-901-1.jdbc4</postgres.version>
   </properties>
 
   <scm>
@@ -289,7 +290,7 @@
       <dependency>
         <groupId>postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>9.1-901-1.jdbc4</version>
+        <version>${postgres.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -536,6 +537,19 @@ Place the jars in this directory: `/usr/libexec/java_home -v
               <link>https://square.github.io/keywhiz/javadoc/</link>
             </links>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>sql-maven-plugin</artifactId>
+          <version>1.5</version>
+          <dependencies>
+            <dependency>
+              <groupId>postgresql</groupId>
+              <artifactId>postgresql</artifactId>
+              <version>${postgres.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
When we switch to mysql, we could write the shell command which is equivalent to createdb. I however think sql-maven-plugin is more database agnostic compared to createdb.