### PR TITLE
Quote db entities as is

### DIFF
--- a/server/src/main/java/keywhiz/utility/DSLContexts.java
+++ b/server/src/main/java/keywhiz/utility/DSLContexts.java
@@ -40,12 +40,8 @@ public class DSLContexts {
     try (Connection conn = dataSource.getConnection()) {
       dialect = dialect(conn);
     }
-    if (dialect == SQLDialect.H2) {
-      return DSL.using(dataSource, SQLDialect.H2,
-            new Settings()
-                .withRenderSchema(false)
-                .withRenderNameStyle(RenderNameStyle.AS_IS));
+    return DSL.using(dataSource, dialect, new Settings()
+                                          .withRenderSchema(false)
+                                          .withRenderNameStyle(RenderNameStyle.AS_IS));
     }
-    return DSL.using(dataSource, dialect);
-  }
 }

--- a/server/src/main/java/keywhiz/utility/DSLContexts.java
+++ b/server/src/main/java/keywhiz/utility/DSLContexts.java
@@ -40,8 +40,9 @@ public class DSLContexts {
     try (Connection conn = dataSource.getConnection()) {
       dialect = dialect(conn);
     }
-    return DSL.using(dataSource, dialect, new Settings()
-                                          .withRenderSchema(false)
-                                          .withRenderNameStyle(RenderNameStyle.AS_IS));
+    return DSL.using(dataSource, dialect,
+            new Settings()
+                .withRenderSchema(false)
+                .withRenderNameStyle(RenderNameStyle.AS_IS));
     }
 }


### PR DESCRIPTION
I was unable to bring up a keywhiz on postgres, because the db-seed step tries to quote all db entities in uppercase, whereas the migrations bring them up lowercase.

It appears that this was an issue with h2 at some point as well. I don't have a mysql to test on, but I don't see any reason that this would break anything so I think we just want this behaviour for everything.