### PR TITLE
Fixes bug in AclDAO.getSecretSeriesFor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.7.5: 2015-06-08
+
+  * Fixes a bug which would cause the server to throw an exception in some
+    cases instead of returning a secret.
+
 v0.7.4: 2015-06-08
 
   * Added support for H2 and MySQL. H2 should make development easier since it's

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -403,6 +403,7 @@ public class AclDAO {
         .join(MEMBERSHIPS).on(ACCESSGRANTS.GROUPID.eq(MEMBERSHIPS.GROUPID))
         .join(CLIENTS).on(CLIENTS.ID.eq(MEMBERSHIPS.CLIENTID))
         .where(SECRETS.NAME.eq(name).and(CLIENTS.NAME.eq(client.getName())))
+        .limit(1)
         .fetchOneInto(SECRETS);
     return Optional.ofNullable(r).map(secretSeriesMapper::map);
   }

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -275,13 +275,16 @@ public class AclDAOTest {
 
     aclDAO.enrollClient(jooqContext.configuration(), client2.getId(), group1.getId());
     aclDAO.enrollClient(jooqContext.configuration(), client2.getId(), group3.getId());
+    aclDAO.enrollClient(jooqContext.configuration(), client2.getId(), group2.getId());
     aclDAO.allowAccess(jooqContext.configuration(), secret1.getId(), group1.getId());
+    aclDAO.allowAccess(jooqContext.configuration(), secret1.getId(), group2.getId());
 
     SecretSeries secretSeries = aclDAO.getSecretSeriesFor(jooqContext.configuration(), client2, secret1.getName())
         .orElseThrow(RuntimeException::new);
     assertThat(secretSeries).isEqualToIgnoringGivenFields(secretSeries1, "id");
 
     aclDAO.evictClient(jooqContext.configuration(), client2.getId(), group1.getId());
+    aclDAO.evictClient(jooqContext.configuration(), client2.getId(), group2.getId());
     assertThat(aclDAO.getSecretSeriesFor(jooqContext.configuration(), client2, secret1.getName()))
         .isEmpty();
 


### PR DESCRIPTION
If a client is allowed to access a secret via multiple groups, a bug in the code would throw an Exception. The issue was introduced when converting JDBI's @SingleValueResult into jOOQ's fetchOneInto.

I looked at all the other instances of fetchOneInto and it seems only one method needs this fix.