### PR TITLE
Wraps configuration in new DSLContexts (for transactions).

### DIFF
--- a/server/src/main/java/keywhiz/ServiceModule.java
+++ b/server/src/main/java/keywhiz/ServiceModule.java
@@ -130,17 +130,13 @@ public class ServiceModule extends AbstractModule {
 
   // DAOs
 
-  @Provides @Singleton AclDAO aclDAO(DSLContext jooqContext, ClientDAO clientDAO,
-      GroupDAO groupDAO, SecretContentDAO secretContentDAO,
-      SecretSeriesDAO secretSeriesDAO, ObjectMapper mapper) {
-    return new AclDAO(jooqContext, clientDAO, groupDAO, secretContentDAO, secretSeriesDAO, mapper);
+  @Provides @Singleton AclDAO aclDAO(DSLContext jooqContext, ObjectMapper mapper) {
+    return new AclDAO(jooqContext, mapper);
   }
 
   @Provides @Singleton
-  @Readonly AclDAO readonlyAclDAO(@Readonly DSLContext jooqContext, @Readonly ClientDAO clientDAO,
-      @Readonly GroupDAO groupDAO, @Readonly SecretContentDAO secretContentDAO,
-      @Readonly SecretSeriesDAO secretSeriesDAO, ObjectMapper mapper) {
-    return new AclDAO(jooqContext, clientDAO, groupDAO, secretContentDAO, secretSeriesDAO, mapper);
+  @Readonly AclDAO readonlyAclDAO(@Readonly DSLContext jooqContext, ObjectMapper mapper) {
+    return new AclDAO(jooqContext, mapper);
   }
 
   @Provides @Singleton ClientDAO clientDAO(DSLContext jooqContext) {
@@ -181,16 +177,13 @@ public class ServiceModule extends AbstractModule {
     return new SecretSeriesDAO(jooqContext, mapper);
   }
 
-  @Provides @Singleton SecretDAO secretDAO(DSLContext jooqContext,
-      SecretContentDAO secretContentDAO, SecretSeriesDAO secretSeriesDAO) {
-    return new SecretDAO(jooqContext, secretContentDAO, secretSeriesDAO);
+  @Provides @Singleton SecretDAO secretDAO(DSLContext jooqContext, ObjectMapper mapper) {
+    return new SecretDAO(jooqContext, mapper);
   }
 
   @Provides @Singleton
-  @Readonly SecretDAO readonlySecretDAO(@Readonly DSLContext jooqContext,
-      @Readonly SecretContentDAO secretContentDAO,
-      @Readonly SecretSeriesDAO secretSeriesDAO) {
-    return new SecretDAO(jooqContext, secretContentDAO, secretSeriesDAO);
+  @Readonly SecretDAO readonlySecretDAO(@Readonly DSLContext jooqContext, ObjectMapper mapper) {
+    return new SecretDAO(jooqContext, mapper);
   }
 
   @Provides @Singleton SecretController secretController(SecretTransformer transformer,

--- a/server/src/main/java/keywhiz/ServiceModule.java
+++ b/server/src/main/java/keywhiz/ServiceModule.java
@@ -130,8 +130,9 @@ public class ServiceModule extends AbstractModule {
 
   // DAOs
 
-  @Provides @Singleton AclDAO aclDAO(ObjectMapper mapper, ClientDAO clientDAO, GroupDAO groupDAO) {
-    return new AclDAO(mapper, clientDAO, groupDAO);
+  @Provides @Singleton AclDAO aclDAO(ObjectMapper mapper, ClientDAO clientDAO, GroupDAO groupDAO,
+      SecretContentDAO secretContentDAO) {
+    return new AclDAO(mapper, clientDAO, groupDAO, secretContentDAO);
   }
 
   @Provides @Singleton ClientDAO clientDAO() {
@@ -142,15 +143,8 @@ public class ServiceModule extends AbstractModule {
     return new GroupDAO();
   }
 
-  @Provides @Singleton SecretContentDAO secretContentDAO(DSLContext jooqContext,
-      ObjectMapper mapper) {
-    return new SecretContentDAO(jooqContext, mapper);
-  }
-
-  @Provides @Singleton
-  @Readonly SecretContentDAO readonlySecretContentDAO(@Readonly DSLContext jooqContext,
-      ObjectMapper mapper) {
-    return new SecretContentDAO(jooqContext, mapper);
+  @Provides @Singleton SecretContentDAO secretContentDAO(ObjectMapper mapper) {
+    return new SecretContentDAO(mapper);
   }
 
   @Provides @Singleton SecretSeriesDAO secretSeriesDAO(DSLContext jooqContext,
@@ -164,13 +158,15 @@ public class ServiceModule extends AbstractModule {
     return new SecretSeriesDAO(jooqContext, mapper);
   }
 
-  @Provides @Singleton SecretDAO secretDAO(DSLContext jooqContext, ObjectMapper mapper) {
-    return new SecretDAO(jooqContext, mapper);
+  @Provides @Singleton SecretDAO secretDAO(DSLContext jooqContext, ObjectMapper mapper,
+      SecretContentDAO secretContentDAO) {
+    return new SecretDAO(jooqContext, mapper, secretContentDAO);
   }
 
   @Provides @Singleton
-  @Readonly SecretDAO readonlySecretDAO(@Readonly DSLContext jooqContext, ObjectMapper mapper) {
-    return new SecretDAO(jooqContext, mapper);
+  @Readonly SecretDAO readonlySecretDAO(@Readonly DSLContext jooqContext, ObjectMapper mapper,
+      SecretContentDAO secretContentDAO) {
+    return new SecretDAO(jooqContext, mapper, secretContentDAO);
   }
 
   @Provides @Singleton SecretController secretController(SecretTransformer transformer,

--- a/server/src/main/java/keywhiz/ServiceModule.java
+++ b/server/src/main/java/keywhiz/ServiceModule.java
@@ -130,20 +130,16 @@ public class ServiceModule extends AbstractModule {
 
   // DAOs
 
-  @Provides @Singleton AclDAO aclDAO(ObjectMapper mapper, ClientDAO clientDAO) {
-    return new AclDAO(mapper, clientDAO);
+  @Provides @Singleton AclDAO aclDAO(ObjectMapper mapper, ClientDAO clientDAO, GroupDAO groupDAO) {
+    return new AclDAO(mapper, clientDAO, groupDAO);
   }
 
   @Provides @Singleton ClientDAO clientDAO() {
     return new ClientDAO();
   }
 
-  @Provides @Singleton GroupDAO groupDAO(DSLContext jooqContext) {
-    return new GroupDAO(jooqContext);
-  }
-
-  @Provides @Singleton @Readonly GroupDAO readonlyGroupDAO(@Readonly DSLContext jooqContext) {
-    return new GroupDAO(jooqContext);
+  @Provides @Singleton GroupDAO groupDAO() {
+    return new GroupDAO();
   }
 
   @Provides @Singleton SecretContentDAO secretContentDAO(DSLContext jooqContext,

--- a/server/src/main/java/keywhiz/ServiceModule.java
+++ b/server/src/main/java/keywhiz/ServiceModule.java
@@ -160,24 +160,18 @@ public class ServiceModule extends AbstractModule {
 
   @Provides @Singleton SecretDAO secretDAO(DSLContext jooqContext, ObjectMapper mapper,
       SecretContentDAO secretContentDAO) {
-    return new SecretDAO(jooqContext, mapper, secretContentDAO);
-  }
-
-  @Provides @Singleton
-  @Readonly SecretDAO readonlySecretDAO(@Readonly DSLContext jooqContext, ObjectMapper mapper,
-      SecretContentDAO secretContentDAO) {
-    return new SecretDAO(jooqContext, mapper, secretContentDAO);
+    return new SecretDAO(mapper, secretContentDAO);
   }
 
   @Provides @Singleton SecretController secretController(SecretTransformer transformer,
-      ContentCryptographer cryptographer, SecretDAO secretDAO) {
-    return new SecretController(transformer, cryptographer, secretDAO);
+      ContentCryptographer cryptographer, DSLContext jooqContext, SecretDAO secretDAO) {
+    return new SecretController(transformer, cryptographer, jooqContext, secretDAO);
   }
 
   @Provides @Singleton
   @Readonly SecretController readonlySecretController(SecretTransformer transformer,
-      ContentCryptographer cryptographer, @Readonly SecretDAO secretDAO) {
-    return new SecretController(transformer, cryptographer, secretDAO);
+      ContentCryptographer cryptographer, @Readonly DSLContext jooqContext, SecretDAO secretDAO) {
+    return new SecretController(transformer, cryptographer, jooqContext, secretDAO);
   }
 
   @Provides @Singleton

--- a/server/src/main/java/keywhiz/ServiceModule.java
+++ b/server/src/main/java/keywhiz/ServiceModule.java
@@ -131,8 +131,8 @@ public class ServiceModule extends AbstractModule {
   // DAOs
 
   @Provides @Singleton AclDAO aclDAO(ObjectMapper mapper, ClientDAO clientDAO, GroupDAO groupDAO,
-      SecretContentDAO secretContentDAO) {
-    return new AclDAO(mapper, clientDAO, groupDAO, secretContentDAO);
+      SecretContentDAO secretContentDAO, SecretSeriesDAO secretSeriesDAO) {
+    return new AclDAO(mapper, clientDAO, groupDAO, secretContentDAO, secretSeriesDAO);
   }
 
   @Provides @Singleton ClientDAO clientDAO() {
@@ -147,20 +147,13 @@ public class ServiceModule extends AbstractModule {
     return new SecretContentDAO(mapper);
   }
 
-  @Provides @Singleton SecretSeriesDAO secretSeriesDAO(DSLContext jooqContext,
-      ObjectMapper mapper) {
-    return new SecretSeriesDAO(jooqContext, mapper);
+  @Provides @Singleton SecretSeriesDAO secretSeriesDAO(ObjectMapper mapper) {
+    return new SecretSeriesDAO(mapper);
   }
 
-  @Provides @Singleton
-  @Readonly SecretSeriesDAO readonlySecretSeriesDAO(@Readonly DSLContext jooqContext,
-      ObjectMapper mapper) {
-    return new SecretSeriesDAO(jooqContext, mapper);
-  }
-
-  @Provides @Singleton SecretDAO secretDAO(DSLContext jooqContext, ObjectMapper mapper,
-      SecretContentDAO secretContentDAO) {
-    return new SecretDAO(mapper, secretContentDAO);
+  @Provides @Singleton SecretDAO secretDAO(SecretContentDAO secretContentDAO,
+  SecretSeriesDAO secretSeriesDAO) {
+    return new SecretDAO(secretContentDAO, secretSeriesDAO);
   }
 
   @Provides @Singleton SecretController secretController(SecretTransformer transformer,

--- a/server/src/main/java/keywhiz/ServiceModule.java
+++ b/server/src/main/java/keywhiz/ServiceModule.java
@@ -135,22 +135,6 @@ public class ServiceModule extends AbstractModule {
     return new AclDAO(mapper, clientDAO, groupDAO, secretContentDAO, secretSeriesDAO);
   }
 
-  @Provides @Singleton ClientDAO clientDAO() {
-    return new ClientDAO();
-  }
-
-  @Provides @Singleton GroupDAO groupDAO() {
-    return new GroupDAO();
-  }
-
-  @Provides @Singleton SecretContentDAO secretContentDAO(ObjectMapper mapper) {
-    return new SecretContentDAO(mapper);
-  }
-
-  @Provides @Singleton SecretSeriesDAO secretSeriesDAO(ObjectMapper mapper) {
-    return new SecretSeriesDAO(mapper);
-  }
-
   @Provides @Singleton SecretDAO secretDAO(SecretContentDAO secretContentDAO,
   SecretSeriesDAO secretSeriesDAO) {
     return new SecretDAO(secretContentDAO, secretSeriesDAO);

--- a/server/src/main/java/keywhiz/ServiceModule.java
+++ b/server/src/main/java/keywhiz/ServiceModule.java
@@ -130,13 +130,8 @@ public class ServiceModule extends AbstractModule {
 
   // DAOs
 
-  @Provides @Singleton AclDAO aclDAO(DSLContext jooqContext, ObjectMapper mapper) {
-    return new AclDAO(jooqContext, mapper);
-  }
-
-  @Provides @Singleton
-  @Readonly AclDAO readonlyAclDAO(@Readonly DSLContext jooqContext, ObjectMapper mapper) {
-    return new AclDAO(jooqContext, mapper);
+  @Provides @Singleton AclDAO aclDAO(ObjectMapper mapper) {
+    return new AclDAO(mapper);
   }
 
   @Provides @Singleton ClientDAO clientDAO(DSLContext jooqContext) {

--- a/server/src/main/java/keywhiz/ServiceModule.java
+++ b/server/src/main/java/keywhiz/ServiceModule.java
@@ -130,16 +130,12 @@ public class ServiceModule extends AbstractModule {
 
   // DAOs
 
-  @Provides @Singleton AclDAO aclDAO(ObjectMapper mapper) {
-    return new AclDAO(mapper);
+  @Provides @Singleton AclDAO aclDAO(ObjectMapper mapper, ClientDAO clientDAO) {
+    return new AclDAO(mapper, clientDAO);
   }
 
-  @Provides @Singleton ClientDAO clientDAO(DSLContext jooqContext) {
-    return new ClientDAO(jooqContext);
-  }
-
-  @Provides @Singleton @Readonly ClientDAO readonlyClientDAO(@Readonly DSLContext jooqContext) {
-    return new ClientDAO(jooqContext);
+  @Provides @Singleton ClientDAO clientDAO() {
+    return new ClientDAO();
   }
 
   @Provides @Singleton GroupDAO groupDAO(DSLContext jooqContext) {

--- a/server/src/main/java/keywhiz/auth/bcrypt/BcryptAuthenticator.java
+++ b/server/src/main/java/keywhiz/auth/bcrypt/BcryptAuthenticator.java
@@ -22,6 +22,7 @@ import io.dropwizard.java8.auth.Authenticator;
 import java.util.Optional;
 import keywhiz.auth.User;
 import keywhiz.service.daos.UserDAO;
+import org.jooq.DSLContext;
 import org.mindrot.jbcrypt.BCrypt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,9 +31,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class BcryptAuthenticator implements Authenticator<BasicCredentials, User> {
   private static final Logger logger = LoggerFactory.getLogger(BcryptAuthenticator.class);
+
+  private final DSLContext dslContext;
   private final UserDAO userDAO;
 
-  public BcryptAuthenticator(UserDAO userDAO) {
+  public BcryptAuthenticator(DSLContext dslContext, UserDAO userDAO) {
+    this.dslContext = dslContext;
     this.userDAO = checkNotNull(userDAO);
   }
 
@@ -48,7 +52,7 @@ public class BcryptAuthenticator implements Authenticator<BasicCredentials, User
     String password = credentials.getPassword();
 
     // Get hashed password column from BCrypt table by username
-    Optional<String> optionalHashedPwForUser = userDAO.getHashedPassword(username);
+    Optional<String> optionalHashedPwForUser = userDAO.getHashedPassword(dslContext, username);
     if (!optionalHashedPwForUser.isPresent()) {
       return Optional.empty();
     }

--- a/server/src/main/java/keywhiz/auth/bcrypt/BcryptAuthenticatorFactory.java
+++ b/server/src/main/java/keywhiz/auth/bcrypt/BcryptAuthenticatorFactory.java
@@ -36,7 +36,7 @@ public class BcryptAuthenticatorFactory implements UserAuthenticatorFactory {
 
   @Override public Authenticator<BasicCredentials, User> build(DSLContext dslContext) {
     logger.debug("Creating BCrypt authenticator");
-    UserDAO userDAO = new UserDAO(dslContext);
-    return new BcryptAuthenticator(userDAO);
+    UserDAO userDAO = new UserDAO();
+    return new BcryptAuthenticator(dslContext, userDAO);
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -51,11 +51,13 @@ public class AclDAO {
 
   private final ObjectMapper mapper;
   private final ClientDAO clientDAO;
+  private final GroupDAO groupDAO;
 
   @Inject
-  public AclDAO(ObjectMapper mapper, ClientDAO clientDAO) {
+  public AclDAO(ObjectMapper mapper, ClientDAO clientDAO, GroupDAO groupDAO) {
     this.mapper = mapper;
     this.clientDAO = clientDAO;
+    this.groupDAO = groupDAO;
   }
 
   public void findAndAllowAccess(DSLContext dslContext, long secretId, long groupId) {
@@ -63,10 +65,9 @@ public class AclDAO {
 
     dslContext.transaction(configuration -> {
       DSLContext innerDslContext = DSL.using(configuration);
-      GroupDAO groupDAO = new GroupDAO(innerDslContext);
       SecretSeriesDAO secretSeriesDAO = new SecretSeriesDAO(innerDslContext, mapper);
 
-      Optional<Group> group = groupDAO.getGroupById(groupId);
+      Optional<Group> group = groupDAO.getGroupById(innerDslContext, groupId);
       if (!group.isPresent()) {
         logger.info("Failure to allow access groupId {}, secretId {}: groupId not found.", groupId,
             secretId);
@@ -89,10 +90,9 @@ public class AclDAO {
 
     dslContext.transaction(configuration -> {
       DSLContext innerDslContext = DSL.using(configuration);
-      GroupDAO groupDAO = new GroupDAO(innerDslContext);
       SecretSeriesDAO secretSeriesDAO = new SecretSeriesDAO(innerDslContext, mapper);
 
-      Optional<Group> group = groupDAO.getGroupById(groupId);
+      Optional<Group> group = groupDAO.getGroupById(innerDslContext, groupId);
       if (!group.isPresent()) {
         logger.info("Failure to revoke access groupId {}, secretId {}: groupId not found.", groupId,
             secretId);
@@ -115,7 +115,6 @@ public class AclDAO {
 
     dslContext.transaction(configuration -> {
       DSLContext innerDslContext = DSL.using(configuration);
-      GroupDAO groupDAO = new GroupDAO(innerDslContext);
 
       Optional<Client> client = clientDAO.getClientById(innerDslContext, clientId);
       if (!client.isPresent()) {
@@ -124,7 +123,7 @@ public class AclDAO {
         throw new IllegalStateException(format("ClientId %d doesn't exist.", clientId));
       }
 
-      Optional<Group> group = groupDAO.getGroupById(groupId);
+      Optional<Group> group = groupDAO.getGroupById(innerDslContext, groupId);
       if (!group.isPresent()) {
         logger.info("Failure to enroll membership clientId {}, groupId {}: groupId not found.",
             clientId, groupId);
@@ -140,7 +139,6 @@ public class AclDAO {
 
     dslContext.transaction(configuration -> {
       DSLContext innerDslContext = DSL.using(configuration);
-      GroupDAO groupDAO = new GroupDAO(innerDslContext);
 
       Optional<Client> client = clientDAO.getClientById(innerDslContext, clientId);
       if (!client.isPresent()) {
@@ -149,7 +147,7 @@ public class AclDAO {
         throw new IllegalStateException(format("ClientId %d doesn't exist.", clientId));
       }
 
-      Optional<Group> group = groupDAO.getGroupById(groupId);
+      Optional<Group> group = groupDAO.getGroupById(innerDslContext, groupId);
       if (!group.isPresent()) {
         logger.info("Failure to evict membership clientId {}, groupId {}: groupId not found.",
             clientId, groupId);

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -53,14 +53,16 @@ public class AclDAO {
   private final ClientDAO clientDAO;
   private final GroupDAO groupDAO;
   private final SecretContentDAO secretContentDAO;
+  private final SecretSeriesDAO secretSeriesDAO;
 
   @Inject
   public AclDAO(ObjectMapper mapper, ClientDAO clientDAO, GroupDAO groupDAO,
-      SecretContentDAO secretContentDAO) {
+      SecretContentDAO secretContentDAO, SecretSeriesDAO secretSeriesDAO) {
     this.mapper = mapper;
     this.clientDAO = clientDAO;
     this.groupDAO = groupDAO;
     this.secretContentDAO = secretContentDAO;
+    this.secretSeriesDAO = secretSeriesDAO;
   }
 
   public void findAndAllowAccess(DSLContext dslContext, long secretId, long groupId) {
@@ -68,7 +70,6 @@ public class AclDAO {
 
     dslContext.transaction(configuration -> {
       DSLContext innerDslContext = DSL.using(configuration);
-      SecretSeriesDAO secretSeriesDAO = new SecretSeriesDAO(innerDslContext, mapper);
 
       Optional<Group> group = groupDAO.getGroupById(innerDslContext, groupId);
       if (!group.isPresent()) {
@@ -77,7 +78,7 @@ public class AclDAO {
         throw new IllegalStateException(format("GroupId %d doesn't exist.", groupId));
       }
 
-      Optional<SecretSeries> secret = secretSeriesDAO.getSecretSeriesById(secretId);
+      Optional<SecretSeries> secret = secretSeriesDAO.getSecretSeriesById(innerDslContext, secretId);
       if (!secret.isPresent()) {
         logger.info("Failure to allow access groupId {}, secretId {}: secretId not found.", groupId,
             secretId);
@@ -93,7 +94,6 @@ public class AclDAO {
 
     dslContext.transaction(configuration -> {
       DSLContext innerDslContext = DSL.using(configuration);
-      SecretSeriesDAO secretSeriesDAO = new SecretSeriesDAO(innerDslContext, mapper);
 
       Optional<Group> group = groupDAO.getGroupById(innerDslContext, groupId);
       if (!group.isPresent()) {
@@ -102,7 +102,8 @@ public class AclDAO {
         throw new IllegalStateException(format("GroupId %d doesn't exist.", groupId));
       }
 
-      Optional<SecretSeries> secret = secretSeriesDAO.getSecretSeriesById(secretId);
+      Optional<SecretSeries> secret = secretSeriesDAO.getSecretSeriesById(innerDslContext,
+          secretId);
       if (!secret.isPresent()) {
         logger.info("Failure to revoke access groupId {}, secretId {}: secretId not found.",
             groupId, secretId);

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -55,8 +55,7 @@ public class AclDAO {
   private final SecretContentDAO secretContentDAO;
   private final SecretSeriesDAO secretSeriesDAO;
 
-  @Inject
-  public AclDAO(ObjectMapper mapper, ClientDAO clientDAO, GroupDAO groupDAO,
+  @Inject public AclDAO(ObjectMapper mapper, ClientDAO clientDAO, GroupDAO groupDAO,
       SecretContentDAO secretContentDAO, SecretSeriesDAO secretSeriesDAO) {
     this.mapper = mapper;
     this.clientDAO = clientDAO;

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -50,10 +50,12 @@ public class AclDAO {
   private static final Logger logger = LoggerFactory.getLogger(AclDAO.class);
 
   private final ObjectMapper mapper;
+  private final ClientDAO clientDAO;
 
   @Inject
-  public AclDAO(ObjectMapper mapper) {
+  public AclDAO(ObjectMapper mapper, ClientDAO clientDAO) {
     this.mapper = mapper;
+    this.clientDAO = clientDAO;
   }
 
   public void findAndAllowAccess(DSLContext dslContext, long secretId, long groupId) {
@@ -113,10 +115,9 @@ public class AclDAO {
 
     dslContext.transaction(configuration -> {
       DSLContext innerDslContext = DSL.using(configuration);
-      ClientDAO clientDAO = new ClientDAO(innerDslContext);
       GroupDAO groupDAO = new GroupDAO(innerDslContext);
 
-      Optional<Client> client = clientDAO.getClientById(clientId);
+      Optional<Client> client = clientDAO.getClientById(innerDslContext, clientId);
       if (!client.isPresent()) {
         logger.info("Failure to enroll membership clientId {}, groupId {}: clientId not found.",
             clientId, groupId);
@@ -139,10 +140,9 @@ public class AclDAO {
 
     dslContext.transaction(configuration -> {
       DSLContext innerDslContext = DSL.using(configuration);
-      ClientDAO clientDAO = new ClientDAO(innerDslContext);
       GroupDAO groupDAO = new GroupDAO(innerDslContext);
 
-      Optional<Client> client = clientDAO.getClientById(clientId);
+      Optional<Client> client = clientDAO.getClientById(innerDslContext, clientId);
       if (!client.isPresent()) {
         logger.info("Failure to evict membership clientId {}, groupId {}: clientId not found.",
             clientId, groupId);

--- a/server/src/main/java/keywhiz/service/daos/ClientDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/ClientDAO.java
@@ -19,12 +19,11 @@ package keywhiz.service.daos;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Optional;
-import javax.inject.Inject;
 import keywhiz.api.model.Client;
 import keywhiz.jooq.tables.records.ClientsRecord;
 import org.jooq.DSLContext;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static keywhiz.jooq.tables.Clients.CLIENTS;
 
 public class ClientDAO {

--- a/server/src/main/java/keywhiz/service/daos/ClientDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/ClientDAO.java
@@ -24,17 +24,13 @@ import keywhiz.api.model.Client;
 import keywhiz.jooq.tables.records.ClientsRecord;
 import org.jooq.DSLContext;
 
+import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
 import static keywhiz.jooq.tables.Clients.CLIENTS;
 
 public class ClientDAO {
-  private final DSLContext dslContext;
+  public long createClient(DSLContext dslContext, String name, String user, Optional<String> description) {
+    checkNotNull(dslContext);
 
-  @Inject
-  public ClientDAO(DSLContext dslContext) {
-    this.dslContext = dslContext;
-  }
-
-  public long createClient(String name, String user, Optional<String> description) {
     ClientsRecord r = dslContext.newRecord(CLIENTS);
 
     r.setName(name);
@@ -48,26 +44,34 @@ public class ClientDAO {
     return r.getId();
   }
 
-  public void deleteClient(Client client) {
+  public void deleteClient(DSLContext dslContext, Client client) {
+    checkNotNull(dslContext);
+
     dslContext
         .delete(CLIENTS)
         .where(CLIENTS.ID.eq(Math.toIntExact(client.getId())))
         .execute();
   }
 
-  public Optional<Client> getClient(String name) {
+  public Optional<Client> getClient(DSLContext dslContext, String name) {
+    checkNotNull(dslContext);
+
     ClientsRecord r = dslContext.fetchOne(CLIENTS, CLIENTS.NAME.eq(name));
     return Optional.ofNullable(r).map(
         rec -> new ClientMapper().map(rec));
   }
 
-  public Optional<Client> getClientById(long id) {
+  public Optional<Client> getClientById(DSLContext dslContext, long id) {
+    checkNotNull(dslContext);
+
     ClientsRecord r = dslContext.fetchOne(CLIENTS, CLIENTS.ID.eq(Math.toIntExact(id)));
     return Optional.ofNullable(r).map(
         rec -> new ClientMapper().map(rec));
   }
 
-  public ImmutableSet<Client> getClients() {
+  public ImmutableSet<Client> getClients(DSLContext dslContext) {
+    checkNotNull(dslContext);
+
     List<Client> r = dslContext
         .selectFrom(CLIENTS)
         .fetch()

--- a/server/src/main/java/keywhiz/service/daos/GroupDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/GroupDAO.java
@@ -19,12 +19,11 @@ package keywhiz.service.daos;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Optional;
-import javax.inject.Inject;
 import keywhiz.api.model.Group;
 import keywhiz.jooq.tables.records.GroupsRecord;
 import org.jooq.DSLContext;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static keywhiz.jooq.tables.Groups.GROUPS;
 
 public class GroupDAO {

--- a/server/src/main/java/keywhiz/service/daos/GroupDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/GroupDAO.java
@@ -24,16 +24,14 @@ import keywhiz.api.model.Group;
 import keywhiz.jooq.tables.records.GroupsRecord;
 import org.jooq.DSLContext;
 
+import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
 import static keywhiz.jooq.tables.Groups.GROUPS;
 
 public class GroupDAO {
-  private final DSLContext dslContext;
 
-  @Inject public GroupDAO(DSLContext dslContext) {
-    this.dslContext = dslContext;
-  }
+  public long createGroup(DSLContext dslContext, String name, String creator, Optional<String> description) {
+    checkNotNull(dslContext);
 
-  public long createGroup(String name, String creator, Optional<String> description) {
     GroupsRecord r = dslContext.newRecord(GROUPS);
 
     r.setName(name);
@@ -45,26 +43,34 @@ public class GroupDAO {
     return r.getId();
   }
 
-  public void deleteGroup(Group group) {
+  public void deleteGroup(DSLContext dslContext, Group group) {
+    checkNotNull(dslContext);
+
     dslContext
         .delete(GROUPS)
         .where(GROUPS.ID.eq(Math.toIntExact(group.getId())))
         .execute();
   }
 
-  public Optional<Group> getGroup(String name) {
+  public Optional<Group> getGroup(DSLContext dslContext, String name) {
+    checkNotNull(dslContext);
+
     GroupsRecord r = dslContext.fetchOne(GROUPS, GROUPS.NAME.eq(name));
     return Optional.ofNullable(r).map(
         rec -> new GroupMapper().map(rec));
   }
 
-  public Optional<Group> getGroupById(long id) {
+  public Optional<Group> getGroupById(DSLContext dslContext, long id) {
+    checkNotNull(dslContext);
+
     GroupsRecord r = dslContext.fetchOne(GROUPS, GROUPS.ID.eq(Math.toIntExact(id)));
     return Optional.ofNullable(r).map(
         rec -> new GroupMapper().map(rec));
   }
 
-  public ImmutableSet<Group> getGroups() {
+  public ImmutableSet<Group> getGroups(DSLContext dslContext) {
+    checkNotNull(dslContext);
+
     List<Group> r = dslContext.selectFrom(GROUPS).fetch().map(new GroupMapper());
     return ImmutableSet.copyOf(r);
   }

--- a/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
@@ -37,8 +37,7 @@ import static keywhiz.jooq.tables.SecretsContent.SECRETS_CONTENT;
 public class SecretContentDAO {
   private final ObjectMapper mapper;
 
-  @Inject
-  public SecretContentDAO(ObjectMapper mapper) {
+  @Inject public SecretContentDAO(ObjectMapper mapper) {
     this.mapper = mapper;
   }
 

--- a/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
@@ -28,23 +28,24 @@ import keywhiz.api.model.SecretContent;
 import keywhiz.jooq.tables.records.SecretsContentRecord;
 import org.jooq.DSLContext;
 
+import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
 import static keywhiz.jooq.tables.SecretsContent.SECRETS_CONTENT;
 
 /**
  * Interacts with 'secrets_content' table and actions on {@link SecretContent} entities.
  */
 public class SecretContentDAO {
-  private final DSLContext dslContext;
   private final ObjectMapper mapper;
 
   @Inject
-  public SecretContentDAO(DSLContext dslContext, ObjectMapper mapper) {
-    this.dslContext = dslContext;
+  public SecretContentDAO(ObjectMapper mapper) {
     this.mapper = mapper;
   }
 
-  public long createSecretContent(long secretId, String encryptedContent, String version,
+  public long createSecretContent(DSLContext dslContext, long secretId, String encryptedContent, String version,
       String creator, Map<String, String> metadata) {
+    checkNotNull(dslContext);
+
     SecretsContentRecord r = dslContext.newRecord(SECRETS_CONTENT);
 
     String jsonMetadata;
@@ -66,15 +67,19 @@ public class SecretContentDAO {
     return r.getId();
   }
 
-  public Optional<SecretContent> getSecretContentById(long id) {
+  public Optional<SecretContent> getSecretContentById(DSLContext dslContext, long id) {
+    checkNotNull(dslContext);
+
     SecretsContentRecord r = dslContext.fetchOne(SECRETS_CONTENT,
         SECRETS_CONTENT.ID.eq(Math.toIntExact(id)));
     return Optional.ofNullable(r).map(
         rec -> new SecretContentMapper(mapper).map(rec));
   }
 
-  public Optional<SecretContent> getSecretContentBySecretIdAndVersion(long secretId,
-      String version) {
+  public Optional<SecretContent> getSecretContentBySecretIdAndVersion(DSLContext dslContext,
+      long secretId, String version) {
+    checkNotNull(dslContext);
+
     SecretsContentRecord r = dslContext.fetchOne(SECRETS_CONTENT,
         SECRETS_CONTENT.SECRETID.eq(Math.toIntExact(secretId))
             .and(SECRETS_CONTENT.VERSION.eq(version)));
@@ -82,7 +87,10 @@ public class SecretContentDAO {
         rec -> new SecretContentMapper(mapper).map(rec));
   }
 
-  public ImmutableList<SecretContent> getSecretContentsBySecretId(long secretId) {
+  public ImmutableList<SecretContent> getSecretContentsBySecretId(DSLContext dslContext,
+      long secretId) {
+    checkNotNull(dslContext);
+
     List<SecretContent> r = dslContext
         .selectFrom(SECRETS_CONTENT)
         .where(SECRETS_CONTENT.SECRETID.eq(Math.toIntExact(secretId)))
@@ -92,7 +100,10 @@ public class SecretContentDAO {
     return ImmutableList.copyOf(r);
   }
 
-  public void deleteSecretContentBySecretIdAndVersion(long secretId, String version) {
+  public void deleteSecretContentBySecretIdAndVersion(DSLContext dslContext, long secretId,
+      String version) {
+    checkNotNull(dslContext);
+
     dslContext
         .delete(SECRETS_CONTENT)
         .where(SECRETS_CONTENT.SECRETID.eq(Math.toIntExact(secretId))
@@ -100,7 +111,9 @@ public class SecretContentDAO {
         .execute();
   }
 
-  public ImmutableList<String> getVersionFromSecretId(long secretId) {
+  public ImmutableList<String> getVersionFromSecretId(DSLContext dslContext, long secretId) {
+    checkNotNull(dslContext);
+
     List<String> r = dslContext
         .select(SECRETS_CONTENT.VERSION)
         .from(SECRETS_CONTENT)

--- a/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
@@ -28,7 +28,7 @@ import keywhiz.api.model.SecretContent;
 import keywhiz.jooq.tables.records.SecretsContentRecord;
 import org.jooq.DSLContext;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static keywhiz.jooq.tables.SecretsContent.SECRETS_CONTENT;
 
 /**

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -16,7 +16,6 @@
 
 package keywhiz.service.daos;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.Map;

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -20,18 +20,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import io.dropwizard.jackson.Jackson;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import keywhiz.KeywhizService;
 import keywhiz.api.model.SecretSeries;
 import keywhiz.jooq.tables.records.SecretsRecord;
 import org.jooq.DSLContext;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static keywhiz.jooq.tables.Secrets.SECRETS;
 
 /**

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -31,23 +31,24 @@ import keywhiz.api.model.SecretSeries;
 import keywhiz.jooq.tables.records.SecretsRecord;
 import org.jooq.DSLContext;
 
+import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
 import static keywhiz.jooq.tables.Secrets.SECRETS;
 
 /**
  * Interacts with 'secrets' table and actions on {@link SecretSeries} entities.
  */
 public class SecretSeriesDAO {
-  private final DSLContext dslContext;
   private final ObjectMapper mapper;
 
   @Inject
-  public SecretSeriesDAO(DSLContext dslContext, ObjectMapper mapper) {
-    this.dslContext = dslContext;
+  public SecretSeriesDAO(ObjectMapper mapper) {
     this.mapper = mapper;
   }
 
-  long createSecretSeries(String name, String creator, String description, @Nullable String type,
-      @Nullable Map<String, String> generationOptions) {
+  long createSecretSeries(DSLContext dslContext, String name, String creator, String description,
+      @Nullable String type, @Nullable Map<String, String> generationOptions) {
+    checkNotNull(dslContext);
+
     SecretsRecord r =  dslContext.newRecord(SECRETS);
 
     r.setName(name);
@@ -70,19 +71,25 @@ public class SecretSeriesDAO {
     return r.getId();
   }
 
-  public Optional<SecretSeries> getSecretSeriesById(long id) {
+  public Optional<SecretSeries> getSecretSeriesById(DSLContext dslContext, long id) {
+    checkNotNull(dslContext);
+
     SecretsRecord r = dslContext.fetchOne(SECRETS, SECRETS.ID.eq(Math.toIntExact(id)));
     return Optional.ofNullable(r).map(
         rec -> new SecretSeriesMapper(mapper).map(rec));
   }
 
-  public Optional<SecretSeries> getSecretSeriesByName(String name) {
+  public Optional<SecretSeries> getSecretSeriesByName(DSLContext dslContext, String name) {
+    checkNotNull(dslContext);
+
     SecretsRecord r = dslContext.fetchOne(SECRETS, SECRETS.NAME.eq(name));
     return Optional.ofNullable(r).map(
         rec -> new SecretSeriesMapper(mapper).map(rec));
   }
 
-  public ImmutableList<SecretSeries> getSecretSeries() {
+  public ImmutableList<SecretSeries> getSecretSeries(DSLContext dslContext) {
+    checkNotNull(dslContext);
+
     List<SecretSeries> r = dslContext
         .selectFrom(SECRETS)
         .fetch()
@@ -91,14 +98,17 @@ public class SecretSeriesDAO {
     return ImmutableList.copyOf(r);
   }
 
-  public void deleteSecretSeriesByName(String name) {
-    dslContext
-        .delete(SECRETS)
+  public void deleteSecretSeriesByName(DSLContext dslContext, String name) {
+    checkNotNull(dslContext);
+
+    dslContext.delete(SECRETS)
         .where(SECRETS.NAME.eq(name))
         .execute();
   }
 
-  public void deleteSecretSeriesById(long id) {
+  public void deleteSecretSeriesById(DSLContext dslContext, long id) {
+    checkNotNull(dslContext);
+
     dslContext.delete(SECRETS)
         .where(SECRETS.ID.eq(Math.toIntExact(id)))
         .execute();

--- a/server/src/main/java/keywhiz/service/daos/UserDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/UserDAO.java
@@ -17,7 +17,6 @@
 package keywhiz.service.daos;
 
 import java.util.Optional;
-import javax.inject.Inject;
 import org.jooq.DSLContext;
 
 import static keywhiz.jooq.tables.Users.USERS;

--- a/server/src/main/java/keywhiz/service/daos/UserDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/UserDAO.java
@@ -23,14 +23,7 @@ import org.jooq.DSLContext;
 import static keywhiz.jooq.tables.Users.USERS;
 
 public class UserDAO {
-  private final DSLContext dslContext;
-
-  @Inject
-  public UserDAO(DSLContext dslContext) {
-    this.dslContext = dslContext;
-  }
-
-  public Optional<String> getHashedPassword(String name) {
+  public Optional<String> getHashedPassword(DSLContext dslContext, String name) {
     String r = dslContext
         .select(USERS.PASSWORD_HASH)
         .from(USERS)

--- a/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
@@ -47,11 +47,9 @@ public class ClientAuthFactory {
   private static final Logger logger = LoggerFactory.getLogger(ClientAuthFactory.class);
 
   private final Authenticator<String, Client> authenticator;
-  private final DSLContext dslContext;
 
   @Inject public ClientAuthFactory(DSLContext dslContext, ClientDAO clientDAO) {
     this.authenticator = new MyAuthenticator(dslContext, clientDAO);
-    this.dslContext = dslContext;
   }
 
   public Client provide(ContainerRequest request) {

--- a/server/src/main/java/keywhiz/service/resources/AutomationEnrollClientGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationEnrollClientGroupResource.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import keywhiz.api.model.AutomationClient;
 import keywhiz.service.daos.AclDAO;
+import org.jooq.DSLContext;
 
 /**
  * @parentEndpointName enroll-clients-automation
@@ -38,10 +39,12 @@ import keywhiz.service.daos.AclDAO;
 @Produces(MediaType.APPLICATION_JSON)
 public class AutomationEnrollClientGroupResource {
   private final AclDAO aclDAO;
+  private final DSLContext dslContext;
 
   @Inject
-  public AutomationEnrollClientGroupResource(AclDAO aclDAO) {
+  public AutomationEnrollClientGroupResource(AclDAO aclDAO, DSLContext dslContext) {
     this.aclDAO = aclDAO;
+    this.dslContext = dslContext;
   }
 
   /**
@@ -61,7 +64,7 @@ public class AutomationEnrollClientGroupResource {
       @PathParam("groupId") LongParam groupId) {
 
     try {
-      aclDAO.findAndEnrollClient(clientId.get(), groupId.get());
+      aclDAO.findAndEnrollClient(dslContext, clientId.get(), groupId.get());
     } catch (IllegalStateException e) {
       throw new NotFoundException();
     }
@@ -86,7 +89,7 @@ public class AutomationEnrollClientGroupResource {
       @PathParam("groupId") long groupId) {
 
     try {
-      aclDAO.findAndEvictClient(clientId, groupId);
+      aclDAO.findAndEvictClient(dslContext, clientId, groupId);
     } catch (IllegalStateException e) {
       throw new NotFoundException();
     }

--- a/server/src/main/java/keywhiz/service/resources/AutomationSecretAccessResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationSecretAccessResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import keywhiz.api.model.AutomationClient;
 import keywhiz.service.daos.AclDAO;
+import org.jooq.DSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,10 +42,13 @@ import org.slf4j.LoggerFactory;
 @Produces(MediaType.APPLICATION_JSON)
 public class AutomationSecretAccessResource {
   private static final Logger logger = LoggerFactory.getLogger(AutomationSecretAccessResource.class);
+
+  private final DSLContext dslContext;
   private final AclDAO aclDAO;
 
   @Inject
-  public AutomationSecretAccessResource(AclDAO aclDAO) {
+  public AutomationSecretAccessResource(DSLContext dslContext, AclDAO aclDAO) {
+    this.dslContext = dslContext;
     this.aclDAO = aclDAO;
   }
 
@@ -67,7 +71,7 @@ public class AutomationSecretAccessResource {
         automationClient, secretId, groupId);
 
     try {
-      aclDAO.findAndAllowAccess(secretId.get(), groupId.get());
+      aclDAO.findAndAllowAccess(dslContext, secretId.get(), groupId.get());
     } catch (IllegalStateException e) {
       throw new NotFoundException();
     }
@@ -94,7 +98,7 @@ public class AutomationSecretAccessResource {
         automationClient, secretId, groupId);
 
     try {
-      aclDAO.findAndRevokeAccess(secretId.get(), groupId.get());
+      aclDAO.findAndRevokeAccess(dslContext, secretId.get(), groupId.get());
     } catch (IllegalStateException e) {
       throw new NotFoundException();
     }

--- a/server/src/main/java/keywhiz/service/resources/AutomationSecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationSecretResource.java
@@ -203,9 +203,9 @@ public class AutomationSecretResource {
   public Response deleteSecretSeries(@Auth AutomationClient automationClient,
       @PathParam("secretName") String secretName) {
 
-    secretSeriesDAO.getSecretSeriesByName(secretName)
+    secretSeriesDAO.getSecretSeriesByName(dslContext, secretName)
         .orElseThrow(() -> new NotFoundException("Secret series not found."));
-    secretSeriesDAO.deleteSecretSeriesByName(secretName);
+    secretSeriesDAO.deleteSecretSeriesByName(dslContext, secretName);
 
     return Response.ok().build();
   }

--- a/server/src/main/java/keywhiz/service/resources/ClientsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/ClientsResource.java
@@ -47,6 +47,7 @@ import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.ClientDAO;
 import keywhiz.service.exceptions.ConflictException;
+import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,11 +63,13 @@ import org.slf4j.LoggerFactory;
 public class ClientsResource {
   private static final Logger logger = LoggerFactory.getLogger(ClientsResource.class);
 
+  private final DSLContext dslContext;
   private final AclDAO aclDAO;
   private final ClientDAO clientDAO;
 
   @Inject
-  public ClientsResource(AclDAO aclDAO, ClientDAO clientDAO) {
+  public ClientsResource(DSLContext dslContext, AclDAO aclDAO, ClientDAO clientDAO) {
+    this.dslContext = dslContext;
     this.aclDAO = aclDAO;
     this.clientDAO = clientDAO;
   }
@@ -183,9 +186,9 @@ public class ClientsResource {
     }
 
     Client client = optionalClient.get();
-    ImmutableList<Group> groups = ImmutableList.copyOf(aclDAO.getGroupsFor(client));
+    ImmutableList<Group> groups = ImmutableList.copyOf(aclDAO.getGroupsFor(dslContext, client));
     ImmutableList<SanitizedSecret> sanitizedSecrets =
-        ImmutableList.copyOf(aclDAO.getSanitizedSecretsFor(client));
+        ImmutableList.copyOf(aclDAO.getSanitizedSecretsFor(dslContext, client));
 
     return ClientDetailResponse.fromClient(client, groups, sanitizedSecrets);
   }

--- a/server/src/main/java/keywhiz/service/resources/ClientsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/ClientsResource.java
@@ -95,7 +95,7 @@ public class ClientsResource {
 
   protected List<Client> listClients(@Auth User user) {
     logger.info("User '{}' listing clients.", user);
-    Set<Client> clients = clientDAO.getClients();
+    Set<Client> clients = clientDAO.getClients(dslContext);
     return ImmutableList.copyOf(clients);
   }
 
@@ -123,7 +123,8 @@ public class ClientsResource {
 
     long clientId;
     try {
-      clientId = clientDAO.createClient(createClientRequest.name, user.getName(), Optional.empty());
+      clientId = clientDAO.createClient(dslContext, createClientRequest.name, user.getName(),
+          Optional.empty());
     } catch (DataAccessException e) {
       logger.warn("Cannot create client {}: {}", createClientRequest.name, e);
       throw new ConflictException("Conflict creating client.");
@@ -169,18 +170,18 @@ public class ClientsResource {
   public Response deleteClient(@Auth User user, @PathParam("clientId") LongParam clientId) {
     logger.info("User '{}' deleting client id={}.", user, clientId);
 
-    Optional<Client> client = clientDAO.getClientById(clientId.get());
+    Optional<Client> client = clientDAO.getClientById(dslContext, clientId.get());
     if (!client.isPresent()) {
       throw new NotFoundException("Client not found.");
     }
 
-    clientDAO.deleteClient(client.get());
+    clientDAO.deleteClient(dslContext, client.get());
 
     return Response.noContent().build();
   }
 
   private ClientDetailResponse clientDetailResponseFromId(long clientId) {
-    Optional<Client> optionalClient = clientDAO.getClientById(clientId);
+    Optional<Client> optionalClient = clientDAO.getClientById(dslContext, clientId);
     if (!optionalClient.isPresent()) {
       throw new NotFoundException("Client not found.");
     }
@@ -194,7 +195,7 @@ public class ClientsResource {
   }
 
   private Client clientFromName(String clientName) {
-    Optional<Client> optionalClient = clientDAO.getClient(clientName);
+    Optional<Client> optionalClient = clientDAO.getClient(dslContext, clientName);
     if (!optionalClient.isPresent()) {
       throw new NotFoundException("Client not found.");
     }

--- a/server/src/main/java/keywhiz/service/resources/GroupsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/GroupsResource.java
@@ -94,7 +94,7 @@ public class GroupsResource {
 
   protected List<Group> listGroups(@Auth User user) {
     logger.info("User '{}' listing groups.", user);
-    Set<Group> groups = groupDAO.getGroups();
+    Set<Group> groups = groupDAO.getGroups(dslContext);
     return ImmutableList.copyOf(groups);
   }
 
@@ -118,11 +118,11 @@ public class GroupsResource {
   public Response createGroup(@Auth User user, @Valid CreateGroupRequest request) {
 
     logger.info("User '{}' creating group.", user);
-    if (groupDAO.getGroup(request.name).isPresent()) {
+    if (groupDAO.getGroup(dslContext, request.name).isPresent()) {
       throw new BadRequestException("Group already exists.");
     }
 
-    long groupId = groupDAO.createGroup(request.name, user.getName(),
+    long groupId = groupDAO.createGroup(dslContext, request.name, user.getName(),
         Optional.ofNullable(request.description));
     URI uri = UriBuilder.fromResource(GroupsResource.class).build(groupId);
     return Response
@@ -163,17 +163,17 @@ public class GroupsResource {
   public Response deleteGroup(@Auth User user, @PathParam("groupId") LongParam groupId) {
     logger.info("User '{}' deleting group id={}.", user, groupId);
 
-    Optional<Group> group = groupDAO.getGroupById(groupId.get());
+    Optional<Group> group = groupDAO.getGroupById(dslContext, groupId.get());
     if (!group.isPresent()) {
       throw new NotFoundException("Group not found.");
     }
 
-    groupDAO.deleteGroup(group.get());
+    groupDAO.deleteGroup(dslContext, group.get());
     return Response.noContent().build();
   }
 
   private GroupDetailResponse groupDetailResponseFromId(long groupId) {
-    Optional<Group> optionalGroup = groupDAO.getGroupById(groupId);
+    Optional<Group> optionalGroup = groupDAO.getGroupById(dslContext, groupId);
     if (!optionalGroup.isPresent()) {
       throw new NotFoundException("Group not found.");
     }
@@ -187,7 +187,7 @@ public class GroupsResource {
   }
 
   private Group groupFromName(String name) {
-    Optional<Group> optionalGroup = groupDAO.getGroup(name);
+    Optional<Group> optionalGroup = groupDAO.getGroup(dslContext, name);
     if (!optionalGroup.isPresent()) {
       throw new NotFoundException("Group not found.");
     }

--- a/server/src/main/java/keywhiz/service/resources/GroupsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/GroupsResource.java
@@ -47,6 +47,7 @@ import keywhiz.api.model.SanitizedSecret;
 import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.GroupDAO;
+import org.jooq.DSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,11 +61,14 @@ import org.slf4j.LoggerFactory;
 @Produces(MediaType.APPLICATION_JSON)
 public class GroupsResource {
   private static final Logger logger = LoggerFactory.getLogger(GroupsResource.class);
+
+  private final DSLContext dslContext;
   private final AclDAO aclDAO;
   private final GroupDAO groupDAO;
 
   @Inject
-  public GroupsResource(AclDAO aclDAO, GroupDAO groupDAO) {
+  public GroupsResource(DSLContext dslContext, AclDAO aclDAO, GroupDAO groupDAO) {
+    this.dslContext = dslContext;
     this.aclDAO = aclDAO;
     this.groupDAO = groupDAO;
   }
@@ -176,8 +180,8 @@ public class GroupsResource {
 
     Group group = optionalGroup.get();
     ImmutableList<SanitizedSecret> secrets =
-        ImmutableList.copyOf(aclDAO.getSanitizedSecretsFor(group));
-    ImmutableList<Client> clients = ImmutableList.copyOf(aclDAO.getClientsFor(group));
+        ImmutableList.copyOf(aclDAO.getSanitizedSecretsFor(dslContext, group));
+    ImmutableList<Client> clients = ImmutableList.copyOf(aclDAO.getClientsFor(dslContext, group));
 
     return GroupDetailResponse.fromGroup(group, secrets, clients);
   }

--- a/server/src/main/java/keywhiz/service/resources/MembershipResource.java
+++ b/server/src/main/java/keywhiz/service/resources/MembershipResource.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
+import org.jooq.DSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,10 +43,12 @@ import org.slf4j.LoggerFactory;
 public class MembershipResource {
   private static final Logger logger = LoggerFactory.getLogger(MembershipResource.class);
 
+  private final DSLContext dslContext;
   private final AclDAO aclDAO;
 
   @Inject
-  public MembershipResource(AclDAO aclDAO) {
+  public MembershipResource(DSLContext dslContext, AclDAO aclDAO) {
+    this.dslContext = dslContext;
     this.aclDAO = aclDAO;
   }
 
@@ -71,7 +74,7 @@ public class MembershipResource {
     logger.info("User '{}' allowing groupId {} access to secretId {}", user, groupId, secretId);
 
     try {
-      aclDAO.findAndAllowAccess(secretId.get(), groupId.get());
+      aclDAO.findAndAllowAccess(dslContext, secretId.get(), groupId.get());
     } catch (IllegalStateException e) {
       throw new NotFoundException();
     }
@@ -101,7 +104,7 @@ public class MembershipResource {
     logger.info("User '{}' disallowing groupId {} access to secretId {}", user, groupId, secretId);
 
     try {
-      aclDAO.findAndRevokeAccess(secretId.get(), groupId.get());
+      aclDAO.findAndRevokeAccess(dslContext, secretId.get(), groupId.get());
     } catch (IllegalStateException e) {
       throw new NotFoundException();
     }
@@ -130,7 +133,7 @@ public class MembershipResource {
     logger.info("User {} enrolling clientId {} in groupId {}.", user.getName(), clientId, groupId);
 
     try {
-      aclDAO.findAndEnrollClient(clientId.get(), groupId.get());
+      aclDAO.findAndEnrollClient(dslContext, clientId.get(), groupId.get());
     } catch (IllegalStateException e) {
       throw new NotFoundException();
     }
@@ -158,7 +161,7 @@ public class MembershipResource {
     logger.info("User {} evicting clientId {} from groupId {}.", user.getName(), clientId, groupId);
 
     try {
-      aclDAO.findAndEvictClient(clientId.get(), groupId.get());
+      aclDAO.findAndEvictClient(dslContext, clientId.get(), groupId.get());
     } catch (IllegalStateException e) {
       throw new NotFoundException();
     }

--- a/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
@@ -38,6 +38,7 @@ import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.ClientDAO;
 import keywhiz.service.daos.SecretController;
 import org.hibernate.validator.constraints.NotEmpty;
+import org.jooq.DSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,13 +55,15 @@ import static keywhiz.api.model.Secret.splitNameAndVersion;
 public class SecretDeliveryResource {
   private final Logger logger = LoggerFactory.getLogger(SecretDeliveryResource.class);
   private final SecretController secretController;
+  private final DSLContext dslContext;
   private final AclDAO aclDAO;
   private final ClientDAO clientDAO;
 
   @Inject
   public SecretDeliveryResource(@Readonly SecretController secretController,
-      @Readonly AclDAO aclDAO, @Readonly ClientDAO clientDAO) {
+      @Readonly DSLContext dslContext, AclDAO aclDAO, @Readonly ClientDAO clientDAO) {
     this.secretController = secretController;
+    this.dslContext = dslContext;
     this.aclDAO = aclDAO;
     this.clientDAO = clientDAO;
   }
@@ -88,7 +91,7 @@ public class SecretDeliveryResource {
     String name = parts[0];
     String version = parts[1];
 
-    Optional<SanitizedSecret> sanitizedSecret = aclDAO.getSanitizedSecretFor(client, name, version);
+    Optional<SanitizedSecret> sanitizedSecret = aclDAO.getSanitizedSecretFor(dslContext, client, name, version);
     Optional<Secret> secret = secretController.getSecretByNameAndVersion(name, version);
 
     if (!sanitizedSecret.isPresent()) {

--- a/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
@@ -61,7 +61,7 @@ public class SecretDeliveryResource {
 
   @Inject
   public SecretDeliveryResource(@Readonly SecretController secretController,
-      @Readonly DSLContext dslContext, AclDAO aclDAO, @Readonly ClientDAO clientDAO) {
+      @Readonly DSLContext dslContext, AclDAO aclDAO, ClientDAO clientDAO) {
     this.secretController = secretController;
     this.dslContext = dslContext;
     this.aclDAO = aclDAO;
@@ -95,7 +95,7 @@ public class SecretDeliveryResource {
     Optional<Secret> secret = secretController.getSecretByNameAndVersion(name, version);
 
     if (!sanitizedSecret.isPresent()) {
-      boolean clientExists = clientDAO.getClient(client.getName()).isPresent();
+      boolean clientExists = clientDAO.getClient(dslContext, client.getName()).isPresent();
       boolean secretExists = secret.isPresent();
 
       if (clientExists && secretExists) {

--- a/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
@@ -27,6 +27,7 @@ import keywhiz.api.SecretDeliveryResponse;
 import keywhiz.api.model.Client;
 import keywhiz.service.config.Readonly;
 import keywhiz.service.daos.AclDAO;
+import org.jooq.DSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,10 +42,12 @@ import static java.util.stream.Collectors.toList;
 @Produces(MediaType.APPLICATION_JSON)
 public class SecretsDeliveryResource {
   private final Logger logger = LoggerFactory.getLogger(SecretsDeliveryResource.class);
+  private final DSLContext dslContext;
   private final AclDAO aclDAO;
 
   @Inject
-  public SecretsDeliveryResource(@Readonly AclDAO aclDAO) {
+  public SecretsDeliveryResource(@Readonly DSLContext dslContext, AclDAO aclDAO) {
+    this.dslContext = dslContext;
     this.aclDAO = aclDAO;
   }
 
@@ -56,7 +59,7 @@ public class SecretsDeliveryResource {
   @GET
   public List<SecretDeliveryResponse> getSecrets(@Auth Client client) {
     logger.info("Client {} listed available secrets.", client.getName());
-    return aclDAO.getSanitizedSecretsFor(client).stream()
+    return aclDAO.getSanitizedSecretsFor(dslContext, client).stream()
         .map(SecretDeliveryResponse::fromSanitizedSecret)
         .collect(toList());
   }

--- a/server/src/main/java/keywhiz/service/resources/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretsResource.java
@@ -50,6 +50,7 @@ import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.SecretController;
 import keywhiz.service.daos.SecretSeriesDAO;
 import keywhiz.service.exceptions.ConflictException;
+import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,15 +69,17 @@ public class SecretsResource {
   private static final Logger logger = LoggerFactory.getLogger(SecretsResource.class);
 
   private final SecretController secretController;
+  private final DSLContext dslContext;
   private final AclDAO aclDAO;
   private final SecretSeriesDAO secretSeriesDAO;
 
   @Inject
-  public SecretsResource(SecretController secretController, AclDAO aclDAO,
+  public SecretsResource(SecretController secretController, DSLContext dslContext, AclDAO aclDAO,
       SecretSeriesDAO secretSeriesDAO) {
     this.secretController = secretController;
     this.aclDAO = aclDAO;
     this.secretSeriesDAO = secretSeriesDAO;
+    this.dslContext = dslContext;
   }
 
   /**
@@ -237,8 +240,8 @@ public class SecretsResource {
 
     // TODO(justin): API change needed to return all versions.
     Secret secret = secrets.get(0);
-    ImmutableList<Group> groups = ImmutableList.copyOf(aclDAO.getGroupsFor(secret));
-    ImmutableList<Client> clients = ImmutableList.copyOf(aclDAO.getClientsFor(secret));
+    ImmutableList<Group> groups = ImmutableList.copyOf(aclDAO.getGroupsFor(dslContext, secret));
+    ImmutableList<Client> clients = ImmutableList.copyOf(aclDAO.getClientsFor(dslContext, secret));
     return SecretDetailResponse.fromSecret(secret, groups, clients);
   }
 

--- a/server/src/main/java/keywhiz/service/resources/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretsResource.java
@@ -228,7 +228,7 @@ public class SecretsResource {
       throw new NotFoundException("Secret not found.");
     }
 
-    secretSeriesDAO.deleteSecretSeriesById(secretId.get());
+    secretSeriesDAO.deleteSecretSeriesById(dslContext, secretId.get());
     return Response.noContent().build();
   }
 

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -62,12 +62,12 @@ public class AclDAOTest {
     jooqContext.delete(SECRETS).execute();
     jooqContext.delete(SECRETS_CONTENT).execute();
 
-    clientDAO = new ClientDAO(jooqContext);
-    long id = clientDAO.createClient("client1", "creator", Optional.empty());
-    client1 = clientDAO.getClientById(id).get();
+    clientDAO = new ClientDAO();
+    long id = clientDAO.createClient(jooqContext, "client1", "creator", Optional.empty());
+    client1 = clientDAO.getClientById(jooqContext, id).get();
 
-    id = clientDAO.createClient("client2", "creator", Optional.empty());
-    client2 = clientDAO.getClientById(id).get();
+    id = clientDAO.createClient(jooqContext, "client2", "creator", Optional.empty());
+    client2 = clientDAO.getClientById(jooqContext, id).get();
 
     groupDAO = new GroupDAO(jooqContext);
     id = groupDAO.createGroup("group1", "creator", Optional.empty());
@@ -86,7 +86,7 @@ public class AclDAOTest {
     secret1 = secretFixtures.createSecret("secret1", "c2VjcmV0MQ==", VersionGenerator.now().toHex());
     secret2 = secretFixtures.createSecret("secret2", "c2VjcmV0Mg==");
 
-    aclDAO = new AclDAO(objectMapper);
+    aclDAO = new AclDAO(objectMapper, clientDAO);
   }
 
   @Test
@@ -149,7 +149,7 @@ public class AclDAOTest {
     groupDAO.deleteGroup(group1);
     assertThat(membershipsTableSize()).isEqualTo(before - 1);
 
-    clientDAO.deleteClient(client2);
+    clientDAO.deleteClient(jooqContext, client2);
     assertThat(membershipsTableSize()).isEqualTo(before - 2);
   }
 

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -69,15 +69,15 @@ public class AclDAOTest {
     id = clientDAO.createClient(jooqContext, "client2", "creator", Optional.empty());
     client2 = clientDAO.getClientById(jooqContext, id).get();
 
-    groupDAO = new GroupDAO(jooqContext);
-    id = groupDAO.createGroup("group1", "creator", Optional.empty());
-    group1 = groupDAO.getGroupById(id).get();
+    groupDAO = new GroupDAO();
+    id = groupDAO.createGroup(jooqContext, "group1", "creator", Optional.empty());
+    group1 = groupDAO.getGroupById(jooqContext, id).get();
 
-    id = groupDAO.createGroup("group2", "creator", Optional.empty());
-    group2 = groupDAO.getGroupById(id).get();
+    id = groupDAO.createGroup(jooqContext, "group2", "creator", Optional.empty());
+    group2 = groupDAO.getGroupById(jooqContext, id).get();
 
-    id = groupDAO.createGroup("group3", "creator", Optional.empty());
-    group3 = groupDAO.getGroupById(id).get();
+    id = groupDAO.createGroup(jooqContext, "group3", "creator", Optional.empty());
+    group3 = groupDAO.getGroupById(jooqContext, id).get();
 
     secretSeriesDAO = new SecretSeriesDAO(jooqContext, objectMapper);
 
@@ -86,7 +86,7 @@ public class AclDAOTest {
     secret1 = secretFixtures.createSecret("secret1", "c2VjcmV0MQ==", VersionGenerator.now().toHex());
     secret2 = secretFixtures.createSecret("secret2", "c2VjcmV0Mg==");
 
-    aclDAO = new AclDAO(objectMapper, clientDAO);
+    aclDAO = new AclDAO(objectMapper, clientDAO, groupDAO);
   }
 
   @Test
@@ -114,7 +114,7 @@ public class AclDAOTest {
     aclDAO.allowAccess(jooqContext, secret2.getId(), group2.getId());
     int before = accessGrantsTableSize();
 
-    groupDAO.deleteGroup(group1);
+    groupDAO.deleteGroup(jooqContext, group1);
     assertThat(accessGrantsTableSize()).isEqualTo(before - 1);
 
     secretSeriesDAO.deleteSecretSeriesById(secret2.getId());
@@ -146,7 +146,7 @@ public class AclDAOTest {
     aclDAO.enrollClient(jooqContext, client2.getId(), group2.getId());
     int before = membershipsTableSize();
 
-    groupDAO.deleteGroup(group1);
+    groupDAO.deleteGroup(jooqContext, group1);
     assertThat(membershipsTableSize()).isEqualTo(before - 1);
 
     clientDAO.deleteClient(jooqContext, client2);

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -81,12 +81,14 @@ public class AclDAOTest {
 
     secretSeriesDAO = new SecretSeriesDAO(jooqContext, objectMapper);
 
-    secretDAO = new SecretDAO(jooqContext, objectMapper);
+    SecretContentDAO secretContentDAO = new SecretContentDAO(objectMapper);
+
+    secretDAO = new SecretDAO(jooqContext, objectMapper, secretContentDAO);
     SecretFixtures secretFixtures = SecretFixtures.using(secretDAO);
     secret1 = secretFixtures.createSecret("secret1", "c2VjcmV0MQ==", VersionGenerator.now().toHex());
     secret2 = secretFixtures.createSecret("secret2", "c2VjcmV0Mg==");
 
-    aclDAO = new AclDAO(objectMapper, clientDAO, groupDAO);
+    aclDAO = new AclDAO(objectMapper, clientDAO, groupDAO, secretContentDAO);
   }
 
   @Test

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -83,8 +83,8 @@ public class AclDAOTest {
 
     SecretContentDAO secretContentDAO = new SecretContentDAO(objectMapper);
 
-    secretDAO = new SecretDAO(jooqContext, objectMapper, secretContentDAO);
-    SecretFixtures secretFixtures = SecretFixtures.using(secretDAO);
+    secretDAO = new SecretDAO(objectMapper, secretContentDAO);
+    SecretFixtures secretFixtures = SecretFixtures.using(jooqContext, secretDAO);
     secret1 = secretFixtures.createSecret("secret1", "c2VjcmV0MQ==", VersionGenerator.now().toHex());
     secret2 = secretFixtures.createSecret("secret2", "c2VjcmV0Mg==");
 

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -79,16 +79,16 @@ public class AclDAOTest {
     id = groupDAO.createGroup(jooqContext, "group3", "creator", Optional.empty());
     group3 = groupDAO.getGroupById(jooqContext, id).get();
 
-    secretSeriesDAO = new SecretSeriesDAO(jooqContext, objectMapper);
+    secretSeriesDAO = new SecretSeriesDAO(objectMapper);
 
     SecretContentDAO secretContentDAO = new SecretContentDAO(objectMapper);
 
-    secretDAO = new SecretDAO(objectMapper, secretContentDAO);
+    secretDAO = new SecretDAO(secretContentDAO, secretSeriesDAO);
     SecretFixtures secretFixtures = SecretFixtures.using(jooqContext, secretDAO);
     secret1 = secretFixtures.createSecret("secret1", "c2VjcmV0MQ==", VersionGenerator.now().toHex());
     secret2 = secretFixtures.createSecret("secret2", "c2VjcmV0Mg==");
 
-    aclDAO = new AclDAO(objectMapper, clientDAO, groupDAO, secretContentDAO);
+    aclDAO = new AclDAO(objectMapper, clientDAO, groupDAO, secretContentDAO, secretSeriesDAO);
   }
 
   @Test
@@ -119,7 +119,7 @@ public class AclDAOTest {
     groupDAO.deleteGroup(jooqContext, group1);
     assertThat(accessGrantsTableSize()).isEqualTo(before - 1);
 
-    secretSeriesDAO.deleteSecretSeriesById(secret2.getId());
+    secretSeriesDAO.deleteSecretSeriesById(jooqContext, secret2.getId());
     assertThat(accessGrantsTableSize()).isEqualTo(before - 2);
   }
 
@@ -257,7 +257,8 @@ public class AclDAOTest {
 
   @Test
   public void getSecretSeriesFor() throws Exception {
-    SecretSeries secretSeries1 = secretSeriesDAO.getSecretSeriesById(secret1.getId()).get();
+    SecretSeries secretSeries1 = secretSeriesDAO.getSecretSeriesById(jooqContext,
+        secret1.getId()).get();
 
     aclDAO.enrollClient(jooqContext, client2.getId(), group1.getId());
     aclDAO.enrollClient(jooqContext, client2.getId(), group3.getId());

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -107,7 +107,7 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.METADATA, objectMapper.writeValueAsString(secret2.content().metadata()))
         .execute();
 
-    secretDAO = new SecretDAO(objectMapper, new SecretContentDAO(objectMapper));
+    secretDAO = new SecretDAO(new SecretContentDAO(objectMapper), new SecretSeriesDAO(objectMapper));
 
     // Secrets created in the DB will have different id, updatedAt values.
     secret1 = secretDAO.getSecretByNameAndVersion(dslContext, secret1.series().getName(),

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -105,8 +105,7 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.METADATA, objectMapper.writeValueAsString(secret2.content().metadata()))
         .execute();
 
-    secretDAO = new SecretDAO(dslContext, new SecretContentDAO(dslContext, objectMapper),
-        new SecretSeriesDAO(dslContext, objectMapper));
+    secretDAO = new SecretDAO(dslContext, objectMapper);
 
     // Secrets created in the DB will have different id, updatedAt values.
     secret1 = secretDAO.getSecretByNameAndVersion(

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -51,7 +51,8 @@ public class SecretDAOTest {
   String content = "c2VjcmV0MQ==";
   String encryptedContent = cryptographer.encryptionKeyDerivedFrom(series1.getName()).encrypt(
       content);
-  SecretContent content1 = SecretContent.of(101, 1, encryptedContent, version, date, "creator", date, "updater", emptyMetadata);
+  SecretContent content1 = SecretContent.of(101, 1, encryptedContent, version, date, "creator",
+      date, "updater", emptyMetadata);
   SecretSeriesAndContent secret1 = SecretSeriesAndContent.of(series1, content1);
 
   SecretSeries series2 = new SecretSeries(2, "secret2", "desc2", date, "creator", date, "updater", null, null);
@@ -59,11 +60,12 @@ public class SecretDAOTest {
   SecretSeriesAndContent secret2 = SecretSeriesAndContent.of(series2, content2);
 
   SecretDAO secretDAO;
+  DSLContext dslContext;
 
   @Before
   public void setUp() throws Exception {
     ObjectMapper objectMapper = new ObjectMapper();
-    DSLContext dslContext = testDBRule.jooqContext();
+    dslContext = testDBRule.jooqContext();
 
     dslContext.delete(SECRETS).execute();
 
@@ -105,13 +107,13 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.METADATA, objectMapper.writeValueAsString(secret2.content().metadata()))
         .execute();
 
-    secretDAO = new SecretDAO(dslContext, objectMapper, new SecretContentDAO(objectMapper));
+    secretDAO = new SecretDAO(objectMapper, new SecretContentDAO(objectMapper));
 
     // Secrets created in the DB will have different id, updatedAt values.
-    secret1 = secretDAO.getSecretByNameAndVersion(
-        secret1.series().getName(), secret1.content().version().get()).get();
-    secret2 = secretDAO.getSecretByNameAndVersion(
-        secret2.series().getName(), secret2.content().version().get()).get();
+    secret1 = secretDAO.getSecretByNameAndVersion(dslContext, secret1.series().getName(),
+        secret1.content().version().get()).get();
+    secret2 = secretDAO.getSecretByNameAndVersion(dslContext, secret2.series().getName(),
+        secret2.content().version().get()).get();
   }
 
   @Test
@@ -123,16 +125,17 @@ public class SecretDAOTest {
     String content = "c2VjcmV0MQ==";
     String encryptedContent = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
     String version = VersionGenerator.now().toHex();
-    long newId = secretDAO.createSecret(name, encryptedContent, version, "creator",
+    long newId = secretDAO.createSecret(dslContext, name, encryptedContent, version, "creator",
         ImmutableMap.of(), "", null, ImmutableMap.of());
-    SecretSeriesAndContent newSecret = secretDAO.getSecretByIdAndVersion(newId, version).get();
+    SecretSeriesAndContent newSecret = secretDAO.getSecretByIdAndVersion(dslContext, newId,
+        version).get();
 
     assertThat(tableSize(SECRETS)).isEqualTo(secretsBefore + 1);
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore + 1);
 
-    newSecret = secretDAO.getSecretByNameAndVersion(
-        newSecret.series().getName(), newSecret.content().version().orElse("")).get();
-    assertThat(secretDAO.getSecrets()).containsOnly(secret1, secret2, newSecret);
+    newSecret = secretDAO.getSecretByNameAndVersion(dslContext, newSecret.series().getName(),
+        newSecret.content().version().orElse("")).get();
+    assertThat(secretDAO.getSecrets(dslContext)).containsOnly(secret1, secret2, newSecret);
   }
 
   @Test
@@ -144,30 +147,32 @@ public class SecretDAOTest {
     String content = "c2VjcmV0MQ==";
     String encryptedContent1 = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
     String version = VersionGenerator.fromLong(1234).toHex();
-    long id = secretDAO.createSecret(name, encryptedContent1, version, "creator", ImmutableMap.of(),
-        "", null, ImmutableMap.of());
-    SecretSeriesAndContent newSecret1 = secretDAO.getSecretByIdAndVersion(id, version).get();
+    long id = secretDAO.createSecret(dslContext, name, encryptedContent1, version, "creator",
+        ImmutableMap.of(), "", null, ImmutableMap.of());
+    SecretSeriesAndContent newSecret1 = secretDAO.getSecretByIdAndVersion(dslContext, id,
+        version).get();
 
     content = "amFja2RvcnNrZXkK";
     String encryptedContent2 = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
     version = VersionGenerator.fromLong(4321).toHex();
-    id = secretDAO.createSecret(name, encryptedContent2, version, "creator", ImmutableMap.of(), "",
-        null, ImmutableMap.of());
-    SecretSeriesAndContent newSecret2 = secretDAO.getSecretByIdAndVersion(id, version).get();
+    id = secretDAO.createSecret(dslContext, name, encryptedContent2, version, "creator",
+        ImmutableMap.of(), "", null, ImmutableMap.of());
+    SecretSeriesAndContent newSecret2 = secretDAO.getSecretByIdAndVersion(dslContext, id,
+        version).get();
 
     // Only one new secrets entry should be created - there should be 2 secrets_content entries though
     assertThat(tableSize(SECRETS)).isEqualTo(secretsBefore + 1);
 
     assertThat(newSecret1.content().encryptedContent()).isEqualTo(encryptedContent1);
     assertThat(newSecret2.content().encryptedContent()).isEqualTo(encryptedContent2);
-    assertThat(secretDAO.getSecrets()).containsOnly(secret1, secret2, newSecret1, newSecret2);
+    assertThat(secretDAO.getSecrets(dslContext)).containsOnly(secret1, secret2, newSecret1, newSecret2);
 
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore + 2);
   }
 
   @Test
   public void getSecretByNameAndVersion() {
-    SecretSeriesAndContent seriesAndContent = secretDAO.getSecretByNameAndVersion(
+    SecretSeriesAndContent seriesAndContent = secretDAO.getSecretByNameAndVersion(dslContext,
         secret1.series().getName(), secret1.content().version().orElse(""))
         .orElseThrow(RuntimeException::new);
     assertThat(seriesAndContent).isEqualTo(secret1);
@@ -176,7 +181,7 @@ public class SecretDAOTest {
   @Test
   public void getSecretByNameAndVersionWithoutVersion() {
     SecretSeriesAndContent seriesAndContent =
-        secretDAO.getSecretByNameAndVersion(secret2.series().getName(), "")
+        secretDAO.getSecretByNameAndVersion(dslContext, secret2.series().getName(), "")
         .orElseThrow(RuntimeException::new);
     assertThat(seriesAndContent).isEqualTo(secret2);
   }
@@ -187,16 +192,19 @@ public class SecretDAOTest {
     String name = secret1.series().getName();
     String content = "bmV3ZXJTZWNyZXQy";
     String encryptedContent = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
-    long newId = secretDAO.createSecret(name, encryptedContent, futureStamp, "creator", ImmutableMap.of(), "desc", null, null);
-    SecretSeriesAndContent newerSecret = secretDAO.getSecretByIdAndVersion(newId, futureStamp)
+    long newId = secretDAO.createSecret(dslContext, name, encryptedContent, futureStamp, "creator",
+        ImmutableMap.of(), "desc", null, null);
+    SecretSeriesAndContent newerSecret = secretDAO.getSecretByIdAndVersion(dslContext, newId,
+        futureStamp)
         .orElseThrow(RuntimeException::new);
 
-    SecretSeriesAndContent seriesAndContent = secretDAO.getSecretByNameAndVersion(
+    SecretSeriesAndContent seriesAndContent = secretDAO.getSecretByNameAndVersion(dslContext,
         secret1.series().getName(), secret1.content().version().orElse(""))
         .orElseThrow(RuntimeException::new);
     assertThat(seriesAndContent).isEqualTo(secret1);
 
-    seriesAndContent = secretDAO.getSecretByNameAndVersion(secret1.series().getName(), futureStamp)
+    seriesAndContent = secretDAO.getSecretByNameAndVersion(dslContext, secret1.series().getName(),
+        futureStamp)
         .orElseThrow(RuntimeException::new);
     assertThat(seriesAndContent).isEqualTo(newerSecret);
   }
@@ -204,7 +212,7 @@ public class SecretDAOTest {
   @Test
   public void getSecretByIdAndVersionWithoutVersion() {
     SecretSeriesAndContent seriesAndContent =
-        secretDAO.getSecretByIdAndVersion(secret2.series().getId(), "")
+        secretDAO.getSecretByIdAndVersion(dslContext, secret2.series().getId(), "")
         .orElseThrow(RuntimeException::new);
     assertThat(seriesAndContent).isEqualTo(secret2);
   }
@@ -215,105 +223,116 @@ public class SecretDAOTest {
     String name = secret1.series().getName();
     String content = "bmV3ZXJTZWNyZXQy";
     String encryptedContent = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
-    secretDAO.createSecret(name, encryptedContent, futureStamp, "creator", ImmutableMap.of(), "desc", null, null);
-    SecretSeriesAndContent newerSecret = secretDAO.getSecretByNameAndVersion(name, futureStamp)
+    secretDAO.createSecret(dslContext, name, encryptedContent, futureStamp, "creator",
+        ImmutableMap.of(), "desc", null, null);
+    SecretSeriesAndContent newerSecret = secretDAO.getSecretByNameAndVersion(dslContext, name,
+        futureStamp)
         .orElseThrow(RuntimeException::new);
 
-    SecretSeriesAndContent seriesAndContent = secretDAO.getSecretByIdAndVersion(
+    SecretSeriesAndContent seriesAndContent = secretDAO.getSecretByIdAndVersion(dslContext,
         secret1.series().getId(), secret1.content().version().orElse(""))
         .orElseThrow(RuntimeException::new);
     assertThat(seriesAndContent).isEqualTo(secret1);
 
-    seriesAndContent = secretDAO.getSecretByIdAndVersion(
-        secret1.series().getId(), newerSecret.content().version().orElse(""))
+    seriesAndContent = secretDAO.getSecretByIdAndVersion(dslContext, secret1.series().getId(),
+        newerSecret.content().version().orElse(""))
         .orElseThrow(RuntimeException::new);
     assertThat(seriesAndContent).isEqualTo(newerSecret);
   }
 
   @Test
   public void getSecretById() {
-    SecretSeriesAndContent expected = secretDAO.getSecretByNameAndVersion(
+    SecretSeriesAndContent expected = secretDAO.getSecretByNameAndVersion(dslContext,
         secret1.series().getName(), secret1.content().version().orElse(""))
         .orElseThrow(RuntimeException::new);
-    List<SecretSeriesAndContent> actual = secretDAO.getSecretsById(expected.series().getId());
+    List<SecretSeriesAndContent> actual = secretDAO.getSecretsById(dslContext,
+        expected.series().getId());
     assertThat(actual).containsExactly(expected);
   }
 
   @Test
   public void getNonExistentSecret() {
-    assertThat(secretDAO.getSecretByNameAndVersion("non-existent", "").isPresent()).isFalse();
-    assertThat(secretDAO.getSecretsById(-1231)).isEmpty();
+    assertThat(secretDAO.getSecretByNameAndVersion(dslContext, "non-existent", "")
+        .isPresent()).isFalse();
+    assertThat(secretDAO.getSecretsById(dslContext, -1231)).isEmpty();
   }
 
   @Test
   public void getSecrets() {
-    assertThat(secretDAO.getSecrets()).containsOnly(secret1, secret2);
+    assertThat(secretDAO.getSecrets(dslContext)).containsOnly(secret1, secret2);
   }
 
   @Test
   public void deleteSecretsByName() {
-    secretDAO.createSecret("toBeDeleted_deleteSecretsByName", "encryptedShhh", "first", "creator",
-        ImmutableMap.of(), "", null, null);
+    secretDAO.createSecret(dslContext, "toBeDeleted_deleteSecretsByName", "encryptedShhh", "first",
+        "creator", ImmutableMap.of(), "", null, null);
 
     int secretsBefore = tableSize(SECRETS);
     int secretContentsBefore = tableSize(SECRETS_CONTENT);
 
-    secretDAO.deleteSecretsByName("toBeDeleted_deleteSecretsByName");
+    secretDAO.deleteSecretsByName(dslContext, "toBeDeleted_deleteSecretsByName");
 
     assertThat(tableSize(SECRETS)).isEqualTo(secretsBefore - 1);
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore - 1);
     Optional<SecretSeriesAndContent> missingSecret =
-        secretDAO.getSecretByNameAndVersion("toBeDeleted_deleteSecretsByName", "first");
+        secretDAO.getSecretByNameAndVersion(dslContext, "toBeDeleted_deleteSecretsByName", "first");
     assertThat(missingSecret.isPresent()).isFalse();
   }
 
   @Test
   public void deleteSecretByNameAndVersion() {
-    secretDAO.createSecret("shadow_deleteSecretByNameAndVersion", "encrypted1", "no1", "creator",
-        ImmutableMap.of(), "desc", null, null);
-    secretDAO.createSecret("shadow_deleteSecretByNameAndVersion", "encrypted2", "no2", "creator",
-        ImmutableMap.of(), "desc", null, null);
+    secretDAO.createSecret(dslContext, "shadow_deleteSecretByNameAndVersion", "encrypted1", "no1",
+        "creator", ImmutableMap.of(), "desc", null, null);
+    secretDAO.createSecret(dslContext, "shadow_deleteSecretByNameAndVersion", "encrypted2", "no2",
+        "creator", ImmutableMap.of(), "desc", null, null);
     int secretsBefore = tableSize(SECRETS);
     int secretContentsBefore = tableSize(SECRETS_CONTENT);
 
-    secretDAO.deleteSecretByNameAndVersion("shadow_deleteSecretByNameAndVersion", "no1");
+    secretDAO.deleteSecretByNameAndVersion(dslContext, "shadow_deleteSecretByNameAndVersion", "no1");
 
     assertThat(tableSize(SECRETS)).isEqualTo(secretsBefore);
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore - 1);
     Optional<SecretSeriesAndContent> missingSecret =
-        secretDAO.getSecretByNameAndVersion("shadow_deleteSecretByNameAndVersion", "no1");
+        secretDAO.getSecretByNameAndVersion(dslContext, "shadow_deleteSecretByNameAndVersion",
+            "no1");
     assertThat(missingSecret.isPresent()).isFalse();
   }
 
   @Test
   public void deleteSecretSeriesWhenEmpty() {
-    secretDAO.createSecret("toBeDeleted_deleteSecretSeriesWhenEmpty", "encryptedOvaltine", "v22",
-        "creator", ImmutableMap.of(), "desc", null, null);
+    secretDAO.createSecret(dslContext, "toBeDeleted_deleteSecretSeriesWhenEmpty",
+        "encryptedOvaltine", "v22", "creator", ImmutableMap.of(), "desc", null, null);
 
     int secretsBefore = tableSize(SECRETS);
     int secretContentsBefore = tableSize(SECRETS_CONTENT);
 
-    secretDAO.deleteSecretByNameAndVersion("toBeDeleted_deleteSecretSeriesWhenEmpty", "v22");
+    secretDAO.deleteSecretByNameAndVersion(dslContext, "toBeDeleted_deleteSecretSeriesWhenEmpty",
+        "v22");
 
     assertThat(tableSize(SECRETS)).isEqualTo(secretsBefore - 1);
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore - 1);
     Optional<SecretSeriesAndContent> missingSecret =
-        secretDAO.getSecretByNameAndVersion("toBeDeleted_deleteSecretSeriesWhenEmpty", "v22");
+        secretDAO.getSecretByNameAndVersion(dslContext, "toBeDeleted_deleteSecretSeriesWhenEmpty",
+            "v22");
     assertThat(missingSecret.isPresent()).isFalse();
   }
 
   @Test(expected = DataAccessException.class)
   public void willNotCreateDuplicateVersionedSecret() throws Exception {
     ImmutableMap<String, String> emptyMap = ImmutableMap.of();
-    secretDAO.createSecret("secret1", "encrypted1", version, "creator", emptyMap, "", null, emptyMap);
-    secretDAO.createSecret("secret1", "encrypted1", version, "creator", emptyMap, "", null, emptyMap);
+    secretDAO.createSecret(dslContext, "secret1", "encrypted1", version, "creator", emptyMap, "",
+        null, emptyMap);
+    secretDAO.createSecret(dslContext, "secret1", "encrypted1", version, "creator", emptyMap, "",
+        null, emptyMap);
   }
 
   @Test(expected = DataAccessException.class)
   public void willNotCreateDuplicateSecret() throws Exception {
     ImmutableMap<String, String> emptyMap = ImmutableMap.of();
-    secretDAO.createSecret("secret1", "encrypted1", "", "creator", emptyMap, "", null, emptyMap);
-    secretDAO.createSecret("secret1", "encrypted1", "", "creator", emptyMap, "", null, emptyMap);
+    secretDAO.createSecret(dslContext, "secret1", "encrypted1", "", "creator", emptyMap, "", null,
+        emptyMap);
+    secretDAO.createSecret(dslContext, "secret1", "encrypted1", "", "creator", emptyMap, "", null,
+        emptyMap);
   }
 
   private int tableSize(Table table) {

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -105,7 +105,7 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.METADATA, objectMapper.writeValueAsString(secret2.content().metadata()))
         .execute();
 
-    secretDAO = new SecretDAO(dslContext, objectMapper);
+    secretDAO = new SecretDAO(dslContext, objectMapper, new SecretContentDAO(objectMapper));
 
     // Secrets created in the DB will have different id, updatedAt values.
     secret1 = secretDAO.getSecretByNameAndVersion(

--- a/server/src/test/java/keywhiz/service/daos/UserDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/UserDAOTest.java
@@ -18,6 +18,7 @@ package keywhiz.service.daos;
 
 import java.time.OffsetDateTime;
 import keywhiz.TestDBRule;
+import org.jooq.DSLContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,11 +30,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class UserDAOTest {
   @Rule public final TestDBRule testDBRule = new TestDBRule();
 
+  DSLContext dslContext;
   UserDAO userDAO;
   String hashedPassword;
 
   @Before public void setUp() {
-    userDAO = new UserDAO(testDBRule.jooqContext());
+    dslContext = testDBRule.jooqContext();
+    userDAO = new UserDAO();
 
     hashedPassword = BCrypt.hashpw("password", BCrypt.gensalt());
 
@@ -47,13 +50,14 @@ public class UserDAOTest {
 
   @Test
   public void getExistingUser() {
-    String retrievedHash = userDAO.getHashedPassword("user").orElseThrow(RuntimeException::new);
+    String retrievedHash = userDAO.getHashedPassword(dslContext, "user")
+        .orElseThrow(RuntimeException::new);
     assertThat(retrievedHash).isEqualTo(hashedPassword);
   }
 
   @Test
   public void getNonexistentUser() {
-    assertThat(userDAO.getHashedPassword("non-user").isPresent()).isFalse();
+    assertThat(userDAO.getHashedPassword(dslContext, "non-user").isPresent()).isFalse();
   }
 
 }

--- a/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
+++ b/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
@@ -25,6 +25,7 @@ import keywhiz.api.model.Client;
 import keywhiz.auth.mutualssl.SimplePrincipal;
 import keywhiz.service.daos.ClientDAO;
 import org.glassfish.jersey.server.ContainerRequest;
+import org.jooq.DSLContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,15 +47,16 @@ public class ClientAuthFactoryTest {
 
   @Mock ContainerRequest request;
   @Mock SecurityContext securityContext;
+  @Mock DSLContext dslContext;
   @Mock ClientDAO clientDAO;
 
   ClientAuthFactory factory;
 
   @Before public void setUp() {
-    factory = new ClientAuthFactory(clientDAO);
+    factory = new ClientAuthFactory(dslContext, clientDAO);
 
     when(request.getSecurityContext()).thenReturn(securityContext);
-    when(clientDAO.getClient("principal")).thenReturn(Optional.of(client));
+    when(clientDAO.getClient(dslContext, "principal")).thenReturn(Optional.of(client));
   }
 
   @Test public void clientWhenClientPresent() {
@@ -76,7 +78,7 @@ public class ClientAuthFactoryTest {
         false /* disabled */, false);
 
     when(securityContext.getUserPrincipal()).thenReturn(SimplePrincipal.of("CN=disabled"));
-    when(clientDAO.getClient("disabled")).thenReturn(Optional.of(disabledClient));
+    when(clientDAO.getClient(dslContext, "disabled")).thenReturn(Optional.of(disabledClient));
 
     factory.provide(request);
   }
@@ -88,11 +90,11 @@ public class ClientAuthFactoryTest {
 
     // lookup doesn't find client
     when(securityContext.getUserPrincipal()).thenReturn(SimplePrincipal.of("CN=new-client"));
-    when(clientDAO.getClient("new-client")).thenReturn(Optional.empty());
+    when(clientDAO.getClient(dslContext, "new-client")).thenReturn(Optional.empty());
 
     // a new DB record is created
-    when(clientDAO.createClient(eq("new-client"), eq("automatic"), any())).thenReturn(2345L);
-    when(clientDAO.getClientById(2345L)).thenReturn(Optional.of(newClient));
+    when(clientDAO.createClient(eq(dslContext), eq("new-client"), eq("automatic"), any())).thenReturn(2345L);
+    when(clientDAO.getClientById(dslContext, 2345L)).thenReturn(Optional.of(newClient));
 
     assertThat(factory.provide(request)).isEqualTo(newClient);
   }

--- a/server/src/test/java/keywhiz/service/resources/AutomationClientResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationClientResourceTest.java
@@ -28,6 +28,7 @@ import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.ClientDAO;
+import org.jooq.DSLContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +42,7 @@ import static org.mockito.Mockito.when;
 public class AutomationClientResourceTest {
   @Rule public TestRule mockito = new MockitoJUnitRule(this);
 
+  @Mock DSLContext dslContext;
   @Mock ClientDAO clientDAO;
   @Mock AclDAO aclDAO;
   OffsetDateTime now = OffsetDateTime.now();
@@ -50,7 +52,7 @@ public class AutomationClientResourceTest {
   AutomationClientResource resource;
 
   @Before public void setUp() {
-    resource = new AutomationClientResource(clientDAO, aclDAO);
+    resource = new AutomationClientResource(dslContext, clientDAO, aclDAO);
   }
 
   @Test public void findClientByName() {
@@ -61,7 +63,7 @@ public class AutomationClientResourceTest {
         ImmutableList.of(firstGroup, secondGroup), ImmutableList.of());
 
     when(clientDAO.getClient("client")).thenReturn(Optional.of(client));
-    when(aclDAO.getGroupsFor(client)).thenReturn(ImmutableSet.of(firstGroup, secondGroup));
+    when(aclDAO.getGroupsFor(dslContext, client)).thenReturn(ImmutableSet.of(firstGroup, secondGroup));
 
     Response response = resource.findClient(automation, Optional.of("client"));
     assertThat(response.getEntity()).hasSameClassAs(expectedClient);
@@ -83,7 +85,7 @@ public class AutomationClientResourceTest {
     when(clientDAO.getClient("client")).thenReturn(Optional.empty());
     when(clientDAO.createClient("client", automation.getName(), Optional.empty())).thenReturn(543L);
     when(clientDAO.getClientById(543L)).thenReturn(Optional.of(client));
-    when(aclDAO.getGroupsFor(client)).thenReturn(ImmutableSet.of());
+    when(aclDAO.getGroupsFor(dslContext, client)).thenReturn(ImmutableSet.of());
 
     ClientDetailResponse response = ClientDetailResponse.fromClient(client, ImmutableList.of(),
         ImmutableList.of());

--- a/server/src/test/java/keywhiz/service/resources/AutomationClientResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationClientResourceTest.java
@@ -62,7 +62,7 @@ public class AutomationClientResourceTest {
     ClientDetailResponse expectedClient = ClientDetailResponse.fromClient(client,
         ImmutableList.of(firstGroup, secondGroup), ImmutableList.of());
 
-    when(clientDAO.getClient("client")).thenReturn(Optional.of(client));
+    when(clientDAO.getClient(dslContext, "client")).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(dslContext, client)).thenReturn(ImmutableSet.of(firstGroup, secondGroup));
 
     Response response = resource.findClient(automation, Optional.of("client"));
@@ -73,7 +73,7 @@ public class AutomationClientResourceTest {
 
   @Test(expected = NotFoundException.class)
   public void findClientByNameNotFound() {
-    when(clientDAO.getClient("client")).thenReturn(Optional.empty());
+    when(clientDAO.getClient(dslContext, "client")).thenReturn(Optional.empty());
     resource.findClient(automation, Optional.of("client"));
   }
 
@@ -82,9 +82,9 @@ public class AutomationClientResourceTest {
 
     CreateClientRequest request = new CreateClientRequest("client");
 
-    when(clientDAO.getClient("client")).thenReturn(Optional.empty());
-    when(clientDAO.createClient("client", automation.getName(), Optional.empty())).thenReturn(543L);
-    when(clientDAO.getClientById(543L)).thenReturn(Optional.of(client));
+    when(clientDAO.getClient(dslContext, "client")).thenReturn(Optional.empty());
+    when(clientDAO.createClient(dslContext, "client", automation.getName(), Optional.empty())).thenReturn(543L);
+    when(clientDAO.getClientById(dslContext, 543L)).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(dslContext, client)).thenReturn(ImmutableSet.of());
 
     ClientDetailResponse response = ClientDetailResponse.fromClient(client, ImmutableList.of(),
@@ -99,9 +99,9 @@ public class AutomationClientResourceTest {
 
     CreateClientRequest request = new CreateClientRequest("client");
 
-    when(clientDAO.getClient("client")).thenReturn(Optional.empty());
-    when(clientDAO.createClient("client", automation.getName(), Optional.empty())).thenReturn(543L);
-    when(clientDAO.getClientById(543L)).thenReturn(Optional.of(client));
+    when(clientDAO.getClient(dslContext, "client")).thenReturn(Optional.empty());
+    when(clientDAO.createClient(dslContext, "client", automation.getName(), Optional.empty())).thenReturn(543L);
+    when(clientDAO.getClientById(dslContext, 543L)).thenReturn(Optional.of(client));
 
     ClientDetailResponse response = ClientDetailResponse.fromClient(client, ImmutableList.of(),
         ImmutableList.of());

--- a/server/src/test/java/keywhiz/service/resources/AutomationGroupResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationGroupResourceTest.java
@@ -59,7 +59,7 @@ public class AutomationGroupResourceTest {
 
   @Test public void findGroupById() {
     Group group = new Group(50, "testGroup", "testing group", now, "automation client", now, "automation client");
-    when(groupDAO.getGroupById(50)).thenReturn(Optional.of(group));
+    when(groupDAO.getGroupById(dslContext, 50)).thenReturn(Optional.of(group));
     when(aclDAO.getClientsFor(dslContext, group)).thenReturn(ImmutableSet.of());
     when(aclDAO.getSanitizedSecretsFor(dslContext, group)).thenReturn(ImmutableSet.of());
 
@@ -71,7 +71,7 @@ public class AutomationGroupResourceTest {
 
   @Test public void findGroupByName() {
     Group group = new Group(50, "testGroup", "testing group", now, "automation client", now, "automation client");
-    when(groupDAO.getGroup("testGroup")).thenReturn(Optional.of(group));
+    when(groupDAO.getGroup(dslContext, "testGroup")).thenReturn(Optional.of(group));
     when(aclDAO.getClientsFor(dslContext, group)).thenReturn(ImmutableSet.of());
     when(aclDAO.getSanitizedSecretsFor(dslContext, group)).thenReturn(ImmutableSet.of());
 
@@ -90,7 +90,7 @@ public class AutomationGroupResourceTest {
     SanitizedSecret secondGroupSecret =
         SanitizedSecret.of(2, "name2", "v1", "desc", now, "test", now, "test", null, "", null);
 
-    when(groupDAO.getGroup("testGroup")).thenReturn(Optional.of(group));
+    when(groupDAO.getGroup(dslContext, "testGroup")).thenReturn(Optional.of(group));
     when(aclDAO.getClientsFor(dslContext, group)).thenReturn(ImmutableSet.of(groupClient));
     when(aclDAO.getSanitizedSecretsFor(dslContext, group))
         .thenReturn(ImmutableSet.of(firstGroupSecret, secondGroupSecret));
@@ -106,9 +106,9 @@ public class AutomationGroupResourceTest {
 
     CreateGroupRequest request = new CreateGroupRequest("testGroup", null);
 
-    when(groupDAO.getGroup("testGroup")).thenReturn(Optional.empty());
-    when(groupDAO.createGroup(group.getName(), automation.getName(), Optional.empty())).thenReturn(500L);
-    when(groupDAO.getGroupById(500L)).thenReturn(Optional.of(group));
+    when(groupDAO.getGroup(dslContext, "testGroup")).thenReturn(Optional.empty());
+    when(groupDAO.createGroup(dslContext, group.getName(), automation.getName(), Optional.empty())).thenReturn(500L);
+    when(groupDAO.getGroupById(dslContext, 500L)).thenReturn(Optional.of(group));
     Group responseGroup = resource.createGroup(automation, request);
 
     assertThat(responseGroup).isEqualTo(group);

--- a/server/src/test/java/keywhiz/service/resources/AutomationGroupResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationGroupResourceTest.java
@@ -30,6 +30,7 @@ import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.GroupDAO;
+import org.jooq.DSLContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.when;
 public class AutomationGroupResourceTest {
   @Rule public TestRule mockito = new MockitoJUnitRule(this);
 
+  @Mock DSLContext dslContext;
   @Mock GroupDAO groupDAO;
   @Mock AclDAO aclDAO;
   OffsetDateTime now = OffsetDateTime.now();
@@ -52,14 +54,14 @@ public class AutomationGroupResourceTest {
   AutomationGroupResource resource;
 
   @Before public void setUp() {
-    resource = new AutomationGroupResource(groupDAO, aclDAO);
+    resource = new AutomationGroupResource(dslContext, groupDAO, aclDAO);
   }
 
   @Test public void findGroupById() {
     Group group = new Group(50, "testGroup", "testing group", now, "automation client", now, "automation client");
     when(groupDAO.getGroupById(50)).thenReturn(Optional.of(group));
-    when(aclDAO.getClientsFor(group)).thenReturn(ImmutableSet.of());
-    when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of());
+    when(aclDAO.getClientsFor(dslContext, group)).thenReturn(ImmutableSet.of());
+    when(aclDAO.getSanitizedSecretsFor(dslContext, group)).thenReturn(ImmutableSet.of());
 
     GroupDetailResponse expectedResponse = GroupDetailResponse.fromGroup(group,
         ImmutableList.of(), ImmutableList.of());
@@ -70,8 +72,8 @@ public class AutomationGroupResourceTest {
   @Test public void findGroupByName() {
     Group group = new Group(50, "testGroup", "testing group", now, "automation client", now, "automation client");
     when(groupDAO.getGroup("testGroup")).thenReturn(Optional.of(group));
-    when(aclDAO.getClientsFor(group)).thenReturn(ImmutableSet.of());
-    when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of());
+    when(aclDAO.getClientsFor(dslContext, group)).thenReturn(ImmutableSet.of());
+    when(aclDAO.getSanitizedSecretsFor(dslContext, group)).thenReturn(ImmutableSet.of());
 
     GroupDetailResponse expectedResponse = GroupDetailResponse.fromGroup(group,
         ImmutableList.of(), ImmutableList.of());
@@ -89,8 +91,8 @@ public class AutomationGroupResourceTest {
         SanitizedSecret.of(2, "name2", "v1", "desc", now, "test", now, "test", null, "", null);
 
     when(groupDAO.getGroup("testGroup")).thenReturn(Optional.of(group));
-    when(aclDAO.getClientsFor(group)).thenReturn(ImmutableSet.of(groupClient));
-    when(aclDAO.getSanitizedSecretsFor(group))
+    when(aclDAO.getClientsFor(dslContext, group)).thenReturn(ImmutableSet.of(groupClient));
+    when(aclDAO.getSanitizedSecretsFor(dslContext, group))
         .thenReturn(ImmutableSet.of(firstGroupSecret, secondGroupSecret));
 
     GroupDetailResponse expectedResponse = GroupDetailResponse.fromGroup(group,

--- a/server/src/test/java/keywhiz/service/resources/AutomationSecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationSecretResourceTest.java
@@ -30,6 +30,7 @@ import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.SecretController;
 import keywhiz.service.daos.SecretSeriesDAO;
 import keywhiz.service.exceptions.ConflictException;
+import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,6 +54,7 @@ public class AutomationSecretResourceTest {
 
   @Mock SecretController secretController;
   @Mock SecretController.SecretBuilder secretBuilder;
+  @Mock DSLContext dslContext;
   @Mock AclDAO aclDAO;
   @Mock SecretSeriesDAO secretSeriesDAO;
 
@@ -61,7 +63,7 @@ public class AutomationSecretResourceTest {
 
   @Before
   public void setUp() {
-    resource = new AutomationSecretResource(secretController, aclDAO, secretSeriesDAO);
+    resource = new AutomationSecretResource(secretController, dslContext, aclDAO, secretSeriesDAO);
 
     when(secretController.builder(anyString(), anyString(), anyString())).thenReturn(secretBuilder);
   }

--- a/server/src/test/java/keywhiz/service/resources/AutomationSecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationSecretResourceTest.java
@@ -113,11 +113,11 @@ public class AutomationSecretResourceTest {
         null,
         null);
 
-    when(secretSeriesDAO.getSecretSeriesByName(secretSeries.getName()))
+    when(secretSeriesDAO.getSecretSeriesByName(dslContext, secretSeries.getName()))
         .thenReturn(Optional.of(secretSeries));
 
     resource.deleteSecretSeries(automation, "mySecret");
-    verify(secretSeriesDAO).deleteSecretSeriesByName(secretSeries.getName());
+    verify(secretSeriesDAO).deleteSecretSeriesByName(dslContext, secretSeries.getName());
   }
 
   @Test(expected = ConflictException.class)

--- a/server/src/test/java/keywhiz/service/resources/ClientsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/ClientsResourceTest.java
@@ -65,7 +65,7 @@ public class ClientsResourceTest {
     Client client1 = new Client(1, "client", "1st client", now, "test", now, "test", true, false);
     Client client2 = new Client(2, "client2", "2nd client", now, "test", now, "test", true, false);
 
-    when(clientDAO.getClients()).thenReturn(ImmutableSet.of(client1, client2));
+    when(clientDAO.getClients(dslContext)).thenReturn(ImmutableSet.of(client1, client2));
 
     List<Client> response = resource.listClients(user);
     assertThat(response).containsOnly(client1, client2);
@@ -73,8 +73,8 @@ public class ClientsResourceTest {
 
   @Test public void createsClient() {
     CreateClientRequest request = new CreateClientRequest("new-client-name");
-    when(clientDAO.createClient("new-client-name", "user", Optional.empty())).thenReturn(42L);
-    when(clientDAO.getClientById(42L)).thenReturn(Optional.of(client));
+    when(clientDAO.createClient(dslContext, "new-client-name", "user", Optional.empty())).thenReturn(42L);
+    when(clientDAO.getClientById(dslContext, 42L)).thenReturn(Optional.of(client));
     when(aclDAO.getSanitizedSecretsFor(dslContext, client)).thenReturn(ImmutableSet.of());
 
     Response response = resource.createClient(user, request);
@@ -82,7 +82,7 @@ public class ClientsResourceTest {
   }
 
   @Test public void includesTheClient() {
-    when(clientDAO.getClientById(1)).thenReturn(Optional.of(client));
+    when(clientDAO.getClientById(dslContext, 1)).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(dslContext, client)).thenReturn(Collections.emptySet());
     when(aclDAO.getSanitizedSecretsFor(dslContext, client)).thenReturn(ImmutableSet.of());
 
@@ -98,7 +98,7 @@ public class ClientsResourceTest {
   }
 
   @Test public void handlesNoAssociations() {
-    when(clientDAO.getClientById(1)).thenReturn(Optional.of(client));
+    when(clientDAO.getClientById(dslContext, 1)).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(dslContext, client)).thenReturn(Collections.emptySet());
     when(aclDAO.getSanitizedSecretsFor(dslContext, client)).thenReturn(ImmutableSet.of());
 
@@ -113,7 +113,7 @@ public class ClientsResourceTest {
     Secret secret = new Secret(15, "secret", null, null, "supersecretdata", now, "creator", now,
         "updater", null, null, null);
 
-    when(clientDAO.getClientById(1)).thenReturn(Optional.of(client));
+    when(clientDAO.getClientById(dslContext, 1)).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(dslContext, client)).thenReturn(Sets.newHashSet(group1, group2));
     when(aclDAO.getSanitizedSecretsFor(dslContext, client))
         .thenReturn(ImmutableSet.of(SanitizedSecret.fromSecret(secret)));
@@ -124,27 +124,27 @@ public class ClientsResourceTest {
   }
 
   @Test public void findClientByName() {
-    when(clientDAO.getClient(client.getName())).thenReturn(Optional.of(client));
+    when(clientDAO.getClient(dslContext, client.getName())).thenReturn(Optional.of(client));
     assertThat(resource.getClientByName(user, "client")).isEqualTo(client);
   }
 
   @Test(expected = NotFoundException.class)
   public void badIdNotFound() {
-    when(clientDAO.getClientById(41)).thenReturn(Optional.empty());
+    when(clientDAO.getClientById(dslContext, 41)).thenReturn(Optional.empty());
     resource.getClient(user, new LongParam("41"));
   }
 
   @Test(expected = NotFoundException.class)
   public void notFoundWhenRetrievingBadName() {
-    when(clientDAO.getClient("non-existent-client")).thenReturn(Optional.empty());
+    when(clientDAO.getClient(dslContext, "non-existent-client")).thenReturn(Optional.empty());
     resource.getClientByName(user, "non-existent-client");
   }
 
   @Test public void deleteCallsDelete() {
-    when(clientDAO.getClientById(12)).thenReturn(Optional.of(client));
+    when(clientDAO.getClientById(dslContext, 12)).thenReturn(Optional.of(client));
 
     Response blah = resource.deleteClient(user, new LongParam("12"));
-    verify(clientDAO).deleteClient(client);
+    verify(clientDAO).deleteClient(dslContext, client);
     assertThat(blah.getStatus()).isEqualTo(204);
   }
 }

--- a/server/src/test/java/keywhiz/service/resources/GroupsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/GroupsResourceTest.java
@@ -31,6 +31,7 @@ import keywhiz.api.model.SanitizedSecret;
 import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.GroupDAO;
+import org.jooq.DSLContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GroupsResourceTest {
+  @Mock DSLContext dslContext;
   @Mock AclDAO aclDAO;
   @Mock GroupDAO groupDAO;
 
@@ -53,7 +55,7 @@ public class GroupsResourceTest {
   GroupsResource resource;
 
   @Before public void setUp() {
-    resource = new GroupsResource(aclDAO, groupDAO);
+    resource = new GroupsResource(dslContext, aclDAO, groupDAO);
   }
 
   @Test public void listingOfGroups() {
@@ -70,7 +72,7 @@ public class GroupsResourceTest {
     when(groupDAO.getGroup("newGroup")).thenReturn(Optional.empty());
     when(groupDAO.createGroup("newGroup", "user", Optional.of("description"))).thenReturn(55L);
     when(groupDAO.getGroupById(55L)).thenReturn(Optional.of(group));
-    when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of());
+    when(aclDAO.getSanitizedSecretsFor(dslContext, group)).thenReturn(ImmutableSet.of());
 
     Response response = resource.createGroup(user, request);
     assertThat(response.getStatus()).isEqualTo(201);
@@ -89,10 +91,10 @@ public class GroupsResourceTest {
     when(groupDAO.getGroupById(4444)).thenReturn(Optional.of(group));
 
     SanitizedSecret secret = SanitizedSecret.of(1, "name", "", null, now, "creator", now, "creator", null, null, null);
-    when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of(secret));
+    when(aclDAO.getSanitizedSecretsFor(dslContext, group)).thenReturn(ImmutableSet.of(secret));
 
     Client client = new Client(1, "client", "desc", now, "creator", now, "creator", true, false);
-    when(aclDAO.getClientsFor(group)).thenReturn(ImmutableSet.of(client));
+    when(aclDAO.getClientsFor(dslContext, group)).thenReturn(ImmutableSet.of(client));
 
     GroupDetailResponse response = resource.getGroup(user, new LongParam("4444"));
 

--- a/server/src/test/java/keywhiz/service/resources/MembershipResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/MembershipResourceTest.java
@@ -24,6 +24,7 @@ import keywhiz.api.model.Group;
 import keywhiz.api.model.Secret;
 import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
+import org.jooq.DSLContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.verify;
 public class MembershipResourceTest {
   private static final OffsetDateTime NOW = OffsetDateTime.now();
 
+  @Mock DSLContext dslContext;
   @Mock AclDAO aclDAO;
 
   User user = User.named("user");
@@ -48,25 +50,25 @@ public class MembershipResourceTest {
   MembershipResource resource;
 
   @Before public void setUp() {
-    resource = new MembershipResource(aclDAO);
+    resource = new MembershipResource(dslContext, aclDAO);
   }
 
   @Test public void canAllowAccess() {
     Response response = resource.allowAccess(user, new LongParam("66"), new LongParam("55"));
 
     assertThat(response.getStatus()).isEqualTo(200);
-    verify(aclDAO).findAndAllowAccess(66, 55);
+    verify(aclDAO).findAndAllowAccess(dslContext, 66, 55);
   }
 
   @Test(expected = NotFoundException.class)
   public void missingSecretAllow() {
-    doThrow(IllegalStateException.class).when(aclDAO).findAndAllowAccess(3, group.getId());
+    doThrow(IllegalStateException.class).when(aclDAO).findAndAllowAccess(dslContext, 3, group.getId());
     resource.allowAccess(user, new LongParam("3"), new LongParam(Long.toString(group.getId())));
   }
 
   @Test(expected = NotFoundException.class)
   public void missingGroupAllow() {
-    doThrow(IllegalStateException.class).when(aclDAO).findAndAllowAccess(secret.getId(), 98);
+    doThrow(IllegalStateException.class).when(aclDAO).findAndAllowAccess(dslContext, secret.getId(), 98);
     resource.allowAccess(user, new LongParam(Long.toString(secret.getId())), new LongParam("98"));
   }
 
@@ -75,18 +77,18 @@ public class MembershipResourceTest {
         new LongParam(Long.toString(group.getId())));
 
     assertThat(response.getStatus()).isEqualTo(200);
-    verify(aclDAO).findAndRevokeAccess(secret.getId(), group.getId());
+    verify(aclDAO).findAndRevokeAccess(dslContext, secret.getId(), group.getId());
   }
 
   @Test(expected = NotFoundException.class)
   public void missingSecretDisallow() {
-    doThrow(IllegalStateException.class).when(aclDAO).findAndRevokeAccess(2, group.getId());
+    doThrow(IllegalStateException.class).when(aclDAO).findAndRevokeAccess(dslContext, 2, group.getId());
     resource.disallowAccess(user, new LongParam("2"), new LongParam(Long.toString(group.getId())));
   }
 
   @Test(expected = NotFoundException.class)
   public void missingGroupDisallow() {
-    doThrow(IllegalStateException.class).when(aclDAO).findAndRevokeAccess(secret.getId(), 3543);
+    doThrow(IllegalStateException.class).when(aclDAO).findAndRevokeAccess(dslContext, secret.getId(), 3543);
     resource.disallowAccess(user, new LongParam(Long.toString(secret.getId())), new LongParam("3543"));
   }
 
@@ -94,18 +96,18 @@ public class MembershipResourceTest {
   public void canEnroll() {
     resource.enrollClient(user, new LongParam(Long.toString(client.getId())),
         new LongParam(Long.toString(group.getId())));
-    verify(aclDAO).findAndEnrollClient(client.getId(), group.getId());
+    verify(aclDAO).findAndEnrollClient(dslContext, client.getId(), group.getId());
   }
 
   @Test(expected = NotFoundException.class)
   public void enrollThrowsWhenClientIdNotFound() {
-    doThrow(IllegalStateException.class).when(aclDAO).findAndEnrollClient(6092384, group.getId());
+    doThrow(IllegalStateException.class).when(aclDAO).findAndEnrollClient(dslContext, 6092384, group.getId());
     resource.enrollClient(user, new LongParam("6092384"), new LongParam(Long.toString(group.getId())));
   }
 
   @Test(expected = NotFoundException.class)
   public void enrollThrowsWhenGroupIdNotFound() {
-    doThrow(IllegalStateException.class).when(aclDAO).findAndEnrollClient(client.getId(), 0xbad);
+    doThrow(IllegalStateException.class).when(aclDAO).findAndEnrollClient(dslContext, client.getId(), 0xbad);
     resource.enrollClient(user, new LongParam("44"), new LongParam(Long.toString(0xbad)));
   }
 
@@ -113,18 +115,18 @@ public class MembershipResourceTest {
   public void canEvict() {
     resource.evictClient(user, new LongParam(Long.toString(client.getId())),
         new LongParam(Long.toString(group.getId())));
-    verify(aclDAO).findAndEvictClient(client.getId(), group.getId());
+    verify(aclDAO).findAndEvictClient(dslContext, client.getId(), group.getId());
   }
 
   @Test(expected = NotFoundException.class)
   public void evictThrowsWhenClientIdNotFound() {
-    doThrow(IllegalStateException.class).when(aclDAO).findAndEvictClient(60984, group.getId());
+    doThrow(IllegalStateException.class).when(aclDAO).findAndEvictClient(dslContext, 60984, group.getId());
     resource.evictClient(user, new LongParam("60984"), new LongParam(Long.toString(group.getId())));
   }
 
   @Test(expected = NotFoundException.class)
   public void evictThrowsWhenGroupIdNotFound() {
-    doThrow(IllegalStateException.class).when(aclDAO).findAndEvictClient(client.getId(), 0xbad2);
+    doThrow(IllegalStateException.class).when(aclDAO).findAndEvictClient(dslContext, client.getId(), 0xbad2);
     resource.evictClient(user, new LongParam(Long.toString(client.getId())),
         new LongParam(Long.toString(0xbad2)));
   }

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
@@ -27,6 +27,7 @@ import keywhiz.api.model.VersionGenerator;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.ClientDAO;
 import keywhiz.service.daos.SecretController;
+import org.jooq.DSLContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,6 +42,7 @@ public class SecretDeliveryResourceTest {
   private static final OffsetDateTime NOW = OffsetDateTime.now();
 
   @Mock SecretController secretController;
+  @Mock DSLContext dslContext;
   @Mock AclDAO aclDAO;
   @Mock ClientDAO clientDAO;
   SecretDeliveryResource secretDeliveryResource;
@@ -52,7 +54,7 @@ public class SecretDeliveryResourceTest {
       null, null, null, null);
 
   @Before public void setUp() {
-    secretDeliveryResource = new SecretDeliveryResource(secretController, aclDAO, clientDAO);
+    secretDeliveryResource = new SecretDeliveryResource(secretController, dslContext, aclDAO, clientDAO);
   }
 
   @Test public void returnsSecretWhenAllowed() throws Exception {
@@ -61,7 +63,7 @@ public class SecretDeliveryResourceTest {
     String name = sanitizedSecret.name();
     String version = sanitizedSecret.version();
 
-    when(aclDAO.getSanitizedSecretFor(client, name, version))
+    when(aclDAO.getSanitizedSecretFor(dslContext, client, name, version))
         .thenReturn(Optional.of(sanitizedSecret));
     when(secretController.getSecretByNameAndVersion(name, version))
         .thenReturn(Optional.of(secret));
@@ -76,7 +78,7 @@ public class SecretDeliveryResourceTest {
     Secret versionedSecret = new Secret(2, name, version, null, "U3BpZGVybWFu", NOW, null, NOW,
         null, null, null, null);
 
-    when(aclDAO.getSanitizedSecretFor(client, name, version))
+    when(aclDAO.getSanitizedSecretFor(dslContext, client, name, version))
         .thenReturn(Optional.of(SanitizedSecret.fromSecret(versionedSecret)));
     when(secretController.getSecretByNameAndVersion(name, version))
         .thenReturn(Optional.of(versionedSecret));
@@ -88,7 +90,7 @@ public class SecretDeliveryResourceTest {
 
   @Test(expected = NotFoundException.class)
   public void returnsNotFoundWhenClientDoesNotExist() throws Exception {
-    when(aclDAO.getSanitizedSecretFor(client, secret.getName(), "")).thenReturn(Optional.empty());
+    when(aclDAO.getSanitizedSecretFor(dslContext, client, secret.getName(), "")).thenReturn(Optional.empty());
     when(clientDAO.getClient(client.getName())).thenReturn(Optional.empty());
     when(secretController.getSecretByNameAndVersion(secret.getName(), ""))
         .thenReturn(Optional.of(secret));
@@ -98,7 +100,7 @@ public class SecretDeliveryResourceTest {
 
   @Test(expected = NotFoundException.class)
   public void returnsNotFoundWhenSecretDoesNotExist() throws Exception {
-    when(aclDAO.getSanitizedSecretFor(client, "secret_name", "")).thenReturn(Optional.empty());
+    when(aclDAO.getSanitizedSecretFor(dslContext, client, "secret_name", "")).thenReturn(Optional.empty());
     when(clientDAO.getClient(client.getName())).thenReturn(Optional.of(client));
     when(secretController.getSecretByNameAndVersion("secret_name", ""))
         .thenReturn(Optional.empty());
@@ -108,7 +110,7 @@ public class SecretDeliveryResourceTest {
 
   @Test(expected = ForbiddenException.class)
   public void returnsUnauthorizedWhenDenied() throws Exception {
-    when(aclDAO.getSanitizedSecretFor(client, secret.getName(), "")).thenReturn(Optional.empty());
+    when(aclDAO.getSanitizedSecretFor(dslContext, client, secret.getName(), "")).thenReturn(Optional.empty());
     when(clientDAO.getClient(client.getName())).thenReturn(Optional.of(client));
     when(secretController.getSecretByNameAndVersion(secret.getName(), ""))
         .thenReturn(Optional.of(secret));
@@ -120,7 +122,7 @@ public class SecretDeliveryResourceTest {
     String name = secretBase64.getName();
     String version = secretBase64.getVersion();
 
-    when(aclDAO.getSanitizedSecretFor(client, name, version))
+    when(aclDAO.getSanitizedSecretFor(dslContext, client, name, version))
         .thenReturn(Optional.of(SanitizedSecret.fromSecret(secretBase64)));
     when(secretController.getSecretByNameAndVersion(name, version))
         .thenReturn(Optional.of(secretBase64));

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
@@ -91,7 +91,7 @@ public class SecretDeliveryResourceTest {
   @Test(expected = NotFoundException.class)
   public void returnsNotFoundWhenClientDoesNotExist() throws Exception {
     when(aclDAO.getSanitizedSecretFor(dslContext, client, secret.getName(), "")).thenReturn(Optional.empty());
-    when(clientDAO.getClient(client.getName())).thenReturn(Optional.empty());
+    when(clientDAO.getClient(dslContext, client.getName())).thenReturn(Optional.empty());
     when(secretController.getSecretByNameAndVersion(secret.getName(), ""))
         .thenReturn(Optional.of(secret));
 
@@ -101,7 +101,7 @@ public class SecretDeliveryResourceTest {
   @Test(expected = NotFoundException.class)
   public void returnsNotFoundWhenSecretDoesNotExist() throws Exception {
     when(aclDAO.getSanitizedSecretFor(dslContext, client, "secret_name", "")).thenReturn(Optional.empty());
-    when(clientDAO.getClient(client.getName())).thenReturn(Optional.of(client));
+    when(clientDAO.getClient(dslContext, client.getName())).thenReturn(Optional.of(client));
     when(secretController.getSecretByNameAndVersion("secret_name", ""))
         .thenReturn(Optional.empty());
 
@@ -111,7 +111,7 @@ public class SecretDeliveryResourceTest {
   @Test(expected = ForbiddenException.class)
   public void returnsUnauthorizedWhenDenied() throws Exception {
     when(aclDAO.getSanitizedSecretFor(dslContext, client, secret.getName(), "")).thenReturn(Optional.empty());
-    when(clientDAO.getClient(client.getName())).thenReturn(Optional.of(client));
+    when(clientDAO.getClient(dslContext, client.getName())).thenReturn(Optional.of(client));
     when(secretController.getSecretByNameAndVersion(secret.getName(), ""))
         .thenReturn(Optional.of(secret));
 

--- a/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceTest.java
@@ -24,6 +24,7 @@ import keywhiz.api.model.Client;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.api.model.Secret;
 import keywhiz.service.daos.AclDAO;
+import org.jooq.DSLContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.when;
 public class SecretsDeliveryResourceTest {
   private static final OffsetDateTime NOW = OffsetDateTime.now();
 
+  @Mock DSLContext dslContext;
   @Mock AclDAO aclDAO;
   SecretsDeliveryResource secretsDeliveryResource;
 
@@ -52,18 +54,18 @@ public class SecretsDeliveryResourceTest {
   Client client;
 
   @Before public void setUp() {
-    secretsDeliveryResource = new SecretsDeliveryResource(aclDAO);
+    secretsDeliveryResource = new SecretsDeliveryResource(dslContext, aclDAO);
     client = new Client(0, "client_name", null, null, null, null, null, false, false);
   }
 
   @Test public void returnsEmptyJsonArrayWhenUserHasNoSecrets() throws Exception {
-    when(aclDAO.getSanitizedSecretsFor(client)).thenReturn(ImmutableSet.of());
+    when(aclDAO.getSanitizedSecretsFor(dslContext, client)).thenReturn(ImmutableSet.of());
     List<SecretDeliveryResponse> secrets = secretsDeliveryResource.getSecrets(client);
     assertThat(secrets).isEmpty();
   }
 
   @Test public void returnsJsonArrayWhenUserHasOneSecret() throws Exception {
-    when(aclDAO.getSanitizedSecretsFor(client)).thenReturn(ImmutableSet.of(sanitizedFirstSecret));
+    when(aclDAO.getSanitizedSecretsFor(dslContext, client)).thenReturn(ImmutableSet.of(sanitizedFirstSecret));
 
     List<SecretDeliveryResponse> secrets = secretsDeliveryResource.getSecrets(client);
     assertThat(secrets).containsOnly(SecretDeliveryResponse.fromSanitizedSecret(
@@ -71,7 +73,7 @@ public class SecretsDeliveryResourceTest {
   }
 
   @Test public void returnsJsonArrayWhenUserHasMultipleSecrets() throws Exception {
-    when(aclDAO.getSanitizedSecretsFor(client))
+    when(aclDAO.getSanitizedSecretsFor(dslContext, client))
         .thenReturn(ImmutableSet.of(sanitizedFirstSecret, sanitizedSecondSecret));
 
     List<SecretDeliveryResponse> secrets = secretsDeliveryResource.getSecrets(client);

--- a/server/src/test/java/keywhiz/service/resources/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretsResourceTest.java
@@ -39,6 +39,7 @@ import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.SecretController;
 import keywhiz.service.daos.SecretSeriesDAO;
 import keywhiz.service.exceptions.ConflictException;
+import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,9 +57,10 @@ import static org.mockito.Mockito.when;
 public class SecretsResourceTest {
   private static final OffsetDateTime NOW = OffsetDateTime.now();
 
+  @Mock SecretController secretController;
+  @Mock DSLContext dslContext;
   @Mock AclDAO aclDAO;
   @Mock SecretSeriesDAO secretSeriesDAO;
-  @Mock SecretController secretController;
 
   User user = User.named("user");
   ImmutableMap<String, String> emptyMap = ImmutableMap.of();
@@ -70,7 +72,7 @@ public class SecretsResourceTest {
 
   @Before
   public void setUp() {
-    resource = new SecretsResource(secretController, aclDAO, secretSeriesDAO);
+    resource = new SecretsResource(secretController, dslContext, aclDAO, secretSeriesDAO);
   }
 
   @Test
@@ -125,8 +127,8 @@ public class SecretsResourceTest {
   @Test
   public void includesTheSecret() {
     when(secretController.getSecretsById(22)).thenReturn(ImmutableList.of(secret));
-    when(aclDAO.getGroupsFor(secret)).thenReturn(Collections.emptySet());
-    when(aclDAO.getClientsFor(secret)).thenReturn(Collections.emptySet());
+    when(aclDAO.getGroupsFor(dslContext, secret)).thenReturn(Collections.emptySet());
+    when(aclDAO.getClientsFor(dslContext, secret)).thenReturn(Collections.emptySet());
 
     SecretDetailResponse response = resource.retrieveSecret(user, new LongParam("22"));
 
@@ -144,8 +146,8 @@ public class SecretsResourceTest {
   @Test
   public void handlesNoAssociations() {
     when(secretController.getSecretsById(22)).thenReturn(ImmutableList.of(secret));
-    when(aclDAO.getGroupsFor(secret)).thenReturn(Collections.emptySet());
-    when(aclDAO.getClientsFor(secret)).thenReturn(Collections.emptySet());
+    when(aclDAO.getGroupsFor(dslContext, secret)).thenReturn(Collections.emptySet());
+    when(aclDAO.getClientsFor(dslContext, secret)).thenReturn(Collections.emptySet());
 
     SecretDetailResponse response = resource.retrieveSecret(user, new LongParam("22"));
     assertThat(response.groups).isEmpty();
@@ -159,8 +161,8 @@ public class SecretsResourceTest {
     Group group2 = new Group(0, "group2", null, null, null, null, null);
 
     when(secretController.getSecretsById(22)).thenReturn(ImmutableList.of(secret));
-    when(aclDAO.getGroupsFor(secret)).thenReturn(Sets.newHashSet(group1, group2));
-    when(aclDAO.getClientsFor(secret)).thenReturn(Sets.newHashSet(client));
+    when(aclDAO.getGroupsFor(dslContext, secret)).thenReturn(Sets.newHashSet(group1, group2));
+    when(aclDAO.getClientsFor(dslContext, secret)).thenReturn(Sets.newHashSet(client));
 
     SecretDetailResponse response = resource.retrieveSecret(user, new LongParam("22"));
     assertThat(response.groups).containsOnly(group1, group2);

--- a/server/src/test/java/keywhiz/service/resources/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretsResourceTest.java
@@ -109,7 +109,7 @@ public class SecretsResourceTest {
     when(secretController.getSecretsById(0xdeadbeef)).thenReturn(ImmutableList.of(secret));
 
     Response response = resource.deleteSecret(user, new LongParam(Long.toString(0xdeadbeef)));
-    verify(secretSeriesDAO).deleteSecretSeriesById(0xdeadbeef);
+    verify(secretSeriesDAO).deleteSecretSeriesById(dslContext, 0xdeadbeef);
     assertThat(response.getStatus()).isEqualTo(204);
   }
 


### PR DESCRIPTION
This is the right way to use jOOQ's transactions
(see http://www.jooq.org/doc/3.6/manual/sql-execution/transaction-management/).

Authoring this PR makes me wonder if all the DAO methods should take a context
as a parameter instead of injecting it. We should make it hard to accidentally
use the incorrect DSLContext.