### PR TITLE
Add setup wizard for docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,18 +13,28 @@
 # will run with the default development config. If COMMAND is 
 # omitted, keywhiz will print a help message.
 #
-# Development:
+# *** Development ***
 #   Create a persistent data volume:
 #     docker volume create --name keywhiz-db-devel
 #
-#   Initialize the database and apply migrations:
+#   Initialize the database, apply migrations, and add seed data:
 #     docker run -v keywhiz-db-devel:/data square/keywhiz migrate
-#
-#   Seed the database with development data:
 #     docker run -v keywhiz-db-devel:/data square/keywhiz db-seed
 #
 #   Finally, run the server with the default development config:
 #     docker run -it -p 4444:4444 -v keywhiz-db-devel:/data square/keywhiz server
+#
+# *** Production setup wizard ***
+#   For production deployments, we have setup wizard that will initialize
+#   a Keywhiz container for you and create a config based on a template.
+#
+#   The wizard can be run using the "wizard" command, like so:
+#       docker run -it \
+#           -v keywhiz-data:/data \
+#           -v keywhiz-secrets:/secrets \
+#           square/keywhiz wizard
+#
+#   Be ready to provide a server certificate/private key for setup.
 #
 # After keywhiz starts up, you can access the admin console by going
 # to https://[DOCKER-MACHINE-IP]/ui in your browser. The default user
@@ -35,8 +45,10 @@
 #
 FROM maven:3.3-jdk-8
 
-# mkdir for app
-RUN mkdir -p /usr/src/app
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install gettext vim-common && \
+    mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # caching trick to speed up build; see:
@@ -63,14 +75,20 @@ COPY testing /usr/src/app/testing/
 RUN mvn install -P docker
 
 # Drop privs inside container
-RUN useradd -ms /bin/false keywhiz && mkdir /data && chown keywhiz:keywhiz /data
+RUN useradd -ms /bin/false keywhiz && \
+    mkdir /data && \
+    chown keywhiz:keywhiz /data && \
+    mkdir /secrets && \
+    chown keywhiz:keywhiz /secrets
 USER keywhiz
 
 # Expose API port by default. Note that the admin console port
 # is NOT exposed by default, can be exposed manually if desired. 
 EXPOSE 4444
 
-VOLUME ["/data"]
+VOLUME ["/data", "/secrets"]
 
-COPY docker.sh /usr/src/app
-ENTRYPOINT ["/usr/src/app/docker.sh"]
+COPY docker/entry.sh /usr/src/app
+COPY docker/wizard.sh /usr/src/app
+COPY docker/keywhiz-config.tpl /usr/src/app
+ENTRYPOINT ["/usr/src/app/entry.sh"]

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -3,6 +3,10 @@
 RESET=$(tput -T xterm sgr0)
 RED=$(tput -T xterm setaf 1) 
 
+if [ "$1" == "wizard" ]; then
+    exec ./wizard.sh
+fi
+
 if [ -z "$KEYWHIZ_CONFIG" ]; then
     KEYWHIZ_CONFIG=server/src/main/resources/keywhiz-development.yaml
     echo -n "${RED}"

