### PR TITLE
Add comments to Dropwizard configuration, and validateCerts: false

### DIFF
--- a/server/src/main/resources/keywhiz-development.yaml.h2
+++ b/server/src/main/resources/keywhiz-development.yaml.h2
@@ -11,13 +11,22 @@ server:
   applicationConnectors:
     - type: https
       port: 4444
+      # The keystore stores your server's TLS certificate.
       keyStorePath: server/src/main/resources/dev_and_test_keystore.p12
       keyStorePassword: ponies
       keyStoreType: PKCS12
+      # The trust store determines which certificates the server trusts.  This should contain your
+      # cert for the CA root that issues client certificates.
       trustStorePath: server/src/main/resources/dev_and_test_truststore.p12
       trustStorePassword: ponies
       trustStoreType: PKCS12
+      # We want clients to provide a client cert.
       wantClientAuth: true
+      # In the dev_and_test key material, we use the same CA for the client and server for easy
+      # management, but in production we issue client certs off a seperate root.  Because only
+      # that root is in the trustStore above, Dropwizard must be told not to validate its own cert
+      validateCerts: false
+      # We don't use CRLDP or OCSP.
       enableCRLDP: false
       enableOCSP: false
       crlPath: server/src/main/resources/dev_and_test.crl

--- a/server/src/main/resources/keywhiz-development.yaml.mysql
+++ b/server/src/main/resources/keywhiz-development.yaml.mysql
@@ -11,13 +11,22 @@ server:
   applicationConnectors:
     - type: https
       port: 4444
+      # The keystore stores your server's TLS certificate.
       keyStorePath: server/src/main/resources/dev_and_test_keystore.p12
       keyStorePassword: ponies
       keyStoreType: PKCS12
+      # The trust store determines which certificates the server trusts.  This should contain your
+      # cert for the CA root that issues client certificates.
       trustStorePath: server/src/main/resources/dev_and_test_truststore.p12
       trustStorePassword: ponies
       trustStoreType: PKCS12
+      # We want clients to provide a client cert.
       wantClientAuth: true
+      # In the dev_and_test key material, we use the same CA for the client and server for easy
+      # management, but in production we issue client certs off a seperate root.  Because only
+      # that root is in the trustStore above, Dropwizard must be told not to validate its own cert
+      validateCerts: false
+      # We don't use CRLDP or OCSP.
       enableCRLDP: false
       enableOCSP: false
       crlPath: server/src/main/resources/dev_and_test.crl

--- a/server/src/main/resources/keywhiz-development.yaml.postgres
+++ b/server/src/main/resources/keywhiz-development.yaml.postgres
@@ -11,13 +11,22 @@ server:
   applicationConnectors:
     - type: https
       port: 4444
+      # The keystore stores your server's TLS certificate.
       keyStorePath: server/src/main/resources/dev_and_test_keystore.p12
       keyStorePassword: ponies
       keyStoreType: PKCS12
+      # The trust store determines which certificates the server trusts.  This should contain your
+      # cert for the CA root that issues client certificates.
       trustStorePath: server/src/main/resources/dev_and_test_truststore.p12
       trustStorePassword: ponies
       trustStoreType: PKCS12
+      # We want clients to provide a client cert.
       wantClientAuth: true
+      # In the dev_and_test key material, we use the same CA for the client and server for easy
+      # management, but in production we issue client certs off a seperate root.  Because only
+      # that root is in the trustStore above, Dropwizard must be told not to validate its own cert
+      validateCerts: false
+      # We don't use CRLDP or OCSP.
       enableCRLDP: false
       enableOCSP: false
       crlPath: server/src/main/resources/dev_and_test.crl


### PR DESCRIPTION
Though validateCerts: false isn't used in the dev setup, there's not really any
production config examples elsewhere, and so it's helpful to include it.

cc @madtrax 

r? @csstaub @alokmenghrajani @sqshh 