### PR TITLE
Replace the usage of System.out or System.err by a logger

### DIFF
--- a/cli/src/main/java/keywhiz/cli/CliMain.java
+++ b/cli/src/main/java/keywhiz/cli/CliMain.java
@@ -29,9 +29,14 @@ import keywhiz.cli.configs.DescribeActionConfig;
 import keywhiz.cli.configs.ListActionConfig;
 import keywhiz.cli.configs.LoginActionConfig;
 import keywhiz.cli.configs.UnassignActionConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Keywhiz ACL Command Line Management Utility */
 public class CliMain {
+    
+  private static final Logger logger = LoggerFactory.getLogger(CliMain.class);  
+    
   public static void main(String[] args) throws Exception {
     CliConfiguration config = new CliConfiguration();
 
@@ -55,7 +60,7 @@ public class CliMain {
     try {
       commander.parse(args);
     } catch (ParameterException e) {
-      System.err.println("Invalid command: " + e.getMessage());
+      logger.error("Invalid command: " + e.getMessage());
       commander.usage();
       System.exit(1);
     }

--- a/cli/src/main/java/keywhiz/cli/ClientUtils.java
+++ b/cli/src/main/java/keywhiz/cli/ClientUtils.java
@@ -51,6 +51,8 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.servlet.http.Cookie;
 import org.eclipse.jetty.server.CookieCutter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -64,6 +66,8 @@ import static java.util.stream.Collectors.toList;
  */
 
 public class ClientUtils {
+  private static final Logger logger = LoggerFactory.getLogger(ClientUtils.class);
+    
   private static final ObjectMapper mapper = Jackson.newObjectMapper();
 
   /**
@@ -167,7 +171,7 @@ public class ClientUtils {
   public static char[] readPassword(String user) {
     Console console = System.console();
     if (console != null) {
-      System.out.format("password for '%s': ", user);
+      logger.info(String.format("password for '%s': ", user));
       return System.console().readPassword();
     } else {
       throw new RuntimeException("Please login by running a command without piping.\n"

--- a/cli/src/main/java/keywhiz/cli/CommandExecutor.java
+++ b/cli/src/main/java/keywhiz/cli/CommandExecutor.java
@@ -47,12 +47,17 @@ import keywhiz.cli.configs.ListActionConfig;
 import keywhiz.cli.configs.UnassignActionConfig;
 import keywhiz.client.KeywhizClient;
 import keywhiz.client.KeywhizClient.UnauthorizedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.StandardSystemProperty.USER_HOME;
 import static com.google.common.base.StandardSystemProperty.USER_NAME;
 import static java.lang.String.format;
 
 public class CommandExecutor {
+    
+  private static final Logger logger = LoggerFactory.getLogger(CommandExecutor.class);
+    
   public static final String APP_VERSION = "2.0";
 
   public enum Command { LOGIN, LIST, DESCRIBE, ADD, DELETE, ASSIGN, UNASSIGN }
@@ -81,9 +86,9 @@ public class CommandExecutor {
   public void executeCommand() throws IOException {
     if (command == null) {
       if (config.version) {
-        System.out.println("Version: " + APP_VERSION);
+        logger.info("Version: " + APP_VERSION);
       } else {
-        System.err.println("Must specify a command.");
+        logger.error("Must specify a command.");
         parentCommander.usage();
       }
 
@@ -93,11 +98,11 @@ public class CommandExecutor {
     HttpUrl url;
     if (Strings.isNullOrEmpty(config.url)) {
       url = HttpUrl.parse("https://localhost:4444");
-      System.out.println("Server URL not specified (--url flag), assuming " + url);
+      logger.info("Server URL not specified (--url flag), assuming " + url);
     } else {
       url = HttpUrl.parse(config.url);
       if (url == null) {
-        System.err.print("Invalid URL " + config.url);
+        logger.error("Invalid URL " + config.url);
         return;
       }
     }

--- a/cli/src/main/java/keywhiz/cli/Printing.java
+++ b/cli/src/main/java/keywhiz/cli/Printing.java
@@ -28,8 +28,13 @@ import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.client.KeywhizClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Printing {
+
+  private static final Logger logger = LoggerFactory.getLogger(Printing.class);
+    
   private final KeywhizClient keywhizClient;
 
   private static final String INDENT = Strings.repeat("\t", 2);
@@ -40,7 +45,7 @@ public class Printing {
   }
 
   public void printClientWithDetails(Client client, List<String> options) {
-    System.out.println(client.getName());
+    logger.info(client.getName());
     ClientDetailResponse clientDetails;
     try {
       clientDetails = keywhizClient.clientDetailsForId(client.getId());
@@ -49,22 +54,22 @@ public class Printing {
     }
 
     if (options.contains("groups")) {
-      System.out.println("\tGroups:");
+      logger.info("\tGroups:");
       clientDetails.groups.stream()
           .sorted(Comparator.comparing(Group::getName))
-          .forEach(g -> System.out.println(INDENT + g.getName()));
+          .forEach(g -> logger.info(INDENT + g.getName()));
     }
 
     if (options.contains("secrets")) {
-      System.out.println("\tSecrets:");
+      logger.info("\tSecrets:");
       clientDetails.secrets.stream()
           .sorted(Comparator.comparing(SanitizedSecret::name))
-          .forEach(s -> System.out.println(INDENT + SanitizedSecret.displayName(s)));
+          .forEach(s -> logger.info(INDENT + SanitizedSecret.displayName(s)));
     }
   }
 
   public void printGroupWithDetails(Group group, List<String> options) {
-    System.out.println(group.getName());
+    logger.info(group.getName());
     GroupDetailResponse groupDetails;
     try {
       groupDetails = keywhizClient.groupDetailsForId(group.getId());
@@ -73,22 +78,22 @@ public class Printing {
     }
 
     if (options.contains("clients")) {
-      System.out.println("\tClients:");
+      logger.info("\tClients:");
       groupDetails.getClients().stream()
           .sorted(Comparator.comparing(Client::getName))
-          .forEach(c -> System.out.println(INDENT + c.getName()));
+          .forEach(c -> logger.info(INDENT + c.getName()));
       }
 
     if (options.contains("secrets")) {
-      System.out.println("\tSecrets:");
+      logger.info("\tSecrets:");
       groupDetails.getSecrets().stream()
           .sorted(Comparator.comparing(SanitizedSecret::name))
-          .forEach(s -> System.out.println(INDENT + SanitizedSecret.displayName(s)));
+          .forEach(s -> logger.info(INDENT + SanitizedSecret.displayName(s)));
     }
   }
 
   public void printSanitizedSecretWithDetails(SanitizedSecret secret, List<String> options) {
-    System.out.println(SanitizedSecret.displayName(secret));
+    logger.info(SanitizedSecret.displayName(secret));
     SecretDetailResponse secretDetails;
     try {
       secretDetails = keywhizClient.secretDetailsForId(secret.id());
@@ -97,23 +102,23 @@ public class Printing {
     }
 
     if (options.contains("groups")) {
-      System.out.println("\tGroups:");
+      logger.info("\tGroups:");
       secretDetails.groups.stream()
           .sorted(Comparator.comparing(Group::getName))
-          .forEach(g -> System.out.println(INDENT + g.getName()));
+          .forEach(g -> logger.info(INDENT + g.getName()));
     }
 
     if (options.contains("clients")) {
-      System.out.println("\tClients:");
+      logger.info("\tClients:");
       secretDetails.clients.stream()
           .sorted(Comparator.comparing(Client::getName))
-          .forEach(c -> System.out.println(INDENT + c.getName()));
+          .forEach(c -> logger.info(INDENT + c.getName()));
     }
 
     if (options.contains("metadata")) {
-      System.out.println("\tMetadata:");
+      logger.info("\tMetadata:");
       if(!secret.metadata().isEmpty()) {
-        System.out.println(INDENT + secret.metadata().toString());
+        logger.info(INDENT + secret.metadata().toString());
       }
     }
   }
@@ -121,18 +126,18 @@ public class Printing {
   public void printAllClients(List<Client> clients) {
     clients.stream()
         .sorted(Comparator.comparing(Client::getName))
-        .forEach(c -> System.out.println(c.getName()));
+        .forEach(c -> logger.info(c.getName()));
   }
 
   public void printAllGroups(List<Group> groups) {
     groups.stream()
         .sorted(Comparator.comparing(Group::getName))
-        .forEach(g -> System.out.println(g.getName()));
+        .forEach(g -> logger.info(g.getName()));
   }
 
   public void printAllSanitizedSecrets(List<SanitizedSecret> secrets) {
     secrets.stream()
         .sorted(Comparator.comparing(SanitizedSecret::name))
-        .forEach(s -> System.out.println(SanitizedSecret.displayName(s)));
+        .forEach(s -> logger.info(SanitizedSecret.displayName(s)));
   }
 }

--- a/cli/src/main/java/keywhiz/cli/commands/DeleteAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/DeleteAction.java
@@ -97,7 +97,7 @@ public class DeleteAction implements Runnable {
               keywhizClient.getSanitizedSecretByNameAndVersion(parts[0], parts[1]);
           BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8));
           while (true) {
-            System.out.println(
+            logger.info(String.
                 format("Please confirm deletion of secret '%s': Y/N", sanitizedSecret.name()));
             String line = reader.readLine();
 

--- a/server/src/main/java/db/h2/migration/V3__remove_foreign_key.java
+++ b/server/src/main/java/db/h2/migration/V3__remove_foreign_key.java
@@ -3,8 +3,11 @@ package db.h2.migration;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class V3__remove_foreign_key implements JdbcMigration {
+  private static final Logger logger = LoggerFactory.getLogger(V3__remove_foreign_key.class);
   public void migrate(Connection connection) throws Exception {
     String find = "select CONSTRAINT_TYPE, CONSTRAINT_NAME, TABLE_NAME from information_schema.constraints";
     ResultSet constraints = connection.createStatement().executeQuery(find);
@@ -14,8 +17,8 @@ public class V3__remove_foreign_key implements JdbcMigration {
       String table = constraints.getString("TABLE_NAME");
       if(type == "REFERENTIAL") {
         connection.createStatement().executeUpdate("ALTER TABLE " + table + " DROP CONSTRAINT " + constraint);
-        System.out.printf("Found constraint (%s, %s, %s)", type, constraint, table);
-        System.out.println(" - Dropped it.");
+        logger.info(String.format("Found constraint (%s, %s, %s)", type, constraint, table));
+        logger.info(" - Dropped it.");
       }
     }
   }

--- a/server/src/main/java/keywhiz/commands/GenerateAesKeyCommand.java
+++ b/server/src/main/java/keywhiz/commands/GenerateAesKeyCommand.java
@@ -29,6 +29,8 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.lang.String.format;
 
@@ -36,6 +38,7 @@ import static java.lang.String.format;
  * Generates an AES key in a keystore. Particularly, this is useful for a base derivation key.
  */
 public class GenerateAesKeyCommand extends Command {
+  private static final Logger logger = LoggerFactory.getLogger(GenerateAesKeyCommand.class);
   public GenerateAesKeyCommand() {
     super("gen-aes", "Generates a new AES key in a keystore");
   }
@@ -73,7 +76,7 @@ public class GenerateAesKeyCommand extends Command {
     String alias = namespace.getString("alias");
 
     generate(password, destination, keySize, alias);
-    System.out.println(format("Generated a %d-bit AES key at %s with alias %s", keySize,
+    logger.info(format("Generated a %d-bit AES key at %s with alias %s", keySize,
         destination.toAbsolutePath(), alias));
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S106 - “Standard outputs should not be used directly to log anything”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S106
Please let me know if you have any questions.
Ayman Abdelghany.