--- a/docker/keywhiz-config.tpl
+++ b/docker/keywhiz-config.tpl
@@ -1,0 +1,86 @@
+server:
+  applicationConnectors:
+    - type: https
+      port: 4444
+      keyStorePath: ${KEYSTORE_PATH}
+      keyStorePassword: ${KEYSTORE_PASSWORD}
+      keyStoreType: PKCS12
+      trustStorePath: ${TRUSTSTORE_PATH} 
+      trustStorePassword: ${TRUSTSTORE_PASSWORD}
+      trustStoreType: PKCS12
+      wantClientAuth: true
+      enableCRLDP: false
+      enableOCSP: false
+      crlPath: ${CRL_PATH}
+      supportedProtocols: [TLSv1.2]
+      supportedCipherSuites:
+        - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+        - TLS_RSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+        - TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+  adminConnectors:
+    - type: http
+      port: 8085
+
+logging:
+  appenders:
+    - type: console
+      threshold: ALL
+
+environment: docker
+
+database:
+  driverClass: org.h2.Driver
+  url: jdbc:h2:/data/keywhizdb_development
+  user: root
+  properties:
+    charSet: UTF-8
+  initialSize: 10
+  minSize: 10
+  maxSize: 10
+  # There is explicitly no password. Do not uncomment.
+  # password:
+
+readonlyDatabase:
+  driverClass: org.h2.Driver
+  url: jdbc:h2:/data/keywhizdb_development
+  user: root
+  properties:
+    charSet: UTF-8
+  readOnlyByDefault: true
+  initialSize: 32
+  minSize: 32
+  maxSize: 32
+  # There is explicitly no password. Do not uncomment.
+  # password:
+
+migrationsDir:
+  db/h2/migration
+
+userAuth:
+  type: bcrypt
+
+cookieKey: external:${COOKIE_KEY_PATH}
+
+sessionCookie:
+  name: session
+  path: /admin
+
+xsrfCookie:
+  name: XSRF-TOKEN
+  path: /
+  httpOnly: false
+
+contentKeyStore:
+  path: ${CONTENT_KEYSTORE_PATH}
+  type: JCEKS
+  password: ${CONTENT_KEYSTORE_PASSWORD}
+  alias: basekey

