### PR TITLE
Fix docker container usage example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #   docker build --rm --force-rm -t square/keywhiz .
 #
 # Example usage:
-#   docker run square/keywhiz java -jar server/target/keywhiz-server-*-SNAPSHOT-shaded.jar server server/src/main/resources/keywhiz-development.yaml
+#   docker run square/keywhiz sh -c "java -jar server/target/keywhiz-server-*-SNAPSHOT-shaded.jar server server/src/main/resources/keywhiz-development.yaml"
 #
 FROM maven:3.3-jdk-8
 


### PR DESCRIPTION
Use `sh -c` otherwise `*` is expanded in the host and fails with something like:

```
no matches found: server/target/keywhiz-server-*-SNAPSHOT-shaded.jar
```

/cc @jfrazelle, because she said that you could trust her :stuck_out_tongue_winking_eye: 