### PR TITLE
Replace postgres JDBC driver with pgjdbc-ng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.7.7: unreleased
+
+  * Replace postgres JDBC driver with pgjdbc-ng
+    (https://github.com/impossibl/pgjdbc-ng).
+
 v0.7.6: 2015-06-22
 
   * Updates bcrypt version to fix potential integer overflow issue,

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -31,8 +31,8 @@
     </dependency>
 
     <dependency>
-      <groupId>postgresql</groupId>
-      <artifactId>postgresql</artifactId>
+      <groupId>com.impossibl.pgjdbc-ng</groupId>
+      <artifactId>pgjdbc-ng</artifactId>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
@@ -53,9 +53,9 @@
       </activation>
       <properties>
         <skipResetDatabase>false</skipResetDatabase>
-        <db.driver>org.postgresql.Driver</db.driver>
-        <db.create-url>jdbc:postgresql:postgres</db.create-url>
-        <db.migrate-url>jdbc:postgresql:keywhizdb_test</db.migrate-url>
+        <db.driver>com.impossibl.postgres.jdbc.PGDriver</db.driver>
+        <db.create-url>jdbc:pgsql:postgres</db.create-url>
+        <db.migrate-url>jdbc:pgsql:keywhizdb_test</db.migrate-url>
         <db.username>${user.name}</db.username>
         <db.migrations-path>postgres/migration</db.migrations-path>
         <jooq.dialect>org.jooq.util.postgres.PostgresDatabase</jooq.dialect>
@@ -137,6 +137,7 @@
         </executions>
 
         <configuration>
+          <driver>${db.driver}</driver>
           <url>${db.migrate-url}</url>
           <user>${db.username}</user>
           <locations>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <powermock.version>1.6.2</powermock.version>
     <slf4j.version>1.7.12</slf4j.version>
     <findbugs.version>3.0.0</findbugs.version>
-    <postgres.version>9.1-901-1.jdbc4</postgres.version>
+    <pgjdbc-ng.version>0.5</pgjdbc-ng.version>
     <mysql.version>5.1.35</mysql.version>
   </properties>
 
@@ -295,9 +295,9 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
-        <groupId>postgresql</groupId>
-        <artifactId>postgresql</artifactId>
-        <version>${postgres.version}</version>
+        <groupId>com.impossibl.pgjdbc-ng</groupId>
+        <artifactId>pgjdbc-ng</artifactId>
+        <version>${pgjdbc-ng.version}</version>
       </dependency>
       <dependency>
         <groupId>com.h2database</groupId>
@@ -562,9 +562,9 @@ Place the jars in this directory: `/usr/libexec/java_home -v
           <version>1.5</version>
           <dependencies>
             <dependency>
-              <groupId>postgresql</groupId>
-              <artifactId>postgresql</artifactId>
-              <version>${postgres.version}</version>
+              <groupId>com.impossibl.pgjdbc-ng</groupId>
+              <artifactId>pgjdbc-ng</artifactId>
+              <version>${pgjdbc-ng.version}</version>
             </dependency>
             <dependency>
               <groupId>mysql</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -99,8 +99,8 @@
 
     <!-- Database -->
     <dependency>
-      <groupId>postgresql</groupId>
-      <artifactId>postgresql</artifactId>
+      <groupId>com.impossibl.pgjdbc-ng</groupId>
+      <artifactId>pgjdbc-ng</artifactId>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/server/src/main/resources/keywhiz-development.yaml.postgres
+++ b/server/src/main/resources/keywhiz-development.yaml.postgres
@@ -52,8 +52,8 @@ logging:
 environment: development
 
 database:
-  driverClass: org.postgresql.Driver
-  url: jdbc:postgresql://localhost/keywhizdb_development
+  driverClass: com.impossibl.postgres.jdbc.PGDriver
+  url: jdbc:pgsql://localhost/keywhizdb_development
   properties:
     charSet: UTF-8
   initialSize: 10
@@ -63,8 +63,8 @@ database:
   # password:
 
 readonlyDatabase:
-  driverClass: org.postgresql.Driver
-  url: jdbc:postgresql://localhost/keywhizdb_development
+  driverClass: com.impossibl.postgres.jdbc.PGDriver
+  url: jdbc:pgsql://localhost/keywhizdb_development
   properties:
     charSet: UTF-8
   readOnlyByDefault: true

--- a/server/src/test/resources/keywhiz-test.yaml.postgres
+++ b/server/src/test/resources/keywhiz-test.yaml.postgres
@@ -42,8 +42,8 @@ logging:
 environment: testing
 
 database:
-  driverClass: org.postgresql.Driver
-  url: jdbc:postgresql://localhost/keywhizdb_test
+  driverClass: com.impossibl.postgres.jdbc.PGDriver
+  url: jdbc:pgsql://localhost/keywhizdb_test
   properties:
     charSet: UTF-8
   initialSize: 2
@@ -53,8 +53,8 @@ database:
   # password:
 
 readonlyDatabase:
-  driverClass: org.postgresql.Driver
-  url: jdbc:postgresql://localhost/keywhizdb_test
+  driverClass: com.impossibl.postgres.jdbc.PGDriver
+  url: jdbc:pgsql://localhost/keywhizdb_test
   properties:
     charSet: UTF-8
   readOnlyByDefault: true


### PR DESCRIPTION
@alokmenghrajani 

pgjdbc-ng is a more up-to-date driver than the official postgres driver.
In particular, prepared statements can be cached.