### PR TITLE
Nested transactions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,9 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <dropwizard.version>0.8.1</dropwizard.version>
-    <guice.version>4.0-beta5</guice.version>
+    <guice.version>4.0</guice.version>
     <jackson.version>2.5.0</jackson.version>
-    <jooq.version>3.5.1</jooq.version>
+    <jooq.version>3.6.2</jooq.version>
     <powermock.version>1.6.1</powermock.version>
     <slf4j.version>1.7.7</slf4j.version>
     <postgres.version>9.1-901-1.jdbc4</postgres.version>
@@ -119,6 +119,11 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-multibindings</artifactId>
+        <version>${guice.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-testlib</artifactId>
         <version>${guice.version}</version>
       </dependency>
       <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -199,6 +199,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-testlib</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.squareup.keywhiz</groupId>
       <artifactId>keywhiz-client</artifactId>
       <version>${project.version}</version>

--- a/server/src/main/java/keywhiz/ServiceModule.java
+++ b/server/src/main/java/keywhiz/ServiceModule.java
@@ -39,14 +39,9 @@ import keywhiz.service.config.Readonly;
 import keywhiz.service.crypto.ContentCryptographer;
 import keywhiz.service.crypto.CryptoModule;
 import keywhiz.service.crypto.SecretTransformer;
-import keywhiz.service.daos.AclDAO;
-import keywhiz.service.daos.ClientDAO;
-import keywhiz.service.daos.GroupDAO;
-import keywhiz.service.daos.SecretContentDAO;
 import keywhiz.service.daos.SecretController;
-import keywhiz.service.daos.SecretDAO;
-import keywhiz.service.daos.SecretSeriesDAO;
 import keywhiz.utility.DSLContexts;
+import keywhiz.service.daos.SecretDAO.SecretDAOFactory;
 import org.jooq.DSLContext;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -130,80 +125,15 @@ public class ServiceModule extends AbstractModule {
     return DSLContexts.databaseAgnostic(dataSource);
   }
 
-  // DAOs
-
-  @Provides @Singleton AclDAO aclDAO(DSLContext jooqContext, ClientDAO clientDAO,
-      GroupDAO groupDAO, SecretContentDAO secretContentDAO,
-      SecretSeriesDAO secretSeriesDAO, ObjectMapper mapper) {
-    return new AclDAO(jooqContext, clientDAO, groupDAO, secretContentDAO, secretSeriesDAO, mapper);
-  }
-
-  @Provides @Singleton
-  @Readonly AclDAO readonlyAclDAO(@Readonly DSLContext jooqContext, @Readonly ClientDAO clientDAO,
-      @Readonly GroupDAO groupDAO, @Readonly SecretContentDAO secretContentDAO,
-      @Readonly SecretSeriesDAO secretSeriesDAO, ObjectMapper mapper) {
-    return new AclDAO(jooqContext, clientDAO, groupDAO, secretContentDAO, secretSeriesDAO, mapper);
-  }
-
-  @Provides @Singleton ClientDAO clientDAO(DSLContext jooqContext) {
-    return new ClientDAO(jooqContext);
-  }
-
-  @Provides @Singleton @Readonly ClientDAO readonlyClientDAO(@Readonly DSLContext jooqContext) {
-    return new ClientDAO(jooqContext);
-  }
-
-  @Provides @Singleton GroupDAO groupDAO(DSLContext jooqContext) {
-    return new GroupDAO(jooqContext);
-  }
-
-  @Provides @Singleton @Readonly GroupDAO readonlyGroupDAO(@Readonly DSLContext jooqContext) {
-    return new GroupDAO(jooqContext);
-  }
-
-  @Provides @Singleton SecretContentDAO secretContentDAO(DSLContext jooqContext,
-      ObjectMapper mapper) {
-    return new SecretContentDAO(jooqContext, mapper);
-  }
-
-  @Provides @Singleton
-  @Readonly SecretContentDAO readonlySecretContentDAO(@Readonly DSLContext jooqContext,
-      ObjectMapper mapper) {
-    return new SecretContentDAO(jooqContext, mapper);
-  }
-
-  @Provides @Singleton SecretSeriesDAO secretSeriesDAO(DSLContext jooqContext,
-      ObjectMapper mapper) {
-    return new SecretSeriesDAO(jooqContext, mapper);
-  }
-
-  @Provides @Singleton
-  @Readonly SecretSeriesDAO readonlySecretSeriesDAO(@Readonly DSLContext jooqContext,
-      ObjectMapper mapper) {
-    return new SecretSeriesDAO(jooqContext, mapper);
-  }
-
-  @Provides @Singleton SecretDAO secretDAO(DSLContext jooqContext,
-      SecretContentDAO secretContentDAO, SecretSeriesDAO secretSeriesDAO) {
-    return new SecretDAO(jooqContext, secretContentDAO, secretSeriesDAO);
-  }
-
-  @Provides @Singleton
-  @Readonly SecretDAO readonlySecretDAO(@Readonly DSLContext jooqContext,
-      @Readonly SecretContentDAO secretContentDAO,
-      @Readonly SecretSeriesDAO secretSeriesDAO) {
-    return new SecretDAO(jooqContext, secretContentDAO, secretSeriesDAO);
-  }
-
   @Provides @Singleton SecretController secretController(SecretTransformer transformer,
-      ContentCryptographer cryptographer, SecretDAO secretDAO) {
-    return new SecretController(transformer, cryptographer, secretDAO);
+      ContentCryptographer cryptographer, SecretDAOFactory secretDAOFactory) {
+    return new SecretController(transformer, cryptographer, secretDAOFactory.readwrite());
   }
 
   @Provides @Singleton
   @Readonly SecretController readonlySecretController(SecretTransformer transformer,
-      ContentCryptographer cryptographer, @Readonly SecretDAO secretDAO) {
-    return new SecretController(transformer, cryptographer, secretDAO);
+      ContentCryptographer cryptographer, SecretDAOFactory secretDAOFactory) {
+    return new SecretController(transformer, cryptographer, secretDAOFactory.readonly());
   }
 
   @Provides @Singleton

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -179,18 +179,7 @@ public class AclDAO {
     return dslContext.transactionResult(configuration -> {
       SecretContentDAO secretContentDAO = secretContentDAOFactory.using(configuration);
 
-      List<SecretSeries> serieses = DSL.using(configuration)
-          .select()
-          .from(SECRETS)
-          .join(ACCESSGRANTS)
-          .on(SECRETS.ID.eq(ACCESSGRANTS.SECRETID))
-          .join(GROUPS)
-          .on(GROUPS.ID.eq(ACCESSGRANTS.GROUPID))
-          .where(GROUPS.NAME.eq(group.getName()))
-          .fetchInto(SECRETS)
-          .map(secretSeriesMapper);
-
-      for (SecretSeries series : serieses) {
+      for (SecretSeries series : getSecretSeriesFor(configuration, group)) {
         for (SecretContent content : secretContentDAO.getSecretContentsBySecretId(series.getId())) {
           SecretSeriesAndContent seriesAndContent = SecretSeriesAndContent.of(series, content);
           set.add(SanitizedSecret.fromSecretSeriesAndContent(seriesAndContent));

--- a/server/src/main/java/keywhiz/service/daos/DAOFactory.java
+++ b/server/src/main/java/keywhiz/service/daos/DAOFactory.java
@@ -12,29 +12,33 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package keywhiz.service.daos;
 
-import java.util.Optional;
-import org.jooq.DSLContext;
+import org.jooq.Configuration;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static keywhiz.jooq.tables.Users.USERS;
+/**
+ * DAO factory implement this interface to provide instances using different underlying database
+ * connections.
+ *
+ * @param <T> DAO type produced by the factory
+ */
+public interface DAOFactory<T> {
+  /**
+   * Returns DAO using a read/write database connection.
+   */
+  T readwrite();
 
-public class UserDAO {
-  private final DSLContext dslContext;
+  /**
+   * Returns DAO using a read-only database connection.
+   */
+  T readonly();
 
-  public UserDAO(DSLContext dslContext) {
-    this.dslContext = checkNotNull(dslContext);
-  }
-
-  public Optional<String> getHashedPassword(String name) {
-    String r = dslContext
-        .select(USERS.PASSWORD_HASH)
-        .from(USERS)
-        .where(USERS.USERNAME.eq(name))
-        .fetchOne(USERS.PASSWORD_HASH);
-    return Optional.ofNullable(r);
-  }
+  /**
+   * Returns DAO using a supplied jOOQ configuration. Useful for issuing queries on the same
+   * underlying transaction from a different DAO.
+   */
+  T using(Configuration configuration);
 }

--- a/server/src/main/java/keywhiz/service/daos/SecretContentMapper.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentMapper.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Map;
+import javax.inject.Inject;
 import keywhiz.api.model.SecretContent;
 import keywhiz.jooq.tables.records.SecretsContentRecord;
 import org.jooq.RecordMapper;
@@ -30,7 +31,7 @@ class SecretContentMapper implements RecordMapper<SecretsContentRecord, SecretCo
       new TypeReference<Map<String, String>>() {};
   private final ObjectMapper mapper;
 
-  SecretContentMapper(ObjectMapper mapper) {
+  @Inject SecretContentMapper(ObjectMapper mapper) {
     this.mapper = mapper;
   }
 

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesMapper.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesMapper.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Map;
+import javax.inject.Inject;
 import keywhiz.api.model.SecretSeries;
 import keywhiz.jooq.tables.records.SecretsRecord;
 import org.jooq.RecordMapper;
@@ -29,7 +30,7 @@ class SecretSeriesMapper implements RecordMapper<SecretsRecord, SecretSeries> {
       new TypeReference<Map<String, String>>() {};
   private final ObjectMapper mapper;
 
-  SecretSeriesMapper(ObjectMapper mapper) {
+  @Inject SecretSeriesMapper(ObjectMapper mapper) {
     this.mapper = mapper;
   }
 

--- a/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
@@ -16,6 +16,7 @@
 
 package keywhiz.service.providers;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.java8.auth.Authenticator;
@@ -25,6 +26,7 @@ import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotAuthorizedException;
 import keywhiz.api.model.AutomationClient;
 import keywhiz.service.daos.ClientDAO;
+import keywhiz.service.daos.ClientDAO.ClientDAOFactory;
 import org.glassfish.jersey.server.ContainerRequest;
 
 import static java.lang.String.format;
@@ -39,7 +41,11 @@ import static java.lang.String.format;
 public class AutomationClientAuthFactory {
   private final Authenticator<String, AutomationClient> authenticator;
 
-  @Inject public AutomationClientAuthFactory(ClientDAO clientDAO) {
+  @Inject public AutomationClientAuthFactory(ClientDAOFactory clientDAOFactory) {
+    this.authenticator = new MyAuthenticator(clientDAOFactory.readwrite());
+  }
+
+  @VisibleForTesting AutomationClientAuthFactory(ClientDAO clientDAO) {
     this.authenticator = new MyAuthenticator(clientDAO);
   }
 

--- a/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
@@ -42,7 +42,7 @@ public class AutomationClientAuthFactory {
   private final Authenticator<String, AutomationClient> authenticator;
 
   @Inject public AutomationClientAuthFactory(ClientDAOFactory clientDAOFactory) {
-    this.authenticator = new MyAuthenticator(clientDAOFactory.readwrite());
+    this.authenticator = new MyAuthenticator(clientDAOFactory.readonly());
   }
 
   @VisibleForTesting AutomationClientAuthFactory(ClientDAO clientDAO) {

--- a/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
@@ -16,6 +16,7 @@
 
 package keywhiz.service.providers;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.java8.auth.Authenticator;
@@ -25,6 +26,7 @@ import javax.inject.Inject;
 import javax.ws.rs.NotAuthorizedException;
 import keywhiz.api.model.Client;
 import keywhiz.service.daos.ClientDAO;
+import keywhiz.service.daos.ClientDAO.ClientDAOFactory;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -47,7 +49,11 @@ public class ClientAuthFactory {
 
   private final Authenticator<String, Client> authenticator;
 
-  @Inject public ClientAuthFactory(ClientDAO clientDAO) {
+  @Inject public ClientAuthFactory(ClientDAOFactory clientDAOFactory) {
+    this.authenticator = new MyAuthenticator(clientDAOFactory.readwrite());
+  }
+
+  @VisibleForTesting ClientAuthFactory(ClientDAO clientDAO) {
     this.authenticator = new MyAuthenticator(clientDAO);
   }
 

--- a/server/src/main/java/keywhiz/service/resources/AutomationClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationClientResource.java
@@ -16,6 +16,7 @@
 
 package keywhiz.service.resources;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
@@ -40,7 +41,9 @@ import keywhiz.api.model.AutomationClient;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import keywhiz.service.daos.ClientDAO;
+import keywhiz.service.daos.ClientDAO.ClientDAOFactory;
 import keywhiz.service.exceptions.ConflictException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,8 +65,12 @@ public class AutomationClientResource {
   private final AclDAO aclDAO;
 
 
-  @Inject
-  public AutomationClientResource(ClientDAO clientDAO, AclDAO aclDAO) {
+  @Inject public AutomationClientResource(ClientDAOFactory clientDAOFactory, AclDAOFactory aclDAOFactory) {
+    this.clientDAO = clientDAOFactory.readwrite();
+    this.aclDAO = aclDAOFactory.readwrite();
+  }
+
+  @VisibleForTesting AutomationClientResource(ClientDAO clientDAO, AclDAO aclDAO) {
     this.clientDAO = clientDAO;
     this.aclDAO = aclDAO;
   }

--- a/server/src/main/java/keywhiz/service/resources/AutomationEnrollClientGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationEnrollClientGroupResource.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import keywhiz.api.model.AutomationClient;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 
 /**
  * @parentEndpointName enroll-clients-automation
@@ -39,9 +40,8 @@ import keywhiz.service.daos.AclDAO;
 public class AutomationEnrollClientGroupResource {
   private final AclDAO aclDAO;
 
-  @Inject
-  public AutomationEnrollClientGroupResource(AclDAO aclDAO) {
-    this.aclDAO = aclDAO;
+  @Inject public AutomationEnrollClientGroupResource(AclDAOFactory aclDAOFactory) {
+    this.aclDAO = aclDAOFactory.readwrite();
   }
 
   /**

--- a/server/src/main/java/keywhiz/service/resources/AutomationGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationGroupResource.java
@@ -16,6 +16,7 @@
 
 package keywhiz.service.resources;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
@@ -41,7 +42,9 @@ import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import keywhiz.service.daos.GroupDAO;
+import keywhiz.service.daos.GroupDAO.GroupDAOFactory;
 import keywhiz.service.exceptions.ConflictException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,8 +65,12 @@ public class AutomationGroupResource {
   private final GroupDAO groupDAO;
   private final AclDAO aclDAO;
 
-  @Inject
-  public AutomationGroupResource(GroupDAO groupDAO, AclDAO aclDAO) {
+  @Inject public AutomationGroupResource(GroupDAOFactory groupDAOFactory, AclDAOFactory aclDAOFactory) {
+    this.groupDAO = groupDAOFactory.readwrite();
+    this.aclDAO = aclDAOFactory.readwrite();
+  }
+
+  @VisibleForTesting AutomationGroupResource(GroupDAO groupDAO, AclDAO aclDAO) {
     this.groupDAO = groupDAO;
     this.aclDAO = aclDAO;
   }

--- a/server/src/main/java/keywhiz/service/resources/AutomationSecretAccessResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationSecretAccessResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import keywhiz.api.model.AutomationClient;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +42,11 @@ import org.slf4j.LoggerFactory;
 @Produces(MediaType.APPLICATION_JSON)
 public class AutomationSecretAccessResource {
   private static final Logger logger = LoggerFactory.getLogger(AutomationSecretAccessResource.class);
+
   private final AclDAO aclDAO;
 
-  @Inject
-  public AutomationSecretAccessResource(AclDAO aclDAO) {
-    this.aclDAO = aclDAO;
+  @Inject public AutomationSecretAccessResource(AclDAOFactory aclDAOFactory) {
+    this.aclDAO = aclDAOFactory.readwrite();
   }
 
   /**

--- a/server/src/main/java/keywhiz/service/resources/AutomationSecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationSecretResource.java
@@ -15,6 +15,7 @@
  */
 package keywhiz.service.resources;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
@@ -41,8 +42,10 @@ import keywhiz.api.model.SanitizedSecret;
 import keywhiz.api.model.Secret;
 import keywhiz.api.model.VersionGenerator;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import keywhiz.service.daos.SecretController;
 import keywhiz.service.daos.SecretSeriesDAO;
+import keywhiz.service.daos.SecretSeriesDAO.SecretSeriesDAOFactory;
 import keywhiz.service.exceptions.ConflictException;
 import org.jooq.exception.DataAccessException;
 import org.slf4j.Logger;
@@ -61,15 +64,21 @@ import static java.lang.String.format;
 public class AutomationSecretResource {
   private static final Logger logger = LoggerFactory.getLogger(AutomationSecretResource.class);
   private final SecretController secretController;
-  private final AclDAO aclDAO;
   private final SecretSeriesDAO secretSeriesDAO;
+  private final AclDAO aclDAO;
 
-  @Inject
-  public AutomationSecretResource(SecretController secretController, AclDAO aclDAO,
-      SecretSeriesDAO secretSeriesDAO) {
+  @Inject public AutomationSecretResource(SecretController secretController,
+      SecretSeriesDAOFactory secretSeriesDAOFactory, AclDAOFactory aclDAOFactory) {
     this.secretController = secretController;
-    this.aclDAO = aclDAO;
+    this.secretSeriesDAO = secretSeriesDAOFactory.readwrite();
+    this.aclDAO = aclDAOFactory.readwrite();
+  }
+
+  @VisibleForTesting AutomationSecretResource(SecretController secretController,
+      SecretSeriesDAO secretSeriesDAO, AclDAO aclDAO) {
+    this.secretController = secretController;
     this.secretSeriesDAO = secretSeriesDAO;
+    this.aclDAO = aclDAO;
   }
 
   /**

--- a/server/src/main/java/keywhiz/service/resources/ClientsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/ClientsResource.java
@@ -16,6 +16,7 @@
 
 package keywhiz.service.resources;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
@@ -45,7 +46,9 @@ import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import keywhiz.service.daos.ClientDAO;
+import keywhiz.service.daos.ClientDAO.ClientDAOFactory;
 import keywhiz.service.exceptions.ConflictException;
 import org.jooq.exception.DataAccessException;
 import org.slf4j.Logger;
@@ -65,8 +68,12 @@ public class ClientsResource {
   private final AclDAO aclDAO;
   private final ClientDAO clientDAO;
 
-  @Inject
-  public ClientsResource(AclDAO aclDAO, ClientDAO clientDAO) {
+  @Inject public ClientsResource(AclDAOFactory aclDAOFactory, ClientDAOFactory clientDAOFactory) {
+    this.aclDAO = aclDAOFactory.readwrite();
+    this.clientDAO = clientDAOFactory.readwrite();
+  }
+
+  @VisibleForTesting ClientsResource(AclDAO aclDAO, ClientDAO clientDAO) {
     this.aclDAO = aclDAO;
     this.clientDAO = clientDAO;
   }

--- a/server/src/main/java/keywhiz/service/resources/GroupsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/GroupsResource.java
@@ -16,6 +16,7 @@
 
 package keywhiz.service.resources;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
@@ -46,7 +47,9 @@ import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import keywhiz.service.daos.GroupDAO;
+import keywhiz.service.daos.GroupDAO.GroupDAOFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,8 +66,12 @@ public class GroupsResource {
   private final AclDAO aclDAO;
   private final GroupDAO groupDAO;
 
-  @Inject
-  public GroupsResource(AclDAO aclDAO, GroupDAO groupDAO) {
+  @Inject public GroupsResource(AclDAOFactory aclDAOFactory, GroupDAOFactory groupDAOFactory) {
+    this.aclDAO = aclDAOFactory.readwrite();
+    this.groupDAO = groupDAOFactory.readwrite();
+  }
+
+  @VisibleForTesting GroupsResource(AclDAO aclDAO, GroupDAO groupDAO) {
     this.aclDAO = aclDAO;
     this.groupDAO = groupDAO;
   }

--- a/server/src/main/java/keywhiz/service/resources/MembershipResource.java
+++ b/server/src/main/java/keywhiz/service/resources/MembershipResource.java
@@ -15,6 +15,7 @@
  */
 package keywhiz.service.resources;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
 import javax.inject.Inject;
@@ -28,6 +29,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +46,11 @@ public class MembershipResource {
 
   private final AclDAO aclDAO;
 
-  @Inject
-  public MembershipResource(AclDAO aclDAO) {
+  @Inject public MembershipResource(AclDAOFactory aclDAOFactory) {
+    this.aclDAO = aclDAOFactory.readwrite();
+  }
+
+  @VisibleForTesting MembershipResource(AclDAO aclDAO) {
     this.aclDAO = aclDAO;
   }
 

--- a/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
@@ -16,6 +16,7 @@
 
 package keywhiz.service.resources;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.auth.Auth;
 import java.text.ParseException;
 import java.util.Optional;
@@ -35,7 +36,9 @@ import keywhiz.api.model.SanitizedSecret;
 import keywhiz.api.model.Secret;
 import keywhiz.service.config.Readonly;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import keywhiz.service.daos.ClientDAO;
+import keywhiz.service.daos.ClientDAO.ClientDAOFactory;
 import keywhiz.service.daos.SecretController;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
@@ -58,9 +61,15 @@ public class SecretDeliveryResource {
   private final AclDAO aclDAO;
   private final ClientDAO clientDAO;
 
-  @Inject
-  public SecretDeliveryResource(@Readonly SecretController secretController,
-      @Readonly AclDAO aclDAO, @Readonly ClientDAO clientDAO) {
+  @Inject public SecretDeliveryResource(@Readonly SecretController secretController,
+      AclDAOFactory aclDAOFactory, ClientDAOFactory clientDAOFactory) {
+    this.secretController = secretController;
+    this.aclDAO = aclDAOFactory.readonly();
+    this.clientDAO = clientDAOFactory.readonly();
+  }
+
+  @VisibleForTesting SecretDeliveryResource(SecretController secretController, AclDAO aclDAO,
+      ClientDAO clientDAO) {
     this.secretController = secretController;
     this.aclDAO = aclDAO;
     this.clientDAO = clientDAO;

--- a/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
@@ -16,6 +16,7 @@
 
 package keywhiz.service.resources;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.auth.Auth;
 import java.util.List;
 import javax.inject.Inject;
@@ -25,8 +26,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import keywhiz.api.SecretDeliveryResponse;
 import keywhiz.api.model.Client;
-import keywhiz.service.config.Readonly;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +45,11 @@ public class SecretsDeliveryResource {
 
   private final AclDAO aclDAO;
 
-  @Inject
-  public SecretsDeliveryResource(@Readonly AclDAO aclDAO) {
+  @Inject public SecretsDeliveryResource(AclDAOFactory aclDAOFactory) {
+    this.aclDAO = aclDAOFactory.readonly();
+  }
+
+  @VisibleForTesting SecretsDeliveryResource(AclDAO aclDAO) {
     this.aclDAO = aclDAO;
   }
 

--- a/server/src/main/java/keywhiz/service/resources/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretsResource.java
@@ -16,6 +16,7 @@
 
 package keywhiz.service.resources;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
@@ -47,8 +48,10 @@ import keywhiz.api.model.Secret;
 import keywhiz.api.model.VersionGenerator;
 import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
+import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import keywhiz.service.daos.SecretController;
 import keywhiz.service.daos.SecretSeriesDAO;
+import keywhiz.service.daos.SecretSeriesDAO.SecretSeriesDAOFactory;
 import keywhiz.service.exceptions.ConflictException;
 import org.jooq.exception.DataAccessException;
 import org.slf4j.Logger;
@@ -71,8 +74,14 @@ public class SecretsResource {
   private final AclDAO aclDAO;
   private final SecretSeriesDAO secretSeriesDAO;
 
-  @Inject
-  public SecretsResource(SecretController secretController, AclDAO aclDAO,
+  @Inject public SecretsResource(SecretController secretController, AclDAOFactory aclDAOFactory,
+      SecretSeriesDAOFactory secretSeriesDAOFactory) {
+    this.secretController = secretController;
+    this.aclDAO = aclDAOFactory.readwrite();
+    this.secretSeriesDAO = secretSeriesDAOFactory.readwrite();
+  }
+
+  @VisibleForTesting SecretsResource(SecretController secretController, AclDAO aclDAO,
       SecretSeriesDAO secretSeriesDAO) {
     this.secretController = secretController;
     this.aclDAO = aclDAO;

--- a/server/src/main/resources/keywhiz-development.yaml.postgres
+++ b/server/src/main/resources/keywhiz-development.yaml.postgres
@@ -64,7 +64,7 @@ database:
 
 readonlyDatabase:
   driverClass: org.postgresql.Driver
-  url: jdbc:postgresql://127.0.0.1/keywhizdb_development
+  url: jdbc:postgresql://localhost/keywhizdb_development
   properties:
     charSet: UTF-8
   readOnlyByDefault: true

--- a/server/src/test/java/keywhiz/service/daos/ClientDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/ClientDAOTest.java
@@ -16,10 +16,17 @@
 
 package keywhiz.service.daos;
 
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import java.util.Optional;
 import java.util.Set;
+import javax.inject.Inject;
 import keywhiz.TestDBRule;
 import keywhiz.api.model.Client;
+import keywhiz.service.config.Readonly;
+import keywhiz.service.daos.ClientDAO.ClientDAOFactory;
+import org.jooq.DSLContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,12 +37,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ClientDAOTest {
   @Rule public final TestDBRule testDBRule = new TestDBRule();
 
+  @Bind DSLContext jooqContext;
+  @Bind @Readonly DSLContext jooqReadonlyContext;
+
+  @Inject ClientDAOFactory clientDAOFactory;
+
   Client client1, client2;
   ClientDAO clientDAO;
 
-  @Before
-  public void setUp() throws Exception {
-    clientDAO = new ClientDAO(testDBRule.jooqContext());
+  @Before public void setUp() throws Exception {
+    jooqContext = jooqReadonlyContext = testDBRule.jooqContext();
+    Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+
+    clientDAO = clientDAOFactory.readwrite();
 
     testDBRule.jooqContext().delete(CLIENTS).execute();
 
@@ -49,8 +63,7 @@ public class ClientDAOTest {
     client2 = clientDAO.getClient("client2").get();
   }
 
-  @Test
-  public void createClient() {
+  @Test public void createClient() {
     int before = tableSize();
     clientDAO.createClient("newClient", "creator", Optional.empty());
     Client newClient = clientDAO.getClient("newClient").orElseThrow(RuntimeException::new);
@@ -59,51 +72,43 @@ public class ClientDAOTest {
     assertThat(clientDAO.getClients()).containsOnly(client1, client2, newClient);
   }
 
-  @Test
-  public void createClientReturnsId() {
+  @Test public void createClientReturnsId() {
     long id = clientDAO.createClient("newClientWithSameId", "creator2", Optional.empty());
     Client clientById = clientDAO.getClient("newClientWithSameId")
         .orElseThrow(RuntimeException::new);
     assertThat(clientById.getId()).isEqualTo(id);
   }
 
-  @Test
-  public void deleteClient() {
+  @Test public void deleteClient() {
     int before = tableSize();
     clientDAO.deleteClient(client1);
     assertThat(tableSize()).isEqualTo(before - 1);
     assertThat(clientDAO.getClients()).containsOnly(client2);
   }
 
-  @Test
-  public void getClientByName() {
-    Client client = clientDAO.getClient("client1").orElseThrow(RuntimeException::new);
-    assertThat(client).isEqualTo(client1);
+  @Test public void getClientByName() {
+    assertThat(clientDAO.getClient("client1")).contains(client1);
   }
 
-  @Test
-  public void getNonExistentClientByName() {
-    assertThat(clientDAO.getClient("non-existent").isPresent()).isFalse();
+  @Test public void getNonExistentClientByName() {
+    assertThat(clientDAO.getClient("non-existent")).isEmpty();
   }
 
-  @Test
-  public void getClientById() {
+  @Test public void getClientById() {
     Client client = clientDAO.getClientById(client1.getId()).orElseThrow(RuntimeException::new);
     assertThat(client).isEqualTo(client1);
   }
 
-  @Test
-  public void getNonExistentClientById() {
-    assertThat(clientDAO.getClientById(-1).isPresent()).isFalse();
+  @Test public void getNonExistentClientById() {
+    assertThat(clientDAO.getClientById(-1)).isEmpty();
   }
 
-  @Test
-  public void getsClients() {
+  @Test public void getsClients() {
     Set<Client> clients = clientDAO.getClients();
     assertThat(clients).containsOnly(client1, client2);
   }
 
   private int tableSize() {
-    return testDBRule.jooqContext().fetchCount(CLIENTS);
+    return jooqContext.fetchCount(CLIENTS);
   }
 }

--- a/server/src/test/java/keywhiz/service/resources/AutomationSecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationSecretResourceTest.java
@@ -63,7 +63,7 @@ public class AutomationSecretResourceTest {
 
   @Before
   public void setUp() {
-    resource = new AutomationSecretResource(secretController, aclDAO, secretSeriesDAO);
+    resource = new AutomationSecretResource(secretController, secretSeriesDAO, aclDAO);
 
     when(secretController.builder(anyString(), anyString(), anyString())).thenReturn(secretBuilder);
   }

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceIntegrationTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceIntegrationTest.java
@@ -60,7 +60,6 @@ public class SecretDeliveryResourceIntegrationTest {
   }
 
   @Test public void returnsNotFoundWhenSecretUnspecified() throws Exception {
-
     Request get = new Request.Builder()
         .get()
         .url("/secret/")

--- a/server/src/test/resources/keywhiz-test.yaml.h2
+++ b/server/src/test/resources/keywhiz-test.yaml.h2
@@ -47,9 +47,9 @@ database:
   user: root
   properties:
     charSet: UTF-8
-  initialSize: 5
-  minSize: 5
-  maxSize: 5
+  initialSize: 2
+  minSize: 2
+  maxSize: 2
   # There is explicitly no password. Do not uncomment.
   # password:
 
@@ -60,9 +60,9 @@ readonlyDatabase:
   properties:
     charSet: UTF-8
   readOnlyByDefault: true
-  initialSize: 5
-  minSize: 5
-  maxSize: 5
+  initialSize: 1
+  minSize: 1
+  maxSize: 1
   # There is explicitly no password. Do not uncomment.
   # password:
 

--- a/server/src/test/resources/keywhiz-test.yaml.mysql
+++ b/server/src/test/resources/keywhiz-test.yaml.mysql
@@ -47,9 +47,9 @@ database:
   user: root
   properties:
     charSet: UTF-8
-  initialSize: 5
-  minSize: 5
-  maxSize: 5
+  initialSize: 2
+  minSize: 2
+  maxSize: 2
   # There is explicitly no password. Do not uncomment.
   # password:
 
@@ -60,9 +60,9 @@ readonlyDatabase:
   properties:
     charSet: UTF-8
   readOnlyByDefault: true
-  initialSize: 5
-  minSize: 5
-  maxSize: 5
+  initialSize: 1
+  minSize: 1
+  maxSize: 1
   # There is explicitly no password. Do not uncomment.
   # password:
 

--- a/server/src/test/resources/keywhiz-test.yaml.postgres
+++ b/server/src/test/resources/keywhiz-test.yaml.postgres
@@ -46,9 +46,9 @@ database:
   url: jdbc:postgresql://localhost/keywhizdb_test
   properties:
     charSet: UTF-8
-  initialSize: 5
-  minSize: 5
-  maxSize: 5
+  initialSize: 2
+  minSize: 2
+  maxSize: 2
   # There is explicitly no password. Do not uncomment.
   # password:
 
@@ -58,9 +58,9 @@ readonlyDatabase:
   properties:
     charSet: UTF-8
   readOnlyByDefault: true
-  initialSize: 5
-  minSize: 5
-  maxSize: 5
+  initialSize: 1
+  minSize: 1
+  maxSize: 1
   # There is explicitly no password. Do not uncomment.
   # password:
 


### PR DESCRIPTION
R: @alokmenghrajani 

* Use DAOFactory's to create DAOs
 
 * DAOFactory reduces passing around DSLContexts everywhere by allowing a
    factory to be injected and the DAO with correct DB backing to be
    instantiated. Particularly during a nested, transaction, the
    instantiated DAO will use the same underlying connection.
 * This makes a bunch of changes to dependencies (DAO factories instead of
    DAOs) and makes it more clear which constructors are `@Inject`'ed and which
    ones are manually called. Lots of DAO entries from ServiceModule are no
    longer needed.
 * Some tests that needed updating but were complex, like AclDAOTest, were
    simplified.

* Limit test database connections

 * Allowing fewer database connections in testing will hopefully bring
    forward more bugs where a queries is happening outside, but during
    another transaction. The read-write pool needs 2 connections for flyway
    migrations.

* Update jOOQ and guice

 * Make guice-testlib available to server.

* Consistent use of localhost in all dev configs