### PR TITLE
Use seconds instead of OffsetDateTime in api v2.

### DIFF
--- a/api/src/main/java/keywhiz/api/automation/v2/ClientDetailResponseV2.java
+++ b/api/src/main/java/keywhiz/api/automation/v2/ClientDetailResponseV2.java
@@ -3,7 +3,6 @@ package keywhiz.api.automation.v2;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import java.time.OffsetDateTime;
 import keywhiz.api.model.Client;
 
 @AutoValue public abstract class ClientDetailResponseV2 {
@@ -13,8 +12,8 @@ import keywhiz.api.model.Client;
     return new AutoValue_ClientDetailResponseV2(
         client.getName(),
         client.getDescription(),
-        client.getCreatedAt(),
-        client.getUpdatedAt(),
+        client.getCreatedAt().toEpochSecond(),
+        client.getUpdatedAt().toEpochSecond(),
         client.getCreatedBy(),
         client.getUpdatedBy());
   }
@@ -26,17 +25,17 @@ import keywhiz.api.model.Client;
   @JsonCreator public static ClientDetailResponseV2 fromParts(
       @JsonProperty("name") String name,
       @JsonProperty("description") String description,
-      @JsonProperty("creationDate") OffsetDateTime creationDate,
-      @JsonProperty("updateDate") OffsetDateTime updateDate,
+      @JsonProperty("createdAtSeconds") long createdAtSeconds,
+      @JsonProperty("updatedAtSeconds") long updatedAtSeconds,
       @JsonProperty("createdBy") String createdBy,
       @JsonProperty("updatedBy") String updatedBy) {
-    return new AutoValue_ClientDetailResponseV2(name, description, creationDate, updateDate, createdBy, updatedBy);
+    return new AutoValue_ClientDetailResponseV2(name, description, createdAtSeconds, updatedAtSeconds, createdBy, updatedBy);
   }
 
   @JsonProperty("name") public abstract String name();
   @JsonProperty("description") public abstract String description();
-  @JsonProperty("creationDate") public abstract OffsetDateTime creationDate();
-  @JsonProperty("updateDate") public abstract OffsetDateTime updateDate();
+  @JsonProperty("createdAtSeconds") public abstract long createdAtSeconds();
+  @JsonProperty("updatedAtSeconds") public abstract long updatedAtSeconds();
   @JsonProperty("createdBy") public abstract String createdBy();
   @JsonProperty("updatedBy") public abstract String updatedBy();
 }

--- a/api/src/main/java/keywhiz/api/automation/v2/GroupDetailResponseV2.java
+++ b/api/src/main/java/keywhiz/api/automation/v2/GroupDetailResponseV2.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
-import java.time.OffsetDateTime;
 import keywhiz.api.model.Group;
 
 @AutoValue public abstract class GroupDetailResponseV2 {
@@ -18,8 +17,8 @@ import keywhiz.api.model.Group;
     // intended to be package-private
     abstract Builder name(String name);
     abstract Builder description(String description);
-    abstract Builder creationDate(OffsetDateTime dateTime);
-    abstract Builder updateDate(OffsetDateTime dateTime);
+    abstract Builder createdAtSeconds(long createdAtSeconds);
+    abstract Builder updatedAtSeconds(long updatedAtSeconds);
     abstract Builder createdBy(String person);
     abstract Builder updatedBy(String person);
     abstract Builder secrets(ImmutableSet<String> secrets);
@@ -29,8 +28,8 @@ import keywhiz.api.model.Group;
       return this
           .name(group.getName())
           .description(group.getDescription())
-          .creationDate(group.getCreatedAt())
-          .updateDate(group.getUpdatedAt())
+          .createdAtSeconds(group.getCreatedAt().toEpochSecond())
+          .updatedAtSeconds(group.getUpdatedAt().toEpochSecond())
           .createdBy(group.getCreatedBy())
           .updatedBy(group.getUpdatedBy());
     }
