### PR TITLE
Add ability to fetch only the list of secret names

### DIFF
--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -21,13 +21,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import keywhiz.api.ApiDate;
-
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import keywhiz.api.ApiDate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.nullToEmpty;
@@ -56,6 +54,10 @@ public abstract class SanitizedSecret {
     return new AutoValue_SanitizedSecret(id, name, version, nullToEmpty(description), createdAt,
         nullToEmpty(createdBy), updatedAt, nullToEmpty(updatedBy), meta, Optional.ofNullable(type),
         genOptions);
+  }
+
+  public static SanitizedSecret of(long id, String name) {
+    return of(id, name, "", null, new ApiDate(0), null, new ApiDate(0), null, null, null, null);
   }
 
   public static SanitizedSecret fromSecretSeriesAndContent(SecretSeriesAndContent seriesAndContent) {

--- a/client/src/main/java/keywhiz/client/KeywhizClient.java
+++ b/client/src/main/java/keywhiz/client/KeywhizClient.java
@@ -140,7 +140,7 @@ public class KeywhizClient {
   }
 
   public List<SanitizedSecret> allSecrets() throws IOException {
-    String response = httpGet(baseUrl.resolve("/admin/secrets"));
+    String response = httpGet(baseUrl.resolve("/admin/secrets?nameOnly=1"));
     return mapper.readValue(response, new TypeReference<List<SanitizedSecret>>() {});
   }
 

--- a/server/src/main/java/keywhiz/service/daos/SecretController.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretController.java
@@ -74,6 +74,14 @@ public class SecretController {
         .collect(toList());
   }
 
+  /** @return all existing sanitized secrets. */
+  public List<SanitizedSecret> getSecretsNameOnly() {
+    return secretDAO.getSecretsNameOnly()
+        .stream()
+        .map(s -> SanitizedSecret.of(s.getKey(), s.getValue()))
+        .collect(toList());
+  }
+
   /** @return all versions for this secret name. */
   public List<String> getVersionsForName(String name) {
     checkArgument(!name.isEmpty());

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -18,14 +18,17 @@ package keywhiz.service.daos;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javafx.util.Pair;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import keywhiz.api.model.Secret;
 import keywhiz.api.model.SecretContent;
 import keywhiz.api.model.SecretSeries;
 import keywhiz.api.model.SecretSeriesAndContent;
+import keywhiz.jooq.tables.Secrets;
 import keywhiz.service.config.Readonly;
 import keywhiz.service.daos.SecretContentDAO.SecretContentDAOFactory;
 import keywhiz.service.daos.SecretSeriesDAO.SecretSeriesDAOFactory;
@@ -35,6 +38,7 @@ import org.jooq.impl.DSL;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static keywhiz.jooq.tables.Secrets.SECRETS;
 
 /**
  * Primary class to interact with {@link Secret}s.
@@ -203,6 +207,18 @@ public class SecretDAO {
       return secretsBuilder.build();
     });
   }
+
+  /**
+   * @return A list of id, name
+   */
+  public ImmutableList<Pair<Long, String>> getSecretsNameOnly() {
+    List<Pair<Long, String>> results = dslContext.select(SECRETS.ID, SECRETS.NAME)
+        .from(SECRETS)
+        .fetchInto(Secrets.SECRETS)
+        .map(r -> new Pair<>(r.getId(), r.getName()));
+    return ImmutableList.copyOf(results);
+  }
+
 
   /**
    * Deletes the series and all associated version of the given secret series name.

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -89,13 +89,14 @@ public class SecretsResource {
   }
 
   /**
-   * Retrieve Secret by a specified name and version, or all Secrets name not given
+   * Retrieve Secret by a specified name and version, or all Secrets if name is not given
    *
    * @excludeParams user
    * @optionalParams name
    * @param name the name of the Secret to retrieve, if provided
    * @optionalParams version
    * @param version the version of the Secret to retrieve, if provided
+   * @param nameOnly if set, the result only contains the id and name for the secrets.
    *
    * @description Returns a single Secret or a set of all Secrets for this user.
    * Used by Keywhiz CLI and the web ui.
@@ -104,9 +105,14 @@ public class SecretsResource {
    */
   @GET
   public Response findSecrets(@Auth User user, @DefaultValue("") @QueryParam("name") String name,
-      @DefaultValue("") @QueryParam("version") String version) {
+      @DefaultValue("") @QueryParam("version") String version,
+      @DefaultValue("") @QueryParam("nameOnly") String nameOnly) {
     if (name.isEmpty()) {
-      return Response.ok().entity(listSecrets(user)).build();
+      if (nameOnly.isEmpty()) {
+        return Response.ok().entity(listSecrets(user)).build();
+      } else {
+        return Response.ok().entity(listSecretsNameOnly(user)).build();
+      }
     }
     return Response.ok().entity(retrieveSecret(user, name, version)).build();
   }
@@ -114,6 +120,11 @@ public class SecretsResource {
   protected List<SanitizedSecret> listSecrets(@Auth User user) {
     logger.info("User '{}' listing secrets.", user);
     return secretController.getSanitizedSecrets();
+  }
+
+  protected List<SanitizedSecret> listSecretsNameOnly(@Auth User user) {
+    logger.info("User '{}' listing secrets.", user);
+    return secretController.getSecretsNameOnly();
   }
 
   protected SanitizedSecret retrieveSecret(@Auth User user, String name, String version) {


### PR DESCRIPTION
With >10k secrets, this significantly improves the time it takes the CLI to list all the secrets. The
results however do not contain individual entries for versions.