--- a/docker/wizard.sh
+++ b/docker/wizard.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -e
+
+function confirm() {
+    echo
+    read -p "$1 (y/n) "
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        return 0
+    fi
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        return 1
+    fi
+    echo "Answer must be one of y/n."
+    confirm "$1"
+}
+
+function assert_file_present() {
+    if ! [ -f $1 ]; then
+        echo "Missing file: $1. Aborting."
+        exit 1
+    fi 
+}
+
+cat - <<EOF
+*** Keywhiz Setup Wizard ***
+
+The Keywhiz Setup Wizard will take you through a step-by-step process to
+bootstrap a Keywhiz server container. This includes generating a new content
+encryption key, adding an initial admin user, as well as adding certificates
+for the Keywhiz server to run. All generated keys and secrets will be stored in
+the /secrets directory inside the container, and an empty H2 database will be
+created in /data. You should make sure you have persistent volumes mounted in
+those places!
+
+Note that if you wish to run Keywhiz with an external database you can do so
+by supplying your own config file via the KEYWHIZ_CONFIG environment variable.
+The wizard will set up an H2 database by default, which should be sufficent
+for most deployments (unless you expect a very high volume of traffic).
+EOF
+
+if ! confirm "The wizard will overwrite previously generated data if present. Proceed?"; then
+    exit 1
+fi
+
+echo
+echo -n "Generating a new cookie secret... "
+export COOKIE_KEY_PATH="/secrets/cookie.key.base64"
+head -c32 /dev/urandom | base64 > $COOKIE_KEY_PATH
+echo "done"
+
+echo -n "Generating a new content encryption key... "
+export CONTENT_KEYSTORE_PASSWORD=`head -c16 /dev/urandom | xxd -p`
+export CONTENT_KEYSTORE_PATH="/secrets/content-encryption-key.jceks"
+rm -f $CONTENT_KEYSTORE_PATH
+keytool \
+    -genseckey -alias basekey -keyalg AES -keysize 128 -storepass "$CONTENT_KEYSTORE_PASSWORD" \
+    -keypass "$CONTENT_KEYSTORE_PASSWORD" -storetype jceks -keystore $CONTENT_KEYSTORE_PATH
+echo "done"
+
+echo
+echo "Keywhiz requires a SSL/TLS server certificate and private key to run."
+echo "You can import your own cert, or have the wizard generate one."
+
+export KEYSTORE_PATH="/secrets/keywhiz-server.p12"
+export KEYSTORE_PASSWORD=`head -c16 /dev/urandom | xxd -p`
+export TRUSTSTORE_PATH="/secrets/ca-bundle.p12"
+export TRUSTSTORE_PASSWORD=ponies # contains public certificates only
+export CRL_FILE_PEM="/secrets/ca-crl.pem"
+
+CERT_CHAIN_PEM="/secrets/keywhiz.pem"
+PRIVATE_KEY_PEM="/secrets/keywhiz-key.pem"
+CA_BUNDLE_PEM="/secrets/ca-bundle.pem"
+
+echo
+echo "Please copy the following files into the container:"
+echo "  1. Copy your certificate chain to $CERT_CHAIN_PEM"
+echo "  2. Copy your private key to $PRIVATE_KEY_PEM"
+echo "  3. Copy your CA bundle to $CA_BUNDLE_PEM"
+echo "  4. Copy a valid CRL file to $CRL_FILE_PEM"
+echo 
+echo "Files can be copied into a running container with docker cp."
+echo
+
+read -p "Hit enter to continue."
+echo
+
+assert_file_present $CERT_CHAIN_PEM
+assert_file_present $PRIVATE_KEY_PEM
+assert_file_present $CA_BUNDLE_PEM
+assert_file_present $CRL_FILE_PEM
+
+echo -n "Bundling certificate and private key into PKCS#12 keystore... "
+rm -f $KEYSTORE_PATH
+openssl pkcs12 \
+    -export -out $KEYSTORE_PATH -inkey $PRIVATE_KEY_PEM -in $CERT_CHAIN_PEM \
+    -password "pass:$KEYSTORE_PASSWORD" -certfile $CA_BUNDLE_PEM
+echo "done"
+
+echo "Bundling CA bundle into PKCS#12 trust store... "
+rm -f $TRUSTSTORE_PATH
+keytool \
+    -noprompt -import -file $CA_BUNDLE_PEM -alias ca -storetype pkcs12 \
+    -storepass $TRUSTSTORE_PASSWORD -keystore $TRUSTSTORE_PATH -trustcacerts
+
+echo -n "Generating configuration from template..."
+export KEYWHIZ_CONFIG=/data/keywhiz-docker.yaml
+envsubst < /usr/src/app/keywhiz-config.tpl > $KEYWHIZ_CONFIG
+echo "done"
+
+echo
+echo "Creating empty database and running migrations... "
+java -jar server/target/keywhiz-server-*-SNAPSHOT-shaded.jar migrate $KEYWHIZ_CONFIG
+
+echo
+echo "Creating admin user for keywhiz... "
+java -jar server/target/keywhiz-server-*-SNAPSHOT-shaded.jar add-user $KEYWHIZ_CONFIG
+
+cat - <<EOF
+All done! Config has been written to $KEYWHIZ_CONFIG. Make sure to set the
+KEYWHIZ_CONFIG environment variable to tell the container which config to use
+on startup.
+EOF

--- a/docker/wizard.sh
+++ b/docker/wizard.sh
@@ -60,7 +60,6 @@ echo "done"
 
 echo
 echo "Keywhiz requires a SSL/TLS server certificate and private key to run."
-echo "You can import your own cert, or have the wizard generate one."
 
 export KEYSTORE_PATH="/secrets/keywhiz-server.p12"
 export KEYSTORE_PASSWORD=`head -c16 /dev/urandom | xxd -p`


### PR DESCRIPTION
r: @mcpherrinm @alokmenghrajani 

Add setup wizard for docker containers.

Run the wizard like this:

    docker run -it \
        -v keywhiz-data:/data \
        -v keywhiz-secrets:/secrets \
        square/keywhiz wizard

The wizard will create symmetric encryption keys and ask for TLS certificates/keys.

After it completes, run keywhiz server with the generated config like this:
    
    docker run \
        -p 4444:4444
        -v keywhiz-data:/data \
        -v keywhiz-secrets:/secrets \
        -e 'KEYWHIZ_CONFIG=/data/keywhiz-docker.yaml'
        square/keywhiz server