### PR TITLE
Uses empty string for missing descriptions

### DIFF
--- a/api/src/main/java/keywhiz/api/TemplatedSecretsGeneratorRequest.java
+++ b/api/src/main/java/keywhiz/api/TemplatedSecretsGeneratorRequest.java
@@ -19,9 +19,10 @@ package keywhiz.api;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.hibernate.validator.constraints.NotEmpty;
+
+import static com.google.common.base.Strings.nullToEmpty;
 
 /**
  * Request message to create a templated secret.
@@ -33,7 +34,6 @@ public class TemplatedSecretsGeneratorRequest {
   @NotEmpty
   private final String template;
 
-  @Nullable
   private final String description;
 
   private final boolean withVersion;
@@ -49,7 +49,7 @@ public class TemplatedSecretsGeneratorRequest {
       @JsonProperty("metadata") @Nullable ImmutableMap<String, String> metadata) {
     this.template = template;
     this.name = name;
-    this.description = description;
+    this.description = nullToEmpty(description);
     this.withVersion = withVersion;
     this.metadata = metadata;
   }
@@ -81,8 +81,8 @@ public class TemplatedSecretsGeneratorRequest {
     return template;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public boolean isWithVersion() {

--- a/server/src/main/java/keywhiz/generators/TemplatedSecretGenerator.java
+++ b/server/src/main/java/keywhiz/generators/TemplatedSecretGenerator.java
@@ -69,7 +69,7 @@ public class TemplatedSecretGenerator extends SecretGenerator<TemplatedSecretsGe
 
     SecretController.SecretBuilder builder =
         secretController.builder(secretName, secretContent, creatorName)
-        .withDescription(request.getDescription().orElse(""))
+        .withDescription(request.getDescription())
         .withMetadata(request.getMetadata())
         .withType("templated")
         .withGenerationOptions(ImmutableMap.of("template", request.getTemplate()));

--- a/server/src/main/java/keywhiz/service/daos/ClientDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/ClientDAO.java
@@ -41,7 +41,7 @@ public class ClientDAO {
     this.clientMapper = clientMapper;
   }
 
-  public long createClient(String name, String user, Optional<String> description) {
+  public long createClient(String name, String user, String description) {
     ClientsRecord r = dslContext.newRecord(CLIENTS);
 
     OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
@@ -51,7 +51,7 @@ public class ClientDAO {
     r.setCreatedat(now);
     r.setUpdatedby(user);
     r.setUpdatedat(now);
-    r.setDescription(description.orElse(null));
+    r.setDescription(description);
     r.setEnabled(true);
     r.setAutomationallowed(false);
     r.store();

--- a/server/src/main/java/keywhiz/service/daos/GroupDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/GroupDAO.java
@@ -41,7 +41,7 @@ public class GroupDAO {
     this.groupMapper = groupMapper;
   }
 
-  public long createGroup(String name, String creator, Optional<String> description) {
+  public long createGroup(String name, String creator, String description) {
     GroupsRecord r = dslContext.newRecord(GROUPS);
 
     OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
@@ -51,7 +51,7 @@ public class GroupDAO {
     r.setCreatedat(now);
     r.setUpdatedby(creator);
     r.setUpdatedat(now);
-    r.setDescription(description.orElse(null));
+    r.setDescription(description);
     r.store();
 
     return r.getId();

--- a/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
@@ -115,7 +115,7 @@ public class ClientAuthFactory {
        */
       // TODO(justin): Consider making this behavior configurable.
       long clientId = clientDAO.createClient(name, "automatic",
-          Optional.of("Client created automatically from valid certificate authentication"));
+          "Client created automatically from valid certificate authentication");
       return Optional.of(clientDAO.getClientById(clientId).get());
     }
   }

--- a/server/src/main/java/keywhiz/service/resources/AutomationClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationClientResource.java
@@ -155,8 +155,7 @@ public class AutomationClientResource {
       throw new ConflictException("Client name already exists.");
     }
 
-    long id = clientDAO.createClient(clientRequest.name, automationClient.getName(),
-        Optional.empty());
+    long id = clientDAO.createClient(clientRequest.name, automationClient.getName(), "");
     client = clientDAO.getClientById(id);
 
     return ClientDetailResponse.fromClient(client.get(), ImmutableList.of(), ImmutableList.of());

--- a/server/src/main/java/keywhiz/service/resources/AutomationGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationGroupResource.java
@@ -48,6 +48,7 @@ import keywhiz.service.exceptions.ConflictException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Strings.nullToEmpty;
 import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -156,7 +157,7 @@ public class AutomationGroupResource {
     }
 
     long id = groupDAO.createGroup(groupRequest.name, automationClient.getName(),
-        Optional.ofNullable(groupRequest.description));
+        nullToEmpty(groupRequest.description));
     return groupDAO.getGroupById(id).get();
   }
 

