### PR TITLE
Rename variables which hide the field declared

### DIFF
--- a/api/src/test/java/keywhiz/api/AutomationSecretResponseTest.java
+++ b/api/src/test/java/keywhiz/api/AutomationSecretResponseTest.java
@@ -61,12 +61,12 @@ public class AutomationSecretResponseTest {
 
   @Test
   public void serializesCorrectly() throws Exception {
-    String secret = "YXNkZGFz";
+    String secretVar = "YXNkZGFz";
 
     AutomationSecretResponse automationSecretResponse = AutomationSecretResponse.create(
         0,
         "Database_Password",
-        secret,
+        secretVar,
         ApiDate.parse("2011-09-29T15:46:00.000Z"),
         false,
         ImmutableMap.of(),
@@ -77,7 +77,7 @@ public class AutomationSecretResponseTest {
     AutomationSecretResponse automationSecretResponseWithVersion = AutomationSecretResponse.create(
         33,
         "General_Password..0be68f903f8b7d86",
-        secret,
+        secretVar,
         ApiDate.parse("2011-09-29T15:46:00.000Z"),
         true,
         ImmutableMap.of(),
@@ -88,7 +88,7 @@ public class AutomationSecretResponseTest {
     AutomationSecretResponse automationSecretResponseWithMetadata = AutomationSecretResponse.create(
         66,
         "Nobody_PgPass",
-        secret,
+        secretVar,
         ApiDate.parse("2011-09-29T15:46:00.000Z"),
         false,
         ImmutableMap.of("mode", "0400", "owner", "nobody"),

--- a/api/src/test/java/keywhiz/api/SecretDeliveryResponseTest.java
+++ b/api/src/test/java/keywhiz/api/SecretDeliveryResponseTest.java
@@ -54,12 +54,12 @@ public class SecretDeliveryResponseTest {
 
   @Test
   public void serializesCorrectly() throws Exception {
-    String secret = "YXNkZGFz";
+    String secretVar = "YXNkZGFz";
 
     SecretDeliveryResponse secretDeliveryResponse = new SecretDeliveryResponse(
         "Database_Password",
-        secret,
-        decodedLength(secret),
+        secretVar,
+        decodedLength(secretVar),
         ApiDate.parse("2011-09-29T15:46:00.000Z"),
         false,
         ImmutableMap.of());
@@ -68,8 +68,8 @@ public class SecretDeliveryResponseTest {
 
     SecretDeliveryResponse secretDeliveryResponseWithVersion = new SecretDeliveryResponse(
         "General_Password..0be68f903f8b7d86",
-        secret,
-        decodedLength(secret),
+        secretVar,
+        decodedLength(secretVar),
         ApiDate.parse("2011-09-29T15:46:00.000Z"),
         true,
         ImmutableMap.of());
@@ -78,8 +78,8 @@ public class SecretDeliveryResponseTest {
 
     SecretDeliveryResponse secretDeliveryResponseWithMetadata = new SecretDeliveryResponse(
         "Nobody_PgPass",
-        secret,
-        decodedLength(secret),
+        secretVar,
+        decodedLength(secretVar),
         ApiDate.parse("2011-09-29T15:46:00.000Z"),
         false,
         ImmutableMap.of("mode", "0400", "owner", "nobody"));

--- a/cli/src/test/java/keywhiz/client/ClientUtilsTest.java
+++ b/cli/src/test/java/keywhiz/client/ClientUtilsTest.java
@@ -88,8 +88,8 @@ public class ClientUtilsTest {
 
     assertThat(sslClient.getCookieHandler()).isNotNull();
     java.util.List<HttpCookie>
-        cookieList = ((CookieManager) sslClient.getCookieHandler()).getCookieStore().getCookies();
-    assertThat(cookieList).isEmpty();
+        cookieList1 = ((CookieManager) sslClient.getCookieHandler()).getCookieStore().getCookies();
+    assertThat(cookieList1).isEmpty();
   }
 
   @Test public void testSslOkHttpClientCreationWithCookies() throws Exception {
@@ -101,9 +101,9 @@ public class ClientUtilsTest {
     assertThat(sslClient.networkInterceptors()).isNotEmpty();
 
     java.util.List<HttpCookie>
-        cookieList = ((CookieManager) sslClient.getCookieHandler()).getCookieStore().getCookies();
-    assertThat(cookieList).contains(xsrfCookie);
-    assertThat(cookieList).contains(sessionCookie);
+        cookieList1 = ((CookieManager) sslClient.getCookieHandler()).getCookieStore().getCookies();
+    assertThat(cookieList1).contains(xsrfCookie);
+    assertThat(cookieList1).contains(sessionCookie);
   }
 
   @Test public void testSaveCookies() throws Exception {

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -439,8 +439,8 @@ public class AclDAO {
     }
 
     @Override public AclDAO using(Configuration configuration) {
-      DSLContext dslContext = DSL.using(checkNotNull(configuration));
-      return new AclDAO(dslContext, clientDAOFactory, groupDAOFactory, secretContentDAOFactory,
+      DSLContext dslContextVar = DSL.using(checkNotNull(configuration));
+      return new AclDAO(dslContextVar, clientDAOFactory, groupDAOFactory, secretContentDAOFactory,
           secretSeriesDAOFactory, clientMapper, groupMapper, secretSeriesMapper);
     }
   }

--- a/server/src/main/java/keywhiz/service/daos/ClientDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/ClientDAO.java
@@ -112,8 +112,8 @@ public class ClientDAO {
     }
 
     @Override public ClientDAO using(Configuration configuration) {
-      DSLContext dslContext = DSL.using(checkNotNull(configuration));
-      return new ClientDAO(dslContext, clientMapper);
+      DSLContext dslContextVar = DSL.using(checkNotNull(configuration));
+      return new ClientDAO(dslContextVar, clientMapper);
     }
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/GroupDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/GroupDAO.java
@@ -111,8 +111,8 @@ public class GroupDAO {
     }
 
     @Override public GroupDAO using(Configuration configuration) {
-      DSLContext dslContext = DSL.using(checkNotNull(configuration));
-      return new GroupDAO(dslContext, groupMapper);
+      DSLContext dslContextVar = DSL.using(checkNotNull(configuration));
+      return new GroupDAO(dslContextVar, groupMapper);
     }
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
@@ -142,8 +142,8 @@ public class SecretContentDAO {
     }
 
     @Override public SecretContentDAO using(Configuration configuration) {
-      DSLContext dslContext = DSL.using(checkNotNull(configuration));
-      return new SecretContentDAO(dslContext, objectMapper, secretContentMapper);
+      DSLContext dslContextVar = DSL.using(checkNotNull(configuration));
+      return new SecretContentDAO(dslContextVar, objectMapper, secretContentMapper);
     }
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -284,8 +284,8 @@ public class SecretDAO {
     }
 
     @Override public SecretDAO using(Configuration configuration) {
-      DSLContext dslContext = DSL.using(checkNotNull(configuration));
-      return new SecretDAO(dslContext, secretContentDAOFactory, secretSeriesDAOFactory);
+      DSLContext dslContextVar = DSL.using(checkNotNull(configuration));
+      return new SecretDAO(dslContextVar, secretContentDAOFactory, secretSeriesDAOFactory);
     }
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -159,8 +159,8 @@ public class SecretSeriesDAO {
     }
 
     @Override public SecretSeriesDAO using(Configuration configuration) {
-      DSLContext dslContext = DSL.using(checkNotNull(configuration));
-      return new SecretSeriesDAO(dslContext, objectMapper, secretSeriesMapper);
+      DSLContext dslContextVar = DSL.using(checkNotNull(configuration));
+      return new SecretSeriesDAO(dslContextVar, objectMapper, secretSeriesMapper);
     }
   }
 }

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -122,12 +122,12 @@ public class SecretDAOTest {
     int secretContentsBefore = tableSize(SECRETS_CONTENT);
 
     String name = "newSecret";
-    String content = "c2VjcmV0MQ==";
-    String encryptedContent = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
-    String version = VersionGenerator.now().toHex();
-    long newId = secretDAO.createSecret(name, encryptedContent, version, "creator",
+    String contentVar = "c2VjcmV0MQ==";
+    String encryptedContentVar = cryptographer.encryptionKeyDerivedFrom(name).encrypt(contentVar);
+    String versionVar = VersionGenerator.now().toHex();
+    long newId = secretDAO.createSecret(name, encryptedContentVar, versionVar, "creator",
         ImmutableMap.of(), "", null, ImmutableMap.of());
-    SecretSeriesAndContent newSecret = secretDAO.getSecretByIdAndVersion(newId, version).get();
+    SecretSeriesAndContent newSecret = secretDAO.getSecretByIdAndVersion(newId, versionVar).get();
 
     assertThat(tableSize(SECRETS)).isEqualTo(secretsBefore + 1);
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore + 1);
@@ -142,19 +142,19 @@ public class SecretDAOTest {
     int secretContentsBefore = tableSize(SECRETS_CONTENT);
 
     String name = "newSecret";
-    String content = "c2VjcmV0MQ==";
-    String encryptedContent1 = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
-    String version = VersionGenerator.fromLong(1234).toHex();
-    long id = secretDAO.createSecret(name, encryptedContent1, version, "creator", ImmutableMap.of(),
+    String contentVar = "c2VjcmV0MQ==";
+    String encryptedContent1 = cryptographer.encryptionKeyDerivedFrom(name).encrypt(contentVar);
+    String versionVar = VersionGenerator.fromLong(1234).toHex();
+    long id = secretDAO.createSecret(name, encryptedContent1, versionVar, "creator", ImmutableMap.of(),
         "", null, ImmutableMap.of());
-    SecretSeriesAndContent newSecret1 = secretDAO.getSecretByIdAndVersion(id, version).get();
+    SecretSeriesAndContent newSecret1 = secretDAO.getSecretByIdAndVersion(id, versionVar).get();
 
-    content = "amFja2RvcnNrZXkK";
-    String encryptedContent2 = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
-    version = VersionGenerator.fromLong(4321).toHex();
-    id = secretDAO.createSecret(name, encryptedContent2, version, "creator", ImmutableMap.of(), "",
+    contentVar = "amFja2RvcnNrZXkK";
+    String encryptedContent2 = cryptographer.encryptionKeyDerivedFrom(name).encrypt(contentVar);
+    versionVar = VersionGenerator.fromLong(4321).toHex();
+    id = secretDAO.createSecret(name, encryptedContent2, versionVar, "creator", ImmutableMap.of(), "",
         null, ImmutableMap.of());
-    SecretSeriesAndContent newSecret2 = secretDAO.getSecretByIdAndVersion(id, version).get();
+    SecretSeriesAndContent newSecret2 = secretDAO.getSecretByIdAndVersion(id, versionVar).get();
 
     // Only one new secrets entry should be created - there should be 2 secrets_content entries though
     assertThat(tableSize(SECRETS)).isEqualTo(secretsBefore + 1);
@@ -168,8 +168,8 @@ public class SecretDAOTest {
 
   @Test public void getSecretByNameAndVersion() {
     String name = secret1.series().name();
-    String version = secret1.content().version().orElse("");
-    assertThat(secretDAO.getSecretByNameAndVersion(name, version)).contains(secret1);
+    String versionVar = secret1.content().version().orElse("");
+    assertThat(secretDAO.getSecretByNameAndVersion(name, versionVar)).contains(secret1);
   }
 
   @Test public void getSecretByNameAndVersionWithoutVersion() {
@@ -181,13 +181,13 @@ public class SecretDAOTest {
     String futureStamp = new VersionGenerator(System.currentTimeMillis() + 100000).toHex();
     String name = secret1.series().name();
     String content = "bmV3ZXJTZWNyZXQy";
-    String encryptedContent = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
-    long newId = secretDAO.createSecret(name, encryptedContent, futureStamp, "creator", ImmutableMap.of(), "desc", null, null);
+    String encryptedContentVar = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
+    long newId = secretDAO.createSecret(name, encryptedContentVar, futureStamp, "creator", ImmutableMap.of(), "desc", null, null);
     SecretSeriesAndContent newerSecret = secretDAO.getSecretByIdAndVersion(newId, futureStamp)
         .orElseThrow(RuntimeException::new);
 
-    String version = secret1.content().version().orElse("");
-    assertThat(secretDAO.getSecretByNameAndVersion(name, version)).contains(secret1);
+    String versionVar = secret1.content().version().orElse("");
+    assertThat(secretDAO.getSecretByNameAndVersion(name, versionVar)).contains(secret1);
 
     assertThat(secretDAO.getSecretByNameAndVersion(name, futureStamp)).contains(newerSecret);
   }
@@ -199,9 +199,9 @@ public class SecretDAOTest {
   @Test public void getSecretByIdAndVersionWithVersion() {
     String futureStamp = new VersionGenerator(System.currentTimeMillis() + 222222).toHex();
     String name = secret1.series().name();
-    String content = "bmV3ZXJTZWNyZXQy";
-    String encryptedContent = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
-    secretDAO.createSecret(name, encryptedContent, futureStamp, "creator", ImmutableMap.of(), "desc", null, null);
+    String contentVar = "bmV3ZXJTZWNyZXQy";
+    String encryptedContentVar = cryptographer.encryptionKeyDerivedFrom(name).encrypt(contentVar);
+    secretDAO.createSecret(name, encryptedContentVar, futureStamp, "creator", ImmutableMap.of(), "desc", null, null);
     SecretSeriesAndContent newerSecret = secretDAO.getSecretByNameAndVersion(name, futureStamp)
         .orElseThrow(RuntimeException::new);
 

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
@@ -60,18 +60,18 @@ public class SecretDeliveryResourceTest {
   }
 
   @Test public void returnsSecretWhenAllowed() throws Exception {
-    Secret secret = new Secret(0, "secret_name", null, null, "unused_secret", NOW, null, NOW, null, null, null, null);
-    SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
+    Secret secretVar = new Secret(0, "secret_name", null, null, "unused_secret", NOW, null, NOW, null, null, null, null);
+    SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secretVar);
     String name = sanitizedSecret.name();
     String version = sanitizedSecret.version();
 
     when(aclDAO.getSanitizedSecretFor(client, name, version))
         .thenReturn(Optional.of(sanitizedSecret));
     when(secretController.getSecretByNameAndVersion(name, version))
-        .thenReturn(Optional.of(secret));
+        .thenReturn(Optional.of(secretVar));
 
     SecretDeliveryResponse response = secretDeliveryResource.getSecret(sanitizedSecret.name(), client);
-    assertThat(response).isEqualTo(SecretDeliveryResponse.fromSecret(secret));
+    assertThat(response).isEqualTo(SecretDeliveryResponse.fromSecret(secretVar));
   }
 
   @Test public void returnsVersionedSecretWhenAllowed() throws Exception {

--- a/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
@@ -84,8 +84,8 @@ public class GroupsResourceTest {
   @Test(expected = BadRequestException.class)
   public void rejectsWhenGroupExists() {
     CreateGroupRequest request = new CreateGroupRequest("newGroup", "description");
-    Group group = new Group(3, "newGroup", "desc", now, "creator", now, "updater");
-    when(groupDAO.getGroup("newGroup")).thenReturn(Optional.of(group));
+    Group groupVar = new Group(3, "newGroup", "desc", now, "creator", now, "updater");
+    when(groupDAO.getGroup("newGroup")).thenReturn(Optional.of(groupVar));
 
     resource.createGroup(user, request);
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:HiddenFieldCheck - “ Local variables should not shadow class fields”. You can find more information about the issues here: https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
Please let me know if you have any questions.
Ayman Abdelghany.