@@ -53,8 +52,8 @@ import keywhiz.api.model.Group;
   @JsonCreator public static GroupDetailResponseV2 fromParts(
       @JsonProperty("name") String name,
       @JsonProperty("description") String description,
-      @JsonProperty("creationDate") OffsetDateTime creationDate,
-      @JsonProperty("updateDate") OffsetDateTime updateDate,
+      @JsonProperty("createdAtSeconds") long createdAtSeconds,
+      @JsonProperty("updatedAtSeconds") long updatedAtSeconds,
       @JsonProperty("createdBy") String createdBy,
       @JsonProperty("updatedBy") String updatedBy,
       @JsonProperty("secrets") Iterable<String> secrets,
@@ -62,8 +61,8 @@ import keywhiz.api.model.Group;
     return builder()
         .name(name)
         .description(description)
-        .creationDate(creationDate)
-        .updateDate(updateDate)
+        .createdAtSeconds(createdAtSeconds)
+        .updatedAtSeconds(updatedAtSeconds)
         .createdBy(createdBy)
         .updatedBy(updatedBy)
         .secrets(secrets)
@@ -73,8 +72,8 @@ import keywhiz.api.model.Group;
 
   @JsonProperty("name") public abstract String name();
   @JsonProperty("description") public abstract String description();
-  @JsonProperty("creationDate") public abstract OffsetDateTime creationDate();
-  @JsonProperty("updateDate") public abstract OffsetDateTime updateDate();
+  @JsonProperty("creationDate") public abstract long createdAtSeconds();
+  @JsonProperty("updateDate") public abstract long updatedAtSeconds();
   @JsonProperty("createdBy") public abstract String createdBy();
   @JsonProperty("updatedBy") public abstract String updatedBy();
   @JsonProperty("secrets") public abstract ImmutableSet<String> secrets();

--- a/api/src/main/java/keywhiz/api/automation/v2/SecretDetailResponseV2.java
+++ b/api/src/main/java/keywhiz/api/automation/v2/SecretDetailResponseV2.java
@@ -7,7 +7,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.UnsignedLong;
-import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +40,7 @@ import static keywhiz.api.model.Secret.decodedLength;
     public abstract Builder name(String name);
     public abstract Builder content(String secret);
     public abstract Builder description(String description);
-    public abstract Builder creationDate(OffsetDateTime dateTime);
+    public abstract Builder createdAtSeconds(long createdAt);
     public abstract Builder createdBy(String person);
     public abstract Builder type(@Nullable String type);
 
@@ -57,7 +56,7 @@ import static keywhiz.api.model.Secret.decodedLength;
       return this
           .name(series.name())
           .description(series.description())
-          .creationDate(series.createdAt())
+          .createdAtSeconds(series.createdAt().toEpochSecond())
           .createdBy(series.createdBy())
           .type(series.type().orElse(null));
     }
@@ -68,7 +67,7 @@ import static keywhiz.api.model.Secret.decodedLength;
           .versions(ImmutableList.of(secret.getVersion()))
           .description(secret.getDescription())
           .content(secret.getSecret())
-          .creationDate(secret.getCreatedAt())
+          .createdAtSeconds(secret.getCreatedAt().toEpochSecond())
           .createdBy(secret.getCreatedBy())
           .type(secret.getType().orElse(null))
           .metadata(secret.getMetadata());
@@ -93,7 +92,7 @@ import static keywhiz.api.model.Secret.decodedLength;
       @JsonProperty("description") @Nullable String description,
       @JsonProperty("content") String content,
       @JsonProperty("size") UnsignedLong size,
-      @JsonProperty("creationDate") OffsetDateTime creationDate,
+      @JsonProperty("createdAtSeconds") long createdAtSeconds,
       @JsonProperty("createdBy") String createdBy,
       @JsonProperty("type") @Nullable String type,
       @JsonProperty("metadata") @Nullable Map<String, String> metadata) {
@@ -103,7 +102,7 @@ import static keywhiz.api.model.Secret.decodedLength;
         .description(nullToEmpty(description))
         .content(content)
         .size(size)
-        .creationDate(creationDate)
+        .createdAtSeconds(createdAtSeconds)
         .createdBy(createdBy)
         .type(type)
         .metadata(metadata == null ? ImmutableMap.of() : ImmutableMap.copyOf(metadata))
@@ -116,7 +115,7 @@ import static keywhiz.api.model.Secret.decodedLength;
   @JsonProperty("description") public abstract String description();
   @JsonProperty("content") public abstract String content();
   @JsonProperty("size") public abstract UnsignedLong size();
-  @JsonProperty("creationDate") public abstract OffsetDateTime creationDate();
+  @JsonProperty("createdAtSeconds") public abstract long createdAtSeconds();
   @JsonProperty("createdBy") public abstract String createdBy();
   @JsonProperty("type") @Nullable public abstract String type();
   @JsonProperty("metadata") public abstract ImmutableMap<String, String> metadata();
@@ -128,7 +127,7 @@ import static keywhiz.api.model.Secret.decodedLength;
         .add("description", description())
         .add("content", "[REDACTED]")
         .add("size", size())
-        .add("creationDate", creationDate())
+        .add("createdAtSeconds", createdAtSeconds())
         .add("createdBy", createdBy())
         .add("type", type())
         .add("metadata", metadata())

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/ClientResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/ClientResourceTest.java
@@ -183,7 +183,7 @@ public class ClientResourceTest {
     ClientDetailResponseV2 clientDetail = modify("client9", request);
     assertThat(clientDetail.name()).isEqualTo("client9b");
     assertThat(clientDetail).isEqualToIgnoringGivenFields(originalClient, "name", "updateDate");
-    assertThat(clientDetail.updateDate()).isGreaterThan(originalClient.updateDate());
+    assertThat(clientDetail.updatedAtSeconds()).isGreaterThan(originalClient.updatedAtSeconds());
   }
 
   private Response createGroup(String name) throws IOException {


### PR DESCRIPTION
Seconds since epoch are much nicer to deal with in an API. It avoids the
need to correctly format and parse date/time strings across different
programming languages. It also takes less space on the wire.

note: JSR-310 makes it easier to use seconds instead of milliseconds.