### PR TITLE
Add a way to add local admin users to keywhiz

### DIFF
--- a/cli/src/main/java/keywhiz/cli/ClientUtils.java
+++ b/cli/src/main/java/keywhiz/cli/ClientUtils.java
@@ -168,7 +168,7 @@ public class ClientUtils {
     Console console = System.console();
     if (console != null) {
       System.out.format("password for '%s': ", user);
-      return System.console().readPassword();
+      return console.readPassword();
     } else {
       throw new RuntimeException("Please login by running a command without piping.\n"
           + "For example: keywhiz.cli login");

--- a/server/src/main/java/keywhiz/KeywhizService.java
+++ b/server/src/main/java/keywhiz/KeywhizService.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import javax.sql.DataSource;
 import keywhiz.auth.mutualssl.ClientCertificateFilter;
 import keywhiz.auth.xsrf.XsrfServletFilter;
+import keywhiz.commands.AddUserCommand;
 import keywhiz.commands.DbSeedCommand;
 import keywhiz.commands.GenerateAesKeyCommand;
 import keywhiz.commands.MigrateCommand;
@@ -142,6 +143,7 @@ public class KeywhizService extends Application<KeywhizConfig> {
     bootstrap.addCommand(new MigrateCommand());
     bootstrap.addCommand(new DbSeedCommand());
     bootstrap.addCommand(new GenerateAesKeyCommand());
+    bootstrap.addCommand(new AddUserCommand());
 
     logger.debug("Registering bundles");
     bootstrap.addBundle(new Java8Bundle());

--- a/server/src/main/java/keywhiz/commands/AddUserCommand.java
+++ b/server/src/main/java/keywhiz/commands/AddUserCommand.java
@@ -1,0 +1,7 @@
+package keywhiz.commands;
+
+/**
+ * Created by mmc on 2/1/16.
+ */
+public class AddUserCommand {
+}

--- a/server/src/main/java/keywhiz/commands/AddUserCommand.java
+++ b/server/src/main/java/keywhiz/commands/AddUserCommand.java
@@ -1,7 +1,48 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package keywhiz.commands;
 
-/**
- * Created by mmc on 2/1/16.
- */
-public class AddUserCommand {
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.setup.Bootstrap;
+import keywhiz.KeywhizConfig;
+import keywhiz.service.daos.UserDAO;
+import keywhiz.utility.DSLContexts;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.jooq.DSLContext;
+
+import javax.sql.DataSource;
+import java.io.Console;
+
+public class AddUserCommand extends ConfiguredCommand<KeywhizConfig> {
+  public AddUserCommand() {
+    super("add-user", "Adds a new admin user");
+  }
+
+  @Override protected void run(Bootstrap<KeywhizConfig> bootstrap, Namespace namespace,
+                               KeywhizConfig config) throws Exception {
+    DataSource dataSource = config.getDataSourceFactory()
+      .build(new MetricRegistry(), "add-user-datasource");
+
+    Console console = System.console();
+    System.out.format("New username:");
+    String user = console.readLine();
+    System.out.format("password for '%s': ", user);
+    char[] password = console.readPassword();
+    DSLContext dslContext = DSLContexts.databaseAgnostic(dataSource);
+    new UserDAO(dslContext).createUser(user, new String(password));
+  }
 }

--- a/server/src/main/java/keywhiz/commands/DbSeedCommand.java
+++ b/server/src/main/java/keywhiz/commands/DbSeedCommand.java
@@ -21,6 +21,7 @@ import io.dropwizard.setup.Bootstrap;
 import java.time.OffsetDateTime;
 import javax.sql.DataSource;
 import keywhiz.KeywhizConfig;
+import keywhiz.service.daos.UserDAO;
 import keywhiz.utility.DSLContexts;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.jooq.DSLContext;
@@ -149,12 +150,9 @@ public class DbSeedCommand extends ConfiguredCommand<KeywhizConfig> {
         .values(668L, 917L, 772L, OffsetDateTime.parse("2012-06-21T14:38:09Z").toEpochSecond(), OffsetDateTime.parse("2012-06-21T14:38:09Z").toEpochSecond())
         .execute();
 
-    dslContext
-        .insertInto(USERS)
-        .set(USERS.USERNAME, defaultUser)
-        .set(USERS.PASSWORD_HASH, BCrypt.hashpw(defaultPassword, BCrypt.gensalt()))
-        .set(USERS.CREATED_AT, OffsetDateTime.parse("2012-06-22T14:38:09Z").toEpochSecond())
-        .set(USERS.UPDATED_AT, OffsetDateTime.parse("2012-06-22T14:38:09Z").toEpochSecond())
-        .execute();
+    new UserDAO(dslContext).createUserAt(
+      defaultUser, defaultPassword,
+      OffsetDateTime.parse("2012-06-22T14:38:09Z"),
+      OffsetDateTime.parse("2012-06-22T14:38:09Z"));
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/UserDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/UserDAO.java
@@ -16,8 +16,10 @@
 
 package keywhiz.service.daos;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import org.jooq.DSLContext;
+import org.mindrot.jbcrypt.BCrypt;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static keywhiz.jooq.tables.Users.USERS;
@@ -36,5 +38,19 @@ public class UserDAO {
         .where(USERS.USERNAME.eq(name))
         .fetchOne(USERS.PASSWORD_HASH);
     return Optional.ofNullable(r);
+  }
+
+  public void createUserAt(String user, String password, OffsetDateTime created, OffsetDateTime updated) {
+    dslContext
+      .insertInto(USERS)
+      .set(USERS.USERNAME, user)
+      .set(USERS.PASSWORD_HASH, BCrypt.hashpw(password, BCrypt.gensalt()))
+      .set(USERS.CREATED_AT, created.toEpochSecond())
+      .set(USERS.UPDATED_AT, updated.toEpochSecond())
+      .execute();
+  }
+
+  public void createUser(String user, String password) {
+    this.createUserAt(user, password, OffsetDateTime.now(), OffsetDateTime.now());
   }
 }


### PR DESCRIPTION
If you don't use ldap, there's no exposed way to add users, except the "db-seed" command that puts a default user in.

This adds a "add-user" commadn to the server jar.

You invoke it like this, from the dev tree:

java -jar ./server/target/keywhiz-server-0.7.11-SNAPSHOT-shaded.jar add-user server/src/main/resources/keywhiz-development.yaml
New username:myuser
password for 'myuser': <type a password here>