--- a/server/src/main/java/keywhiz/service/resources/AutomationSecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/AutomationSecretResource.java
@@ -50,6 +50,7 @@ import org.jooq.exception.DataAccessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -98,11 +99,8 @@ public class AutomationSecretResource {
       @Valid CreateSecretRequest request) {
 
     SecretController.SecretBuilder builder = secretController.builder(request.name, request.content,
-        automationClient.getName());
-
-    if (request.description != null) {
-      builder.withDescription(request.description);
-    }
+        automationClient.getName())
+        .withDescription(nullToEmpty(request.description));
 
     if (request.withVersion) {
       builder.withVersion(VersionGenerator.now().toHex());

--- a/server/src/main/java/keywhiz/service/resources/ClientsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/ClientsResource.java
@@ -130,7 +130,7 @@ public class ClientsResource {
 
     long clientId;
     try {
-      clientId = clientDAO.createClient(createClientRequest.name, user.getName(), Optional.empty());
+      clientId = clientDAO.createClient(createClientRequest.name, user.getName(), "");
     } catch (DataAccessException e) {
       logger.warn("Cannot create client {}: {}", createClientRequest.name, e);
       throw new ConflictException("Conflict creating client.");

--- a/server/src/main/java/keywhiz/service/resources/GroupsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/GroupsResource.java
@@ -52,6 +52,7 @@ import keywhiz.service.daos.GroupDAO.GroupDAOFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Strings.nullToEmpty;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 /**
@@ -129,7 +130,7 @@ public class GroupsResource {
     }
 
     long groupId = groupDAO.createGroup(request.name, user.getName(),
-        Optional.ofNullable(request.description));
+        nullToEmpty(request.description));
     URI uri = UriBuilder.fromResource(GroupsResource.class).build(groupId);
     return Response
         .created(uri)

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -84,19 +84,19 @@ public class AclDAOTest {
     jooqContext.delete(SECRETS).execute();
     jooqContext.delete(SECRETS_CONTENT).execute();
 
-    long id = clientDAO.createClient("client1", "creator", Optional.empty());
+    long id = clientDAO.createClient("client1", "creator", "");
     client1 = clientDAO.getClientById(id).get();
 
-    id = clientDAO.createClient("client2", "creator", Optional.empty());
+    id = clientDAO.createClient("client2", "creator", "");
     client2 = clientDAO.getClientById(id).get();
 
-    id = groupDAO.createGroup("group1", "creator", Optional.empty());
+    id = groupDAO.createGroup("group1", "creator", "");
     group1 = groupDAO.getGroupById(id).get();
 
-    id = groupDAO.createGroup("group2", "creator", Optional.empty());
+    id = groupDAO.createGroup("group2", "creator", "");
     group2 = groupDAO.getGroupById(id).get();
 
-    id = groupDAO.createGroup("group3", "creator", Optional.empty());
+    id = groupDAO.createGroup("group3", "creator", "");
     group3 = groupDAO.getGroupById(id).get();
 
     SecretFixtures secretFixtures = SecretFixtures.using(secretDAOFactory.readwrite());

--- a/server/src/test/java/keywhiz/service/daos/ClientDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/ClientDAOTest.java
@@ -19,7 +19,6 @@ package keywhiz.service.daos;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
-import java.util.Optional;
 import java.util.Set;
 import javax.inject.Inject;
 import keywhiz.TestDBRule;
@@ -65,7 +64,7 @@ public class ClientDAOTest {
 
   @Test public void createClient() {
     int before = tableSize();
-    clientDAO.createClient("newClient", "creator", Optional.empty());
+    clientDAO.createClient("newClient", "creator", "");
     Client newClient = clientDAO.getClient("newClient").orElseThrow(RuntimeException::new);
 
     assertThat(tableSize()).isEqualTo(before + 1);
@@ -73,7 +72,7 @@ public class ClientDAOTest {
   }
 
   @Test public void createClientReturnsId() {
-    long id = clientDAO.createClient("newClientWithSameId", "creator2", Optional.empty());
+    long id = clientDAO.createClient("newClientWithSameId", "creator2", "");
     Client clientById = clientDAO.getClient("newClientWithSameId")
         .orElseThrow(RuntimeException::new);
     assertThat(clientById.getId()).isEqualTo(id);

--- a/server/src/test/java/keywhiz/service/daos/GroupDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/GroupDAOTest.java
@@ -20,7 +20,6 @@ import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import java.util.List;
-import java.util.Optional;
 import javax.inject.Inject;
 import keywhiz.TestDBRule;
 import keywhiz.api.model.Group;
@@ -66,7 +65,7 @@ public class GroupDAOTest {
 
   @Test public void createGroup() {
     int before = tableSize();
-    groupDAO.createGroup("newGroup", "creator3", Optional.empty());
+    groupDAO.createGroup("newGroup", "creator3", "");
     assertThat(tableSize()).isEqualTo(before + 1);
 
     List<String> names = groupDAO.getGroups()
@@ -107,7 +106,7 @@ public class GroupDAOTest {
 
   @Test(expected = DataAccessException.class)
   public void willNotCreateDuplicateGroup() throws Exception {
-    groupDAO.createGroup("group1", "creator1", Optional.empty());
+    groupDAO.createGroup("group1", "creator1", "");
   }
 
   private int tableSize() {

--- a/server/src/test/java/keywhiz/service/resources/AutomationClientResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationClientResourceTest.java
@@ -81,7 +81,7 @@ public class AutomationClientResourceTest {
     CreateClientRequest request = new CreateClientRequest("client");
 
     when(clientDAO.getClient("client")).thenReturn(Optional.empty());
-    when(clientDAO.createClient("client", automation.getName(), Optional.empty())).thenReturn(543L);
+    when(clientDAO.createClient("client", automation.getName(), "")).thenReturn(543L);
     when(clientDAO.getClientById(543L)).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(client)).thenReturn(ImmutableSet.of());
 
@@ -98,7 +98,7 @@ public class AutomationClientResourceTest {
     CreateClientRequest request = new CreateClientRequest("client");
 
     when(clientDAO.getClient("client")).thenReturn(Optional.empty());
-    when(clientDAO.createClient("client", automation.getName(), Optional.empty())).thenReturn(543L);
+    when(clientDAO.createClient("client", automation.getName(), "")).thenReturn(543L);
     when(clientDAO.getClientById(543L)).thenReturn(Optional.of(client));
 
     ClientDetailResponse response = ClientDetailResponse.fromClient(client, ImmutableList.of(),

--- a/server/src/test/java/keywhiz/service/resources/AutomationGroupResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationGroupResourceTest.java
@@ -105,7 +105,7 @@ public class AutomationGroupResourceTest {
     CreateGroupRequest request = new CreateGroupRequest("testGroup", null);
 
     when(groupDAO.getGroup("testGroup")).thenReturn(Optional.empty());
-    when(groupDAO.createGroup(group.getName(), automation.getName(), Optional.empty())).thenReturn(500L);
+    when(groupDAO.createGroup(group.getName(), automation.getName(), "")).thenReturn(500L);
     when(groupDAO.getGroupById(500L)).thenReturn(Optional.of(group));
     Group responseGroup = resource.createGroup(automation, request);
 

--- a/server/src/test/java/keywhiz/service/resources/AutomationSecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/AutomationSecretResourceTest.java
@@ -66,6 +66,7 @@ public class AutomationSecretResourceTest {
     resource = new AutomationSecretResource(secretController, secretSeriesDAO, aclDAO);
 
     when(secretController.builder(anyString(), anyString(), anyString())).thenReturn(secretBuilder);
+    when(secretBuilder.withDescription(anyString())).thenReturn(secretBuilder);
   }
 
   @Test

--- a/server/src/test/java/keywhiz/service/resources/ClientsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/ClientsResourceTest.java
@@ -73,7 +73,7 @@ public class ClientsResourceTest {
 
   @Test public void createsClient() {
     CreateClientRequest request = new CreateClientRequest("new-client-name");
-    when(clientDAO.createClient("new-client-name", "user", Optional.empty())).thenReturn(42L);
+    when(clientDAO.createClient("new-client-name", "user", "")).thenReturn(42L);
     when(clientDAO.getClientById(42L)).thenReturn(Optional.of(client));
     when(aclDAO.getSanitizedSecretsFor(client)).thenReturn(ImmutableSet.of());
 

--- a/server/src/test/java/keywhiz/service/resources/GroupsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/GroupsResourceTest.java
@@ -70,7 +70,7 @@ public class GroupsResourceTest {
   @Test public void createsGroup() {
     CreateGroupRequest request = new CreateGroupRequest("newGroup", "description");
     when(groupDAO.getGroup("newGroup")).thenReturn(Optional.empty());
-    when(groupDAO.createGroup("newGroup", "user", Optional.of("description"))).thenReturn(55L);
+    when(groupDAO.createGroup("newGroup", "user", "description")).thenReturn(55L);
     when(groupDAO.getGroupById(55L)).thenReturn(Optional.of(group));
     when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of());
 


### PR DESCRIPTION
There has been no value in representing descriptions as fields that may
or may not be present (i.e. Optional), so this PR removed any Optional
treatment of descriptions. Similarly, null descriptions are not a useful
value either. As just a display/infomative metadata, an empty string
provides more benefit than null. This PR moves null descriptions to
empty strings.

R: @alokmenghrajani 