### PR TITLE
Register Jackson JavaTimeModule in cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+sudo: required
+dist: trusty
 
 # Experimental group for MySQL 5.6
 group: dev
@@ -10,6 +12,8 @@ env:
   - UI_DIR=ui
 
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install mysql-server-5.6 mysql-client-5.6
   # Extra Chrome setup from: http://stackoverflow.com/questions/19255976
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0

--- a/cli/src/main/java/keywhiz/cli/CliModule.java
+++ b/cli/src/main/java/keywhiz/cli/CliModule.java
@@ -19,6 +19,7 @@ import com.beust.jcommander.JCommander;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
@@ -71,6 +72,7 @@ public class CliModule extends AbstractModule {
      */
     ObjectMapper objectMapper = Jackson.newObjectMapper();
     objectMapper.registerModule(new Jdk8Module());
+    objectMapper.registerModules(new JavaTimeModule());
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     return objectMapper;
   }


### PR DESCRIPTION
In commit 9c33fdf344ce8baf0df1b282037235de642c88b7 the deprecated JSR310Module
was removed, instead of being replaced with JavaTimeModule.  This results in
being unable to deserialize ApiDate objects (because it calls the OffsetDateTime
deserializer), and so some keywhiz.cli commands don't work without this fix.