### PR TITLE
Website instructions for git clone

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -137,7 +137,7 @@
                 <a href="https://github.com/square/keywhiz">square/keywhiz</a>. KeywhizFs source is
                 in <a href="https://github.com/square/keywhiz-fs">square/keywhiz-fs</a>. To checkout
                 the Keywhiz source code:</p>
-            <pre class="prettyprint">$ git clone https://github.com/square/keywhiz.git && cd keywhiz</pre>
+            <pre class="prettyprint">$ git clone https://github.com/square/keywhiz.git &amp;&amp; cd keywhiz</pre>
 
             <h4>Starting the Server</h4>
             <p>The default configuration assumes PostgreSQL, so first install that (or change the

--- a/website/index.html
+++ b/website/index.html
@@ -135,7 +135,9 @@
             <h3 id="setup">Setup</h3>
             <p>Source code for the Server, CLI, and UI is available in
                 <a href="https://github.com/square/keywhiz">square/keywhiz</a>. KeywhizFs source is
-                in <a href="https://github.com/square/keywhiz-fs">square/keywhiz-fs</a>.</p>
+                in <a href="https://github.com/square/keywhiz-fs">square/keywhiz-fs</a>. To checkout
+                the Keywhiz source code:</p>
+            <pre class="prettyprint">$ git clone https://github.com/square/keywhiz.git && cd keywhiz</pre>
 
             <h4>Starting the Server</h4>
             <p>The default configuration assumes PostgreSQL, so first install that (or change the


### PR DESCRIPTION
Adds instruction to `git clone https://github.com/square/keywhiz.git && cd keywhiz` to website. From #78.

R: @alokmenghrajani 