### PR TITLE
Enable and fixup findbugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ script:
   - mvn test -P postgres
   - mvn test -P mysql
   - mvn test -P h2
+  - "mvn compile findbugs:check"
   - cd $UI_DIR && grunt test

--- a/api/src/main/java/keywhiz/api/LoginRequest.java
+++ b/api/src/main/java/keywhiz/api/LoginRequest.java
@@ -16,39 +16,28 @@
 
 package keywhiz.api;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Arrays;
-import java.util.Objects;
-import javax.validation.constraints.NotNull;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.MoreObjects;
 
-public class LoginRequest {
-  @NotNull
-  @JsonProperty
-  public final String username;
+import static com.google.common.base.Strings.repeat;
 
-  @NotNull
-  @JsonProperty
-  public final char[] password;
-
-  public LoginRequest(@JsonProperty("username") String username,
-      @JsonProperty("password") char[] password) {
-    this.username = username;
-    this.password = password;
+@AutoValue
+public abstract class LoginRequest {
+  @JsonCreator public static LoginRequest from(
+      @JsonProperty("username") String username, @JsonProperty("password") char[] password) {
+    return new AutoValue_LoginRequest(username, password);
   }
 
-  @Override public int hashCode() {
-    return Objects.hash(username, password);
-  }
+  @JsonProperty public abstract String username();
 
-  @Override public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o instanceof LoginRequest) {
-      LoginRequest that = (LoginRequest) o;
-      if (Objects.equals(this.username, that.username) &&
-          Arrays.equals(this.password, that.password)) {
-        return true;
-      }
-    }
-    return false;
+  @JsonProperty public abstract char[] password();
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("username", username())
+        .add("password", repeat("*", password().length))
+        .toString();
   }
 }

--- a/api/src/test/java/keywhiz/api/LoginRequestTest.java
+++ b/api/src/test/java/keywhiz/api/LoginRequestTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LoginRequestTest {
   @Test public void deserializesCorrectly() throws Exception {
-    LoginRequest loginRequest = new LoginRequest("keywhizAdmin", "adminPass".toCharArray());
+    LoginRequest loginRequest = LoginRequest.from("keywhizAdmin", "adminPass".toCharArray());
     assertThat(fromJson(jsonFixture("fixtures/loginRequest.json"), LoginRequest.class))
         .isEqualTo(loginRequest);
   }

--- a/client/src/main/java/keywhiz/client/KeywhizClient.java
+++ b/client/src/main/java/keywhiz/client/KeywhizClient.java
@@ -109,7 +109,7 @@ public class KeywhizClient {
    * @throws IOException if a network IO error occurs
    */
   public void login(String username, char[] password) throws IOException {
-    httpPost("/admin/login", new LoginRequest(username, password));
+    httpPost("/admin/login", LoginRequest.from(username, password));
   }
 
   public List<Group> allGroups() throws IOException {

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
+  <!-- Skip jOOQ generated code. -->
+  <Match>
+    <Package name="keywhiz.jooq"/>
+  </Match>
+  <Match>
+    <Package name="keywhiz.jooq.tables"/>
+  </Match>
+
   <!-- Not interested in serializing a servlet. -->
   <Match>
     <Class name="keywhiz.FileAssetServlet"/>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -13,6 +13,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jooq</groupId>
       <artifactId>jooq</artifactId>
     </dependency>

--- a/model/src/main/java/keywhiz/model/TinyIntConverter.java
+++ b/model/src/main/java/keywhiz/model/TinyIntConverter.java
@@ -16,9 +16,11 @@
 
 package keywhiz.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jooq.Converter;
 
 public class TinyIntConverter implements Converter<Byte, Boolean> {
+  @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "null is a valid DB value")
   @Override public Boolean from(Byte aByte) {
     if (aByte == null) {
       return null;

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <jooq.version>3.5.1</jooq.version>
     <powermock.version>1.6.1</powermock.version>
     <slf4j.version>1.7.7</slf4j.version>
+    <findbugs.version>3.0.0</findbugs.version>
     <postgres.version>9.1-901-1.jdbc4</postgres.version>
     <mysql.version>5.1.35</mysql.version>
   </properties>
@@ -108,8 +109,13 @@
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${findbugs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
-        <version>3.0.0</version>
+        <version>${findbugs.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>
@@ -411,7 +417,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.0.1</version>
           <configuration>
             <effort>Max</effort>
             <threshold>Default</threshold>

--- a/server/src/main/java/keywhiz/commands/DbSeedCommand.java
+++ b/server/src/main/java/keywhiz/commands/DbSeedCommand.java
@@ -50,8 +50,8 @@ import static keywhiz.jooq.tables.Users.USERS;
  */
 public class DbSeedCommand extends ConfiguredCommand<KeywhizConfig> {
   // Didn't we say not to keep passwords in code? ;)
-  public static String defaultUser = "keywhizAdmin";
-  public static String defaultPassword = "adminPass";
+  public static final String defaultUser = "keywhizAdmin";
+  public static final String defaultPassword = "adminPass";
 
   public DbSeedCommand() {
     super("db-seed", "Populates database with development data.");

--- a/server/src/main/java/keywhiz/service/resources/SessionLoginResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SessionLoginResource.java
@@ -77,8 +77,8 @@ public class SessionLoginResource {
   @Produces(MediaType.APPLICATION_JSON)
   public Response login(@Valid LoginRequest request) {
 
-    String username = request.username;
-    String password = String.copyValueOf(request.password);
+    String username = request.username();
+    String password = String.copyValueOf(request.password());
 
     Optional<User> optionalUser = Optional.empty();
     try {

--- a/server/src/test/java/keywhiz/service/resources/SessionLoginResourceIntegrationTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SessionLoginResourceIntegrationTest.java
@@ -101,7 +101,7 @@ public class SessionLoginResourceIntegrationTest {
     Request request = buildLoginPost(null, null);
 
     Response response = client.newCall(request).execute();
-    assertThat(response.code()).isEqualTo(422);
+    assertThat(response.code()).isEqualTo(400);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class SessionLoginResourceIntegrationTest {
     Request request = buildLoginPost(null, "password");
 
     Response response = client.newCall(request).execute();
-    assertThat(response.code()).isEqualTo(422);
+    assertThat(response.code()).isEqualTo(400);
   }
 
   @Test
@@ -117,6 +117,6 @@ public class SessionLoginResourceIntegrationTest {
     Request request = buildLoginPost("username", null);
 
     Response response = client.newCall(request).execute();
-    assertThat(response.code()).isEqualTo(422);
+    assertThat(response.code()).isEqualTo(400);
   }
 }

--- a/server/src/test/java/keywhiz/service/resources/SessionLoginResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SessionLoginResourceTest.java
@@ -73,7 +73,7 @@ public class SessionLoginResourceTest {
   public void badCredentialsThrowUnauthorized() throws Exception {
     when(ldapAuthenticator.authenticate(badCredentials)).thenReturn(Optional.empty());
 
-    sessionLoginResource.login(new LoginRequest("bad", "credentials".toCharArray()));
+    sessionLoginResource.login(LoginRequest.from("bad", "credentials".toCharArray()));
   }
 
   @Test
@@ -81,7 +81,7 @@ public class SessionLoginResourceTest {
     User user = User.named("goodUser");
     when(ldapAuthenticator.authenticate(goodCredentials)).thenReturn(Optional.of(user));
 
-    Response response = sessionLoginResource.login(new LoginRequest("good", "credentials".toCharArray()));
+    Response response = sessionLoginResource.login(LoginRequest.from("good", "credentials".toCharArray()));
     assertThat(response.getStatus()).isEqualTo(SEE_OTHER.getStatusCode());
 
     Map<String, NewCookie> responseCookies = response.getCookies();
@@ -94,11 +94,11 @@ public class SessionLoginResourceTest {
 
   @Test(expected = NullPointerException.class)
   public void missingUsernameThrowsException() throws Exception {
-    sessionLoginResource.login(new LoginRequest(null, "password".toCharArray()));
+    sessionLoginResource.login(LoginRequest.from(null, "password".toCharArray()));
   }
 
   @Test(expected = NullPointerException.class)
   public void missingPasswordThrowsException() throws Exception {
-    sessionLoginResource.login(new LoginRequest("username", null));
+    sessionLoginResource.login(LoginRequest.from("username", null));
   }
 }


### PR DESCRIPTION
R: @alokmenghrajani 

- Enables findbugs in CI
- Changes LoginRequest to use AutoValue so char[] is not exposed
  - Subtle change makes the response type 400 when field missing, which
    is arguably more correct.
- Make some fields final
- Suppress TinyIntConverter warning where null should be returned
- Suppress checking jOOQ-generated files