### PR TITLE
Update bcrypt dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,9 +260,9 @@
         <version>${jooq.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.mindrot</groupId>
-        <artifactId>jbcrypt</artifactId>
-        <version>0.3m</version>
+        <groupId>de.svenkubiak</groupId>
+        <artifactId>jBCrypt</artifactId>
+        <version>0.4</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -147,8 +147,8 @@
 
     <!-- Support for BCrypt -->
     <dependency>
-      <groupId>org.mindrot</groupId>
-      <artifactId>jbcrypt</artifactId>
+      <groupId>de.svenkubiak</groupId>
+      <artifactId>jBCrypt</artifactId>
     </dependency>
 
     <!-- Authentication support -->


### PR DESCRIPTION
R: @alokmenghrajani 

[Version 0.4](http://www.mindrot.org/projects/jBCrypt/news/rel04.html) fixes a integer overflow vulnerability. As used in Keywhiz,
this vulnerabilty is not present. Noneless, it's a good idea to update.