### PR TITLE
Adding metrics

### DIFF
--- a/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
@@ -90,7 +90,7 @@ public class SecretDeliveryResource {
    * @responseMessage 404 Secret with given name not found
    * @responseMessage 500 Secret response could not be generated for given Secret
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public SecretDeliveryResponse getSecret(@NotEmpty @PathParam("secretName") String secretName,
                                           @Auth Client client) {
     String[] parts;

--- a/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.auth.Auth;

--- a/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
@@ -90,7 +90,8 @@ public class SecretDeliveryResource {
    * @responseMessage 404 Secret with given name not found
    * @responseMessage 500 Secret response could not be generated for given Secret
    */
-  @GET @Timed
+  @Timed
+  @GET
   public SecretDeliveryResponse getSecret(@NotEmpty @PathParam("secretName") String secretName,
                                           @Auth Client client) {
     String[] parts;

--- a/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.auth.Auth;
 import java.text.ParseException;
@@ -87,7 +90,7 @@ public class SecretDeliveryResource {
    * @responseMessage 404 Secret with given name not found
    * @responseMessage 500 Secret response could not be generated for given Secret
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public SecretDeliveryResponse getSecret(@NotEmpty @PathParam("secretName") String secretName,
                                           @Auth Client client) {
     String[] parts;

--- a/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
@@ -62,7 +62,8 @@ public class SecretsDeliveryResource {
    * @excludeParams client
    * @description Returns all Secrets for the current Client
    */
-  @GET @Timed
+  @Timed
+  @GET
   public List<SecretDeliveryResponse> getSecrets(@Auth Client client) {
     logger.info("Client {} listed available secrets.", client.getName());
     return aclDAO.getSanitizedSecretsFor(client).stream()

--- a/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.auth.Auth;
 import java.util.List;
@@ -59,7 +62,7 @@ public class SecretsDeliveryResource {
    * @excludeParams client
    * @description Returns all Secrets for the current Client
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public List<SecretDeliveryResponse> getSecrets(@Auth Client client) {
     logger.info("Client {} listed available secrets.", client.getName());
     return aclDAO.getSanitizedSecretsFor(client).stream()

--- a/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.auth.Auth;

--- a/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretsDeliveryResource.java
@@ -62,7 +62,7 @@ public class SecretsDeliveryResource {
    * @excludeParams client
    * @description Returns all Secrets for the current Client
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public List<SecretDeliveryResponse> getSecrets(@Auth Client client) {
     logger.info("Client {} listed available secrets.", client.getName());
     return aclDAO.getSanitizedSecretsFor(client).stream()

--- a/server/src/main/java/keywhiz/service/resources/StatusResource.java
+++ b/server/src/main/java/keywhiz/service/resources/StatusResource.java
@@ -1,5 +1,8 @@
 package keywhiz.service.resources;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import io.dropwizard.setup.Environment;
@@ -26,7 +29,7 @@ public class StatusResource {
     this.environment = environment;
   }
 
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public boolean get() {
     HealthCheckRegistry checks = this.environment.healthChecks();
     SortedMap<String, HealthCheck.Result> results = checks.runHealthChecks();

--- a/server/src/main/java/keywhiz/service/resources/StatusResource.java
+++ b/server/src/main/java/keywhiz/service/resources/StatusResource.java
@@ -1,7 +1,5 @@
 package keywhiz.service.resources;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;

--- a/server/src/main/java/keywhiz/service/resources/StatusResource.java
+++ b/server/src/main/java/keywhiz/service/resources/StatusResource.java
@@ -29,7 +29,8 @@ public class StatusResource {
     this.environment = environment;
   }
 
-  @GET @Timed
+  @Timed
+  @GET
   public boolean get() {
     HealthCheckRegistry checks = this.environment.healthChecks();
     SortedMap<String, HealthCheck.Result> results = checks.runHealthChecks();

--- a/server/src/main/java/keywhiz/service/resources/StatusResource.java
+++ b/server/src/main/java/keywhiz/service/resources/StatusResource.java
@@ -29,7 +29,7 @@ public class StatusResource {
     this.environment = environment;
   }
 
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public boolean get() {
     HealthCheckRegistry checks = this.environment.healthChecks();
     SortedMap<String, HealthCheck.Result> results = checks.runHealthChecks();

--- a/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.admin;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;

--- a/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
@@ -92,7 +92,8 @@ public class ClientsResource {
    * @responseMessage 200 Found and retrieved Client(s)
    * @responseMessage 404 Client with given name not found (if name provided)
    */
-  @GET @Timed
+  @Timed
+  @GET
   public Response findClients(@Auth User user, @DefaultValue("") @QueryParam("name") String name) {
     if (name.isEmpty()) {
       return Response.ok().entity(listClients(user)).build();
@@ -122,7 +123,8 @@ public class ClientsResource {
    * @responseMessage 200 Successfully created Client
    * @responseMessage 409 Client with given name already exists
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public Response createClient(@Auth User user,
       @Valid CreateClientRequest createClientRequest) {
@@ -156,7 +158,8 @@ public class ClientsResource {
    * @responseMessage 404 Client with given ID not Found
    */
   @Path("{clientId}")
-  @GET @Timed
+  @Timed
+  @GET
   public ClientDetailResponse getClient(@Auth User user,
       @PathParam("clientId") LongParam clientId) {
     logger.info("User '{}' retrieving client id={}.", user, clientId);
@@ -175,7 +178,8 @@ public class ClientsResource {
    * @responseMessage 404 Client with given ID not Found
    */
   @Path("{clientId}")
-  @DELETE @Timed
+  @Timed
+  @DELETE
   public Response deleteClient(@Auth User user, @PathParam("clientId") LongParam clientId) {
     logger.info("User '{}' deleting client id={}.", user, clientId);
 

--- a/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.admin;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
@@ -89,7 +92,7 @@ public class ClientsResource {
    * @responseMessage 200 Found and retrieved Client(s)
    * @responseMessage 404 Client with given name not found (if name provided)
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response findClients(@Auth User user, @DefaultValue("") @QueryParam("name") String name) {
     if (name.isEmpty()) {
       return Response.ok().entity(listClients(user)).build();
@@ -119,7 +122,7 @@ public class ClientsResource {
    * @responseMessage 200 Successfully created Client
    * @responseMessage 409 Client with given name already exists
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public Response createClient(@Auth User user,
       @Valid CreateClientRequest createClientRequest) {
@@ -153,7 +156,7 @@ public class ClientsResource {
    * @responseMessage 404 Client with given ID not Found
    */
   @Path("{clientId}")
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public ClientDetailResponse getClient(@Auth User user,
       @PathParam("clientId") LongParam clientId) {
     logger.info("User '{}' retrieving client id={}.", user, clientId);
@@ -172,7 +175,7 @@ public class ClientsResource {
    * @responseMessage 404 Client with given ID not Found
    */
   @Path("{clientId}")
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response deleteClient(@Auth User user, @PathParam("clientId") LongParam clientId) {
     logger.info("User '{}' deleting client id={}.", user, clientId);
 

--- a/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
@@ -92,7 +92,7 @@ public class ClientsResource {
    * @responseMessage 200 Found and retrieved Client(s)
    * @responseMessage 404 Client with given name not found (if name provided)
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public Response findClients(@Auth User user, @DefaultValue("") @QueryParam("name") String name) {
     if (name.isEmpty()) {
       return Response.ok().entity(listClients(user)).build();
@@ -122,7 +122,7 @@ public class ClientsResource {
    * @responseMessage 200 Successfully created Client
    * @responseMessage 409 Client with given name already exists
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public Response createClient(@Auth User user,
       @Valid CreateClientRequest createClientRequest) {
@@ -156,7 +156,7 @@ public class ClientsResource {
    * @responseMessage 404 Client with given ID not Found
    */
   @Path("{clientId}")
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public ClientDetailResponse getClient(@Auth User user,
       @PathParam("clientId") LongParam clientId) {
     logger.info("User '{}' retrieving client id={}.", user, clientId);
@@ -175,7 +175,7 @@ public class ClientsResource {
    * @responseMessage 404 Client with given ID not Found
    */
   @Path("{clientId}")
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   public Response deleteClient(@Auth User user, @PathParam("clientId") LongParam clientId) {
     logger.info("User '{}' deleting client id={}.", user, clientId);
 

--- a/server/src/main/java/keywhiz/service/resources/admin/GroupsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/GroupsResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.admin;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;

--- a/server/src/main/java/keywhiz/service/resources/admin/GroupsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/GroupsResource.java
@@ -93,7 +93,7 @@ public class GroupsResource {
    * @responseMessage 200 Found and retrieved Group(s)
    * @responseMessage 404 Group with given name not found (if name provided)
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public Response findGroups(@Auth User user, @DefaultValue("") @QueryParam("name") String name) {
     if (name.isEmpty()) {
       return Response.ok().entity(listGroups(user)).build();
@@ -123,7 +123,7 @@ public class GroupsResource {
    * @responseMessage 200 Successfully created Group
    * @responseMessage 400 Group with given name already exists
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public Response createGroup(@Auth User user, @Valid CreateGroupRequest request) {
 
@@ -153,7 +153,7 @@ public class GroupsResource {
    * @responseMessage 404 Group with given ID not Found
    */
   @Path("{groupId}")
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public GroupDetailResponse getGroup(@Auth User user, @PathParam("groupId") LongParam groupId) {
     logger.info("User '{}' retrieving group id={}.", user, groupId);
     return groupDetailResponseFromId(groupId.get());
@@ -171,7 +171,7 @@ public class GroupsResource {
    * @responseMessage 404 Group with given ID not Found
    */
   @Path("{groupId}")
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   public Response deleteGroup(@Auth User user, @PathParam("groupId") LongParam groupId) {
     logger.info("User '{}' deleting group id={}.", user, groupId);
 

--- a/server/src/main/java/keywhiz/service/resources/admin/GroupsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/GroupsResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.admin;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
@@ -90,7 +93,7 @@ public class GroupsResource {
    * @responseMessage 200 Found and retrieved Group(s)
    * @responseMessage 404 Group with given name not found (if name provided)
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response findGroups(@Auth User user, @DefaultValue("") @QueryParam("name") String name) {
     if (name.isEmpty()) {
       return Response.ok().entity(listGroups(user)).build();
@@ -120,7 +123,7 @@ public class GroupsResource {
    * @responseMessage 200 Successfully created Group
    * @responseMessage 400 Group with given name already exists
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public Response createGroup(@Auth User user, @Valid CreateGroupRequest request) {
 
@@ -150,7 +153,7 @@ public class GroupsResource {
    * @responseMessage 404 Group with given ID not Found
    */
   @Path("{groupId}")
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public GroupDetailResponse getGroup(@Auth User user, @PathParam("groupId") LongParam groupId) {
     logger.info("User '{}' retrieving group id={}.", user, groupId);
     return groupDetailResponseFromId(groupId.get());
@@ -168,7 +171,7 @@ public class GroupsResource {
    * @responseMessage 404 Group with given ID not Found
    */
   @Path("{groupId}")
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response deleteGroup(@Auth User user, @PathParam("groupId") LongParam groupId) {
     logger.info("User '{}' deleting group id={}.", user, groupId);
 

--- a/server/src/main/java/keywhiz/service/resources/admin/GroupsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/GroupsResource.java
@@ -93,7 +93,8 @@ public class GroupsResource {
    * @responseMessage 200 Found and retrieved Group(s)
    * @responseMessage 404 Group with given name not found (if name provided)
    */
-  @GET @Timed
+  @Timed
+  @GET
   public Response findGroups(@Auth User user, @DefaultValue("") @QueryParam("name") String name) {
     if (name.isEmpty()) {
       return Response.ok().entity(listGroups(user)).build();
@@ -123,7 +124,8 @@ public class GroupsResource {
    * @responseMessage 200 Successfully created Group
    * @responseMessage 400 Group with given name already exists
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public Response createGroup(@Auth User user, @Valid CreateGroupRequest request) {
 
@@ -153,7 +155,8 @@ public class GroupsResource {
    * @responseMessage 404 Group with given ID not Found
    */
   @Path("{groupId}")
-  @GET @Timed
+  @Timed
+  @GET
   public GroupDetailResponse getGroup(@Auth User user, @PathParam("groupId") LongParam groupId) {
     logger.info("User '{}' retrieving group id={}.", user, groupId);
     return groupDetailResponseFromId(groupId.get());
@@ -171,7 +174,8 @@ public class GroupsResource {
    * @responseMessage 404 Group with given ID not Found
    */
   @Path("{groupId}")
-  @DELETE @Timed
+  @Timed
+  @DELETE
   public Response deleteGroup(@Auth User user, @PathParam("groupId") LongParam groupId) {
     logger.info("User '{}' deleting group id={}.", user, groupId);
 

--- a/server/src/main/java/keywhiz/service/resources/admin/MembershipResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/MembershipResource.java
@@ -15,8 +15,6 @@
  */
 package keywhiz.service.resources.admin;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.auth.Auth;

--- a/server/src/main/java/keywhiz/service/resources/admin/MembershipResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/MembershipResource.java
@@ -15,6 +15,9 @@
  */
 package keywhiz.service.resources.admin;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
@@ -68,7 +71,7 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Secret or Group
    */
   @Path("/secrets/{secretId}/groups/{groupId}")
-  @PUT
+  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response allowAccess(
       @Auth User user,
       @PathParam("secretId") LongParam secretId,
@@ -98,7 +101,7 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Secret or Group
    */
   @Path("/secrets/{secretId}/groups/{groupId}")
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response disallowAccess(
       @Auth User user,
       @PathParam("secretId") LongParam secretId,
@@ -127,7 +130,7 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Client or Group
    */
   @Path("/clients/{clientId}/groups/{groupId}")
-  @PUT
+  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response enrollClient(
     @Auth User user,
     @PathParam("clientId") LongParam clientId,
@@ -156,7 +159,7 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Client or Group
    */
   @Path("/clients/{clientId}/groups/{groupId}")
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response evictClient(
       @Auth User user,
       @PathParam("clientId") LongParam clientId,

--- a/server/src/main/java/keywhiz/service/resources/admin/MembershipResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/MembershipResource.java
@@ -71,7 +71,7 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Secret or Group
    */
   @Path("/secrets/{secretId}/groups/{groupId}")
-  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @PUT @Timed
   public Response allowAccess(
       @Auth User user,
       @PathParam("secretId") LongParam secretId,
@@ -101,7 +101,7 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Secret or Group
    */
   @Path("/secrets/{secretId}/groups/{groupId}")
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   public Response disallowAccess(
       @Auth User user,
       @PathParam("secretId") LongParam secretId,
@@ -130,7 +130,7 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Client or Group
    */
   @Path("/clients/{clientId}/groups/{groupId}")
-  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @PUT @Timed
   public Response enrollClient(
     @Auth User user,
     @PathParam("clientId") LongParam clientId,
@@ -159,7 +159,7 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Client or Group
    */
   @Path("/clients/{clientId}/groups/{groupId}")
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   public Response evictClient(
       @Auth User user,
       @PathParam("clientId") LongParam clientId,

--- a/server/src/main/java/keywhiz/service/resources/admin/MembershipResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/MembershipResource.java
@@ -71,7 +71,8 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Secret or Group
    */
   @Path("/secrets/{secretId}/groups/{groupId}")
-  @PUT @Timed
+  @Timed
+  @PUT
   public Response allowAccess(
       @Auth User user,
       @PathParam("secretId") LongParam secretId,
@@ -101,7 +102,8 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Secret or Group
    */
   @Path("/secrets/{secretId}/groups/{groupId}")
-  @DELETE @Timed
+  @Timed
+  @DELETE
   public Response disallowAccess(
       @Auth User user,
       @PathParam("secretId") LongParam secretId,
@@ -130,7 +132,8 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Client or Group
    */
   @Path("/clients/{clientId}/groups/{groupId}")
-  @PUT @Timed
+  @Timed
+  @PUT
   public Response enrollClient(
     @Auth User user,
     @PathParam("clientId") LongParam clientId,
@@ -159,7 +162,8 @@ public class MembershipResource {
    * @responseMessage 404 Could not find Client or Group
    */
   @Path("/clients/{clientId}/groups/{groupId}")
-  @DELETE @Timed
+  @Timed
+  @DELETE
   public Response evictClient(
       @Auth User user,
       @PathParam("clientId") LongParam clientId,

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretGeneratorsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretGeneratorsResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.admin;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.auth.Auth;
 import java.io.IOException;
@@ -69,7 +72,7 @@ public class SecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect
    */
   @Path("{generatorName}")
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> generate(@Auth User user,
       @PathParam("generatorName") String generatorName, String requestBody) {
@@ -99,7 +102,7 @@ public class SecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect, batch may have been empty
    */
   @Path("{generatorName}/batch")
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> batchGenerate(@Auth User user,
       @PathParam("generatorName") String generatorName, String requestBody) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretGeneratorsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretGeneratorsResource.java
@@ -72,7 +72,7 @@ public class SecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect
    */
   @Path("{generatorName}")
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> generate(@Auth User user,
       @PathParam("generatorName") String generatorName, String requestBody) {
@@ -102,7 +102,7 @@ public class SecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect, batch may have been empty
    */
   @Path("{generatorName}/batch")
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> batchGenerate(@Auth User user,
       @PathParam("generatorName") String generatorName, String requestBody) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretGeneratorsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretGeneratorsResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.admin;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.auth.Auth;

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretGeneratorsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretGeneratorsResource.java
@@ -72,7 +72,8 @@ public class SecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect
    */
   @Path("{generatorName}")
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> generate(@Auth User user,
       @PathParam("generatorName") String generatorName, String requestBody) {
@@ -102,7 +103,8 @@ public class SecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect, batch may have been empty
    */
   @Path("{generatorName}/batch")
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> batchGenerate(@Auth User user,
       @PathParam("generatorName") String generatorName, String requestBody) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.admin;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
@@ -103,7 +106,7 @@ public class SecretsResource {
    * @responseMessage 200 Found and retrieved Secret(s)
    * @responseMessage 404 Secret with given name not found (if name provided)
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response findSecrets(@Auth User user, @DefaultValue("") @QueryParam("name") String name,
       @DefaultValue("") @QueryParam("version") String version,
       @DefaultValue("") @QueryParam("nameOnly") String nameOnly) {
@@ -144,7 +147,7 @@ public class SecretsResource {
    * @responseMessage 400 Name not given
    */
   @Path("/versions")
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public List<String> getVersionsForSecretName(@Auth User user,
       @DefaultValue("") @QueryParam("name") String name) {
     if (name.isEmpty()) {
@@ -171,7 +174,7 @@ public class SecretsResource {
    * @responseMessage 200 Successfully created Secret
    * @responseMessage 400 Secret with given name already exists
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public Response createSecret(@Auth User user, @Valid CreateSecretRequest request) {
 
@@ -220,7 +223,7 @@ public class SecretsResource {
    * @responseMessage 404 Secret with given ID not Found
    */
   @Path("{secretId}")
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public SecretDetailResponse retrieveSecret(@Auth User user,
       @PathParam("secretId") LongParam secretId) {
 
@@ -240,7 +243,7 @@ public class SecretsResource {
    * @responseMessage 404 Secret with given ID not Found
    */
   @Path("{secretId}")
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response deleteSecret(@Auth User user, @PathParam("secretId") LongParam secretId) {
     List<Secret> secrets = secretController.getSecretsById(secretId.get());
     if (secrets.isEmpty()) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.admin;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -106,7 +106,8 @@ public class SecretsResource {
    * @responseMessage 200 Found and retrieved Secret(s)
    * @responseMessage 404 Secret with given name not found (if name provided)
    */
-  @GET @Timed
+  @Timed
+  @GET
   public Response findSecrets(@Auth User user, @DefaultValue("") @QueryParam("name") String name,
       @DefaultValue("") @QueryParam("version") String version,
       @DefaultValue("") @QueryParam("nameOnly") String nameOnly) {
@@ -147,7 +148,8 @@ public class SecretsResource {
    * @responseMessage 400 Name not given
    */
   @Path("/versions")
-  @GET @Timed
+  @Timed
+  @GET
   public List<String> getVersionsForSecretName(@Auth User user,
       @DefaultValue("") @QueryParam("name") String name) {
     if (name.isEmpty()) {
@@ -174,7 +176,8 @@ public class SecretsResource {
    * @responseMessage 200 Successfully created Secret
    * @responseMessage 400 Secret with given name already exists
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public Response createSecret(@Auth User user, @Valid CreateSecretRequest request) {
 
@@ -223,7 +226,8 @@ public class SecretsResource {
    * @responseMessage 404 Secret with given ID not Found
    */
   @Path("{secretId}")
-  @GET @Timed
+  @Timed
+  @GET
   public SecretDetailResponse retrieveSecret(@Auth User user,
       @PathParam("secretId") LongParam secretId) {
 
@@ -243,7 +247,8 @@ public class SecretsResource {
    * @responseMessage 404 Secret with given ID not Found
    */
   @Path("{secretId}")
-  @DELETE @Timed
+  @Timed
+  @DELETE
   public Response deleteSecret(@Auth User user, @PathParam("secretId") LongParam secretId) {
     List<Secret> secrets = secretController.getSecretsById(secretId.get());
     if (secrets.isEmpty()) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -106,7 +106,7 @@ public class SecretsResource {
    * @responseMessage 200 Found and retrieved Secret(s)
    * @responseMessage 404 Secret with given name not found (if name provided)
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public Response findSecrets(@Auth User user, @DefaultValue("") @QueryParam("name") String name,
       @DefaultValue("") @QueryParam("version") String version,
       @DefaultValue("") @QueryParam("nameOnly") String nameOnly) {
@@ -147,7 +147,7 @@ public class SecretsResource {
    * @responseMessage 400 Name not given
    */
   @Path("/versions")
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public List<String> getVersionsForSecretName(@Auth User user,
       @DefaultValue("") @QueryParam("name") String name) {
     if (name.isEmpty()) {
@@ -174,7 +174,7 @@ public class SecretsResource {
    * @responseMessage 200 Successfully created Secret
    * @responseMessage 400 Secret with given name already exists
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public Response createSecret(@Auth User user, @Valid CreateSecretRequest request) {
 
@@ -223,7 +223,7 @@ public class SecretsResource {
    * @responseMessage 404 Secret with given ID not Found
    */
   @Path("{secretId}")
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public SecretDetailResponse retrieveSecret(@Auth User user,
       @PathParam("secretId") LongParam secretId) {
 
@@ -243,7 +243,7 @@ public class SecretsResource {
    * @responseMessage 404 Secret with given ID not Found
    */
   @Path("{secretId}")
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   public Response deleteSecret(@Auth User user, @PathParam("secretId") LongParam secretId) {
     List<Secret> secrets = secretController.getSecretsById(secretId.get());
     if (secrets.isEmpty()) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionLoginResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionLoginResource.java
@@ -76,7 +76,8 @@ public class SessionLoginResource {
    * @responseMessage 200 Logged in successfully
    * @responseMessage 401 Incorrect credentials or not authorized
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   public Response login(@Valid LoginRequest request) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionLoginResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionLoginResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.admin;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.AuthenticationException;

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionLoginResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionLoginResource.java
@@ -76,7 +76,7 @@ public class SessionLoginResource {
    * @responseMessage 200 Logged in successfully
    * @responseMessage 401 Incorrect credentials or not authorized
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   public Response login(@Valid LoginRequest request) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionLoginResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionLoginResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.admin;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.basic.BasicCredentials;
@@ -73,7 +76,7 @@ public class SessionLoginResource {
    * @responseMessage 200 Logged in successfully
    * @responseMessage 401 Incorrect credentials or not authorized
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   public Response login(@Valid LoginRequest request) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionLogoutResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionLogoutResource.java
@@ -65,7 +65,7 @@ public class SessionLogoutResource {
    * @description Log out and remove any session cookies
    * @responseMessage 200 Logged out successfully
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Produces(APPLICATION_JSON)
   public Response logout(@Nullable @CookieParam(value = "session") Cookie sessionCookie) {
     if (sessionCookie != null) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionLogoutResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionLogoutResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.admin;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import java.net.URI;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -62,7 +65,7 @@ public class SessionLogoutResource {
    * @description Log out and remove any session cookies
    * @responseMessage 200 Logged out successfully
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Produces(APPLICATION_JSON)
   public Response logout(@Nullable @CookieParam(value = "session") Cookie sessionCookie) {
     if (sessionCookie != null) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionLogoutResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionLogoutResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.admin;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import java.net.URI;
 import java.util.Optional;

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionLogoutResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionLogoutResource.java
@@ -65,7 +65,8 @@ public class SessionLogoutResource {
    * @description Log out and remove any session cookies
    * @responseMessage 200 Logged out successfully
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Produces(APPLICATION_JSON)
   public Response logout(@Nullable @CookieParam(value = "session") Cookie sessionCookie) {
     if (sessionCookie != null) {

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionMeResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionMeResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.admin;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -42,7 +45,7 @@ public class SessionMeResource {
    * @description Returns JSON information about the current Keywhiz user
    * @responseMessage 200 Found and retrieved User information
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Produces(APPLICATION_JSON)
   public User getInformation(@Auth User user) {
     logger.info("User '{}' accessing me.", user);

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionMeResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionMeResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.admin;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import javax.ws.rs.GET;

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionMeResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionMeResource.java
@@ -45,7 +45,7 @@ public class SessionMeResource {
    * @description Returns JSON information about the current Keywhiz user
    * @responseMessage 200 Found and retrieved User information
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Produces(APPLICATION_JSON)
   public User getInformation(@Auth User user) {
     logger.info("User '{}' accessing me.", user);

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionMeResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionMeResource.java
@@ -45,7 +45,8 @@ public class SessionMeResource {
    * @description Returns JSON information about the current Keywhiz user
    * @responseMessage 200 Found and retrieved User information
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Produces(APPLICATION_JSON)
   public User getInformation(@Auth User user) {
     logger.info("User '{}' accessing me.", user);

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.automation;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
@@ -87,7 +90,7 @@ public class AutomationClientResource {
    * @responseMessage 200 Found and retrieved Client with given ID
    * @responseMessage 404 Client with given ID not Found
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{clientId}")
   public Response findClientById(
       @Auth AutomationClient automationClient,
@@ -114,7 +117,7 @@ public class AutomationClientResource {
    * @responseMessage 200 Found and retrieved Client(s)
    * @responseMessage 404 Client with given name not found (if name provided)
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response findClient(
       @Auth AutomationClient automationClient,
       @QueryParam("name") Optional<String> name) {
@@ -145,7 +148,7 @@ public class AutomationClientResource {
    * @responseMessage 200 Successfully created Client
    * @responseMessage 409 Client with given name already exists
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public ClientDetailResponse createClient(
       @Auth AutomationClient automationClient,
@@ -173,7 +176,7 @@ public class AutomationClientResource {
    * @responseMessage 200 Deleted client
    * @responseMessage 404 Client not found by id
    */
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{clientId}")
   public Response deleteClient(@Auth AutomationClient automationClient,
       @PathParam("clientId") LongParam clientId) {

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
@@ -90,7 +90,8 @@ public class AutomationClientResource {
    * @responseMessage 200 Found and retrieved Client with given ID
    * @responseMessage 404 Client with given ID not Found
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Path("{clientId}")
   public Response findClientById(
       @Auth AutomationClient automationClient,
@@ -117,7 +118,8 @@ public class AutomationClientResource {
    * @responseMessage 200 Found and retrieved Client(s)
    * @responseMessage 404 Client with given name not found (if name provided)
    */
-  @GET @Timed
+  @Timed
+  @GET
   public Response findClient(
       @Auth AutomationClient automationClient,
       @QueryParam("name") Optional<String> name) {
@@ -148,7 +150,8 @@ public class AutomationClientResource {
    * @responseMessage 200 Successfully created Client
    * @responseMessage 409 Client with given name already exists
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public ClientDetailResponse createClient(
       @Auth AutomationClient automationClient,
@@ -176,7 +179,8 @@ public class AutomationClientResource {
    * @responseMessage 200 Deleted client
    * @responseMessage 404 Client not found by id
    */
-  @DELETE @Timed
+  @Timed
+  @DELETE
   @Path("{clientId}")
   public Response deleteClient(@Auth AutomationClient automationClient,
       @PathParam("clientId") LongParam clientId) {

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.automation;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
@@ -90,7 +90,7 @@ public class AutomationClientResource {
    * @responseMessage 200 Found and retrieved Client with given ID
    * @responseMessage 404 Client with given ID not Found
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Path("{clientId}")
   public Response findClientById(
       @Auth AutomationClient automationClient,
@@ -117,7 +117,7 @@ public class AutomationClientResource {
    * @responseMessage 200 Found and retrieved Client(s)
    * @responseMessage 404 Client with given name not found (if name provided)
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public Response findClient(
       @Auth AutomationClient automationClient,
       @QueryParam("name") Optional<String> name) {
@@ -148,7 +148,7 @@ public class AutomationClientResource {
    * @responseMessage 200 Successfully created Client
    * @responseMessage 409 Client with given name already exists
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public ClientDetailResponse createClient(
       @Auth AutomationClient automationClient,
@@ -176,7 +176,7 @@ public class AutomationClientResource {
    * @responseMessage 200 Deleted client
    * @responseMessage 404 Client not found by id
    */
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   @Path("{clientId}")
   public Response deleteClient(@Auth AutomationClient automationClient,
       @PathParam("clientId") LongParam clientId) {

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationEnrollClientGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationEnrollClientGroupResource.java
@@ -15,6 +15,9 @@
  */
 package keywhiz.service.resources.automation;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
 import javax.inject.Inject;
@@ -58,7 +61,7 @@ public class AutomationEnrollClientGroupResource {
    * @responseMessage 200 Successfully enrolled Client in Group
    * @responseMessage 404 Could not find Client or Group
    */
-  @PUT
+  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response enrollClientInGroup(
       @Auth AutomationClient automationClient,
       @PathParam("clientId") LongParam clientId,
@@ -84,7 +87,7 @@ public class AutomationEnrollClientGroupResource {
    * @responseMessage 200 Successfully removed Client from Group
    * @responseMessage 404 Could not find Client or Group
    */
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response evictClientFromGroup(
       @Auth AutomationClient automationClient,
       @PathParam("clientId") long clientId,

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationEnrollClientGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationEnrollClientGroupResource.java
@@ -15,8 +15,6 @@
  */
 package keywhiz.service.resources.automation;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationEnrollClientGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationEnrollClientGroupResource.java
@@ -61,7 +61,7 @@ public class AutomationEnrollClientGroupResource {
    * @responseMessage 200 Successfully enrolled Client in Group
    * @responseMessage 404 Could not find Client or Group
    */
-  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @PUT @Timed
   public Response enrollClientInGroup(
       @Auth AutomationClient automationClient,
       @PathParam("clientId") LongParam clientId,
@@ -87,7 +87,7 @@ public class AutomationEnrollClientGroupResource {
    * @responseMessage 200 Successfully removed Client from Group
    * @responseMessage 404 Could not find Client or Group
    */
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   public Response evictClientFromGroup(
       @Auth AutomationClient automationClient,
       @PathParam("clientId") long clientId,

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationEnrollClientGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationEnrollClientGroupResource.java
@@ -61,7 +61,8 @@ public class AutomationEnrollClientGroupResource {
    * @responseMessage 200 Successfully enrolled Client in Group
    * @responseMessage 404 Could not find Client or Group
    */
-  @PUT @Timed
+  @Timed
+  @PUT
   public Response enrollClientInGroup(
       @Auth AutomationClient automationClient,
       @PathParam("clientId") LongParam clientId,
@@ -87,7 +88,8 @@ public class AutomationEnrollClientGroupResource {
    * @responseMessage 200 Successfully removed Client from Group
    * @responseMessage 404 Could not find Client or Group
    */
-  @DELETE @Timed
+  @Timed
+  @DELETE
   public Response evictClientFromGroup(
       @Auth AutomationClient automationClient,
       @PathParam("clientId") long clientId,

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationGroupResource.java
@@ -90,7 +90,7 @@ public class AutomationGroupResource {
    * @responseMessage 200 Found and retrieved Group with given ID
    * @responseMessage 404 Group with given ID not Found
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Path("{groupId}")
   public GroupDetailResponse getGroupById(
       @Auth AutomationClient automationClient,
@@ -114,7 +114,7 @@ public class AutomationGroupResource {
    * @responseMessage 200 Found and retrieved Group(s)
    * @responseMessage 404 Group with given name not found (if name provided)
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public Response getGroupByName(
       @Auth AutomationClient automationClient,
       @QueryParam("name") Optional<String> name) {
@@ -148,7 +148,7 @@ public class AutomationGroupResource {
    * @responseMessage 200 Successfully created Group
    * @responseMessage 409 Group with given name already exists
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public Group createGroup(
       @Auth AutomationClient automationClient,
@@ -175,7 +175,7 @@ public class AutomationGroupResource {
    * @responseMessage 200 Deleted group
    * @responseMessage 404 Group not found by id
    */
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   @Path("{groupId}")
   public Response deleteGroup(
       @Auth AutomationClient automationClient,

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationGroupResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.automation;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
@@ -87,7 +90,7 @@ public class AutomationGroupResource {
    * @responseMessage 200 Found and retrieved Group with given ID
    * @responseMessage 404 Group with given ID not Found
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{groupId}")
   public GroupDetailResponse getGroupById(
       @Auth AutomationClient automationClient,
@@ -111,7 +114,7 @@ public class AutomationGroupResource {
    * @responseMessage 200 Found and retrieved Group(s)
    * @responseMessage 404 Group with given name not found (if name provided)
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response getGroupByName(
       @Auth AutomationClient automationClient,
       @QueryParam("name") Optional<String> name) {
@@ -145,7 +148,7 @@ public class AutomationGroupResource {
    * @responseMessage 200 Successfully created Group
    * @responseMessage 409 Group with given name already exists
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public Group createGroup(
       @Auth AutomationClient automationClient,
@@ -172,7 +175,7 @@ public class AutomationGroupResource {
    * @responseMessage 200 Deleted group
    * @responseMessage 404 Group not found by id
    */
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{groupId}")
   public Response deleteGroup(
       @Auth AutomationClient automationClient,

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationGroupResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.automation;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationGroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationGroupResource.java
@@ -90,7 +90,8 @@ public class AutomationGroupResource {
    * @responseMessage 200 Found and retrieved Group with given ID
    * @responseMessage 404 Group with given ID not Found
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Path("{groupId}")
   public GroupDetailResponse getGroupById(
       @Auth AutomationClient automationClient,
@@ -114,7 +115,8 @@ public class AutomationGroupResource {
    * @responseMessage 200 Found and retrieved Group(s)
    * @responseMessage 404 Group with given name not found (if name provided)
    */
-  @GET @Timed
+  @Timed
+  @GET
   public Response getGroupByName(
       @Auth AutomationClient automationClient,
       @QueryParam("name") Optional<String> name) {
@@ -148,7 +150,8 @@ public class AutomationGroupResource {
    * @responseMessage 200 Successfully created Group
    * @responseMessage 409 Group with given name already exists
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public Group createGroup(
       @Auth AutomationClient automationClient,
@@ -175,7 +178,8 @@ public class AutomationGroupResource {
    * @responseMessage 200 Deleted group
    * @responseMessage 404 Group not found by id
    */
-  @DELETE @Timed
+  @Timed
+  @DELETE
   @Path("{groupId}")
   public Response deleteGroup(
       @Auth AutomationClient automationClient,

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretAccessResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretAccessResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.automation;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
 import javax.inject.Inject;
@@ -63,7 +66,7 @@ public class AutomationSecretAccessResource {
    * @responseMessage 200 Successfully enrolled Secret in Group
    * @responseMessage 404 Could not find Secret or Group
    */
-  @PUT
+  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response allowAccess(
       @Auth AutomationClient automationClient,
       @PathParam("secretId") LongParam secretId,
@@ -91,7 +94,7 @@ public class AutomationSecretAccessResource {
    * @responseMessage 200 Successfully removed Secret from Group
    * @responseMessage 404 Could not find Secret or Group
    */
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response disallowAccess(
       @Auth AutomationClient automationClient,
       @PathParam("secretId") LongParam secretId,

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretAccessResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretAccessResource.java
@@ -66,7 +66,7 @@ public class AutomationSecretAccessResource {
    * @responseMessage 200 Successfully enrolled Secret in Group
    * @responseMessage 404 Could not find Secret or Group
    */
-  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @PUT @Timed
   public Response allowAccess(
       @Auth AutomationClient automationClient,
       @PathParam("secretId") LongParam secretId,
@@ -94,7 +94,7 @@ public class AutomationSecretAccessResource {
    * @responseMessage 200 Successfully removed Secret from Group
    * @responseMessage 404 Could not find Secret or Group
    */
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   public Response disallowAccess(
       @Auth AutomationClient automationClient,
       @PathParam("secretId") LongParam secretId,

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretAccessResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretAccessResource.java
@@ -66,7 +66,8 @@ public class AutomationSecretAccessResource {
    * @responseMessage 200 Successfully enrolled Secret in Group
    * @responseMessage 404 Could not find Secret or Group
    */
-  @PUT @Timed
+  @Timed
+  @PUT
   public Response allowAccess(
       @Auth AutomationClient automationClient,
       @PathParam("secretId") LongParam secretId,
@@ -94,7 +95,8 @@ public class AutomationSecretAccessResource {
    * @responseMessage 200 Successfully removed Secret from Group
    * @responseMessage 404 Could not find Secret or Group
    */
-  @DELETE @Timed
+  @Timed
+  @DELETE
   public Response disallowAccess(
       @Auth AutomationClient automationClient,
       @PathParam("secretId") LongParam secretId,

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretAccessResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretAccessResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.automation;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretGeneratorsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretGeneratorsResource.java
@@ -16,8 +16,6 @@
 
 package keywhiz.service.resources.automation;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.auth.Auth;

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretGeneratorsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretGeneratorsResource.java
@@ -68,7 +68,8 @@ public class AutomationSecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect
    */
   @Path("{generatorName}")
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> generate(@Auth AutomationClient client,
       @PathParam("generatorName") String generatorName, String requestBody) {
@@ -96,7 +97,8 @@ public class AutomationSecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect, batch may have been empty
    */
   @Path("{generatorName}/batch")
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> batchGenerate(@Auth AutomationClient client,
       @PathParam("generatorName") String generatorName, String requestBody) {

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretGeneratorsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretGeneratorsResource.java
@@ -68,7 +68,7 @@ public class AutomationSecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect
    */
   @Path("{generatorName}")
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> generate(@Auth AutomationClient client,
       @PathParam("generatorName") String generatorName, String requestBody) {
@@ -96,7 +96,7 @@ public class AutomationSecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect, batch may have been empty
    */
   @Path("{generatorName}/batch")
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> batchGenerate(@Auth AutomationClient client,
       @PathParam("generatorName") String generatorName, String requestBody) {

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretGeneratorsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretGeneratorsResource.java
@@ -16,6 +16,9 @@
 
 package keywhiz.service.resources.automation;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.auth.Auth;
 import java.io.IOException;
@@ -65,7 +68,7 @@ public class AutomationSecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect
    */
   @Path("{generatorName}")
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> generate(@Auth AutomationClient client,
       @PathParam("generatorName") String generatorName, String requestBody) {
@@ -93,7 +96,7 @@ public class AutomationSecretGeneratorsResource {
    * @responseMessage 422 Request was formed correctly but was semantically incorrect, batch may have been empty
    */
   @Path("{generatorName}/batch")
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public List<SanitizedSecret> batchGenerate(@Auth AutomationClient client,
       @PathParam("generatorName") String generatorName, String requestBody) {

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
@@ -15,6 +15,9 @@
  */
 package keywhiz.service.resources.automation;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
@@ -93,7 +96,7 @@ public class AutomationSecretResource {
    * @responseMessage 200 Successfully created secret
    * @responseMessage 409 Secret with given name already exists
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public AutomationSecretResponse createSecret(
       @Auth AutomationClient automationClient,
@@ -136,7 +139,7 @@ public class AutomationSecretResource {
    * @responseMessage 200 Found and retrieved secret(s)
    * @responseMessage 404 Secret with given name not found (if name provided)
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public ImmutableList<AutomationSecretResponse> readSecrets(
       @Auth AutomationClient automationClient, @QueryParam("name") String name) {
 
@@ -180,7 +183,7 @@ public class AutomationSecretResource {
    * @responseMessage 404 Secret with given ID not found
    */
   @Path("{secretId}")
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public AutomationSecretResponse readSecretById(
       @Auth AutomationClient automationClient,
       @PathParam("secretId") LongParam secretId) {
@@ -208,7 +211,7 @@ public class AutomationSecretResource {
    * @responseMessage 404 Secret series not Found
    */
   @Path("{secretName}")
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   public Response deleteSecretSeries(
       @Auth AutomationClient automationClient,
       @PathParam("secretName") String secretName) {

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
@@ -96,7 +96,8 @@ public class AutomationSecretResource {
    * @responseMessage 200 Successfully created secret
    * @responseMessage 409 Secret with given name already exists
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public AutomationSecretResponse createSecret(
       @Auth AutomationClient automationClient,
@@ -139,7 +140,8 @@ public class AutomationSecretResource {
    * @responseMessage 200 Found and retrieved secret(s)
    * @responseMessage 404 Secret with given name not found (if name provided)
    */
-  @GET @Timed
+  @Timed
+  @GET
   public ImmutableList<AutomationSecretResponse> readSecrets(
       @Auth AutomationClient automationClient, @QueryParam("name") String name) {
 
@@ -183,7 +185,8 @@ public class AutomationSecretResource {
    * @responseMessage 404 Secret with given ID not found
    */
   @Path("{secretId}")
-  @GET @Timed
+  @Timed
+  @GET
   public AutomationSecretResponse readSecretById(
       @Auth AutomationClient automationClient,
       @PathParam("secretId") LongParam secretId) {
@@ -211,7 +214,8 @@ public class AutomationSecretResource {
    * @responseMessage 404 Secret series not Found
    */
   @Path("{secretName}")
-  @DELETE @Timed
+  @Timed
+  @DELETE
   public Response deleteSecretSeries(
       @Auth AutomationClient automationClient,
       @PathParam("secretName") String secretName) {

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
@@ -15,8 +15,6 @@
  */
 package keywhiz.service.resources.automation;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
@@ -96,7 +96,7 @@ public class AutomationSecretResource {
    * @responseMessage 200 Successfully created secret
    * @responseMessage 409 Secret with given name already exists
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public AutomationSecretResponse createSecret(
       @Auth AutomationClient automationClient,
@@ -139,7 +139,7 @@ public class AutomationSecretResource {
    * @responseMessage 200 Found and retrieved secret(s)
    * @responseMessage 404 Secret with given name not found (if name provided)
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public ImmutableList<AutomationSecretResponse> readSecrets(
       @Auth AutomationClient automationClient, @QueryParam("name") String name) {
 
@@ -183,7 +183,7 @@ public class AutomationSecretResource {
    * @responseMessage 404 Secret with given ID not found
    */
   @Path("{secretId}")
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   public AutomationSecretResponse readSecretById(
       @Auth AutomationClient automationClient,
       @PathParam("secretId") LongParam secretId) {
@@ -211,7 +211,7 @@ public class AutomationSecretResource {
    * @responseMessage 404 Secret series not Found
    */
   @Path("{secretName}")
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   public Response deleteSecretSeries(
       @Auth AutomationClient automationClient,
       @PathParam("secretName") String secretName) {

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/ClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/ClientResource.java
@@ -73,7 +73,7 @@ public class ClientResource {
    * @responseMessage 201 Created client and assigned to given groups
    * @responseMessage 409 Client already exists
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public Response createClient(@Auth AutomationClient automationClient,
       @Valid CreateClientRequestV2 request) {
@@ -104,7 +104,7 @@ public class ClientResource {
    * @excludeParams automationClient
    * @responseMessage 200 List of client names
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientListing(@Auth AutomationClient automationClient) {
     return clientDAO.getClients().stream()
@@ -121,7 +121,7 @@ public class ClientResource {
    * @responseMessage 200 Client information retrieved
    * @responseMessage 404 Client not found
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public ClientDetailResponseV2 clientInfo(@Auth AutomationClient automationClient,
@@ -142,7 +142,7 @@ public class ClientResource {
    * @responseMessage 200 Listing succeeded
    * @responseMessage 404 Client not found
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Path("{name}/groups")
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientGroupsListing(@Auth AutomationClient automationClient,
@@ -165,7 +165,7 @@ public class ClientResource {
    * @responseMessage 201 Client modified successfully
    * @responseMessage 404 Client not found
    */
-  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @PUT @Timed
   @Path("{name}/groups")
   @Produces(APPLICATION_JSON)
   public Iterable<String> modifyClientGroups(@Auth AutomationClient automationClient,
@@ -206,7 +206,7 @@ public class ClientResource {
    * @responseMessage 200 Client lookup succeeded
    * @responseMessage 404 Client not found
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Path("{name}/secrets")
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientSecretsListing(@Auth AutomationClient automationClient,
@@ -227,7 +227,7 @@ public class ClientResource {
    * @responseMessage 204 Client deleted
    * @responseMessage 404 Client not found
    */
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   @Path("{name}")
   public Response deleteClient(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
@@ -249,7 +249,7 @@ public class ClientResource {
    * @responseMessage 201 Client updated
    * @responseMessage 404 Client not found
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Path("{name}")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/ClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/ClientResource.java
@@ -1,5 +1,8 @@
 package keywhiz.service.resources.automation.v2;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.Sets;
 import io.dropwizard.auth.Auth;
 import java.net.URI;
@@ -70,7 +73,7 @@ public class ClientResource {
    * @responseMessage 201 Created client and assigned to given groups
    * @responseMessage 409 Client already exists
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public Response createClient(@Auth AutomationClient automationClient,
       @Valid CreateClientRequestV2 request) {
@@ -101,7 +104,7 @@ public class ClientResource {
    * @excludeParams automationClient
    * @responseMessage 200 List of client names
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientListing(@Auth AutomationClient automationClient) {
     return clientDAO.getClients().stream()
@@ -118,7 +121,7 @@ public class ClientResource {
    * @responseMessage 200 Client information retrieved
    * @responseMessage 404 Client not found
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public ClientDetailResponseV2 clientInfo(@Auth AutomationClient automationClient,
@@ -139,7 +142,7 @@ public class ClientResource {
    * @responseMessage 200 Listing succeeded
    * @responseMessage 404 Client not found
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}/groups")
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientGroupsListing(@Auth AutomationClient automationClient,
@@ -162,7 +165,7 @@ public class ClientResource {
    * @responseMessage 201 Client modified successfully
    * @responseMessage 404 Client not found
    */
-  @PUT
+  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}/groups")
   @Produces(APPLICATION_JSON)
   public Iterable<String> modifyClientGroups(@Auth AutomationClient automationClient,
@@ -203,7 +206,7 @@ public class ClientResource {
    * @responseMessage 200 Client lookup succeeded
    * @responseMessage 404 Client not found
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}/secrets")
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientSecretsListing(@Auth AutomationClient automationClient,
@@ -224,7 +227,7 @@ public class ClientResource {
    * @responseMessage 204 Client deleted
    * @responseMessage 404 Client not found
    */
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}")
   public Response deleteClient(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
@@ -246,7 +249,7 @@ public class ClientResource {
    * @responseMessage 201 Client updated
    * @responseMessage 404 Client not found
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/ClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/ClientResource.java
@@ -1,7 +1,5 @@
 package keywhiz.service.resources.automation.v2;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.Sets;
 import io.dropwizard.auth.Auth;

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/ClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/ClientResource.java
@@ -73,7 +73,8 @@ public class ClientResource {
    * @responseMessage 201 Created client and assigned to given groups
    * @responseMessage 409 Client already exists
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public Response createClient(@Auth AutomationClient automationClient,
       @Valid CreateClientRequestV2 request) {
@@ -104,7 +105,8 @@ public class ClientResource {
    * @excludeParams automationClient
    * @responseMessage 200 List of client names
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientListing(@Auth AutomationClient automationClient) {
     return clientDAO.getClients().stream()
@@ -121,7 +123,8 @@ public class ClientResource {
    * @responseMessage 200 Client information retrieved
    * @responseMessage 404 Client not found
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public ClientDetailResponseV2 clientInfo(@Auth AutomationClient automationClient,
@@ -142,7 +145,8 @@ public class ClientResource {
    * @responseMessage 200 Listing succeeded
    * @responseMessage 404 Client not found
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Path("{name}/groups")
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientGroupsListing(@Auth AutomationClient automationClient,
@@ -165,7 +169,8 @@ public class ClientResource {
    * @responseMessage 201 Client modified successfully
    * @responseMessage 404 Client not found
    */
-  @PUT @Timed
+  @Timed
+  @PUT
   @Path("{name}/groups")
   @Produces(APPLICATION_JSON)
   public Iterable<String> modifyClientGroups(@Auth AutomationClient automationClient,
@@ -206,7 +211,8 @@ public class ClientResource {
    * @responseMessage 200 Client lookup succeeded
    * @responseMessage 404 Client not found
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Path("{name}/secrets")
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientSecretsListing(@Auth AutomationClient automationClient,
@@ -227,7 +233,8 @@ public class ClientResource {
    * @responseMessage 204 Client deleted
    * @responseMessage 404 Client not found
    */
-  @DELETE @Timed
+  @Timed
+  @DELETE
   @Path("{name}")
   public Response deleteClient(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
@@ -249,7 +256,8 @@ public class ClientResource {
    * @responseMessage 201 Client updated
    * @responseMessage 404 Client not found
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Path("{name}")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
@@ -61,7 +61,8 @@ public class GroupResource {
    * @responseMessage 201 Created group
    * @responseMessage 409 Group already exists
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public Response createGroup(@Auth AutomationClient automationClient,
       @Valid CreateGroupRequestV2 request) {
@@ -84,7 +85,8 @@ public class GroupResource {
    * @excludeParams automationClient
    * @responseMessage 200 List of group names
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Produces(APPLICATION_JSON)
   public Iterable<String> groupListing(@Auth AutomationClient automationClient) {
     return groupDAO.getGroups().stream()
@@ -101,7 +103,8 @@ public class GroupResource {
    * @responseMessage 200 Group information retrieved
    * @responseMessage 404 Group not found
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public GroupDetailResponseV2 groupInfo(@Auth AutomationClient automationClient,
@@ -133,7 +136,8 @@ public class GroupResource {
    * @responseMessage 204 Group deleted
    * @responseMessage 404 Group not found
    */
-  @DELETE @Timed
+  @Timed
+  @DELETE
   @Path("{name}")
   public Response deleteGroup(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
@@ -61,7 +61,7 @@ public class GroupResource {
    * @responseMessage 201 Created group
    * @responseMessage 409 Group already exists
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public Response createGroup(@Auth AutomationClient automationClient,
       @Valid CreateGroupRequestV2 request) {
@@ -84,7 +84,7 @@ public class GroupResource {
    * @excludeParams automationClient
    * @responseMessage 200 List of group names
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Produces(APPLICATION_JSON)
   public Iterable<String> groupListing(@Auth AutomationClient automationClient) {
     return groupDAO.getGroups().stream()
@@ -101,7 +101,7 @@ public class GroupResource {
    * @responseMessage 200 Group information retrieved
    * @responseMessage 404 Group not found
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public GroupDetailResponseV2 groupInfo(@Auth AutomationClient automationClient,
@@ -133,7 +133,7 @@ public class GroupResource {
    * @responseMessage 204 Group deleted
    * @responseMessage 404 Group not found
    */
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   @Path("{name}")
   public Response deleteGroup(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
@@ -1,5 +1,8 @@
 package keywhiz.service.resources.automation.v2;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import java.net.URI;
 import java.util.Set;
@@ -58,7 +61,7 @@ public class GroupResource {
    * @responseMessage 201 Created group
    * @responseMessage 409 Group already exists
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public Response createGroup(@Auth AutomationClient automationClient,
       @Valid CreateGroupRequestV2 request) {
@@ -81,7 +84,7 @@ public class GroupResource {
    * @excludeParams automationClient
    * @responseMessage 200 List of group names
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Produces(APPLICATION_JSON)
   public Iterable<String> groupListing(@Auth AutomationClient automationClient) {
     return groupDAO.getGroups().stream()
@@ -98,7 +101,7 @@ public class GroupResource {
    * @responseMessage 200 Group information retrieved
    * @responseMessage 404 Group not found
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public GroupDetailResponseV2 groupInfo(@Auth AutomationClient automationClient,
@@ -130,7 +133,7 @@ public class GroupResource {
    * @responseMessage 204 Group deleted
    * @responseMessage 404 Group not found
    */
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}")
   public Response deleteGroup(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
@@ -1,7 +1,5 @@
 package keywhiz.service.resources.automation.v2;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import java.net.URI;

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -1,7 +1,5 @@
 package keywhiz.service.resources.automation.v2;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.Sets;
 import io.dropwizard.auth.Auth;

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -84,7 +84,7 @@ public class SecretResource {
    * @responseMessage 201 Created secret and assigned to given groups
    * @responseMessage 409 Secret already exists
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Consumes(APPLICATION_JSON)
   public Response createSecret(@Auth AutomationClient automationClient,
       @Valid CreateSecretRequestV2 request) {
@@ -129,7 +129,7 @@ public class SecretResource {
    * @excludeParams automationClient
    * @responseMessage 200 List of secret names
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Produces(APPLICATION_JSON)
   public Iterable<String> secretListing(@Auth AutomationClient automationClient) {
     return secretController.getSanitizedSecrets().stream()
@@ -145,7 +145,7 @@ public class SecretResource {
    * @responseMessage 201 Secret series modified successfully
    * @responseMessage 404 Secret series not found
    */
-  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @POST @Timed
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public SecretDetailResponseV2 modifySecretSeries(@Auth AutomationClient automationClient,
@@ -166,7 +166,7 @@ public class SecretResource {
    * @responseMessage 200 Secret series information retrieved
    * @responseMessage 404 Secret series not found
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public SecretDetailResponseV2 secretInfo(@Auth AutomationClient automationClient,
@@ -189,7 +189,7 @@ public class SecretResource {
    * @responseMessage 200 Listing succeeded
    * @responseMessage 404 Secret series not found
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Path("{name}/groups")
   public Iterable<String> secretGroupsListing(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
@@ -211,7 +211,7 @@ public class SecretResource {
    * @responseMessage 201 Group membership changed
    * @responseMessage 404 Secret series not found
    */
-  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @PUT @Timed
   @Path("{name}/groups")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
@@ -254,7 +254,7 @@ public class SecretResource {
    * @responseMessage 200 Secret information retrieved
    * @responseMessage 404 Secret not found
    */
-  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @GET @Timed
   @Path("{name}/{version:.*}")
   @Produces(APPLICATION_JSON)
   public SecretDetailResponseV2 secretVersionInfo(@Auth AutomationClient automationClient,
@@ -273,7 +273,7 @@ public class SecretResource {
    * @responseMessage 204 Secret series deleted
    * @responseMessage 404 Secret series not found
    */
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   @Path("{name}")
   public Response deleteSecretSeries(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
@@ -293,7 +293,7 @@ public class SecretResource {
    * @responseMessage 204 Secret version deleted
    * @responseMessage 404 Secret version not found
    */
-  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
+  @DELETE @Timed
   @Path("{name}/{version:.*}")
   public Response deleteSecretVersion(@Auth AutomationClient automationClient,
       @PathParam("name") String name, @PathParam("version") String version) {

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -1,5 +1,8 @@
 package keywhiz.service.resources.automation.v2;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.Sets;
 import io.dropwizard.auth.Auth;
 import java.util.List;
@@ -81,7 +84,7 @@ public class SecretResource {
    * @responseMessage 201 Created secret and assigned to given groups
    * @responseMessage 409 Secret already exists
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Consumes(APPLICATION_JSON)
   public Response createSecret(@Auth AutomationClient automationClient,
       @Valid CreateSecretRequestV2 request) {
@@ -126,7 +129,7 @@ public class SecretResource {
    * @excludeParams automationClient
    * @responseMessage 200 List of secret names
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Produces(APPLICATION_JSON)
   public Iterable<String> secretListing(@Auth AutomationClient automationClient) {
     return secretController.getSanitizedSecrets().stream()
@@ -142,7 +145,7 @@ public class SecretResource {
    * @responseMessage 201 Secret series modified successfully
    * @responseMessage 404 Secret series not found
    */
-  @POST
+  @POST @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public SecretDetailResponseV2 modifySecretSeries(@Auth AutomationClient automationClient,
@@ -163,7 +166,7 @@ public class SecretResource {
    * @responseMessage 200 Secret series information retrieved
    * @responseMessage 404 Secret series not found
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public SecretDetailResponseV2 secretInfo(@Auth AutomationClient automationClient,
@@ -186,7 +189,7 @@ public class SecretResource {
    * @responseMessage 200 Listing succeeded
    * @responseMessage 404 Secret series not found
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}/groups")
   public Iterable<String> secretGroupsListing(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
@@ -208,7 +211,7 @@ public class SecretResource {
    * @responseMessage 201 Group membership changed
    * @responseMessage 404 Secret series not found
    */
-  @PUT
+  @PUT @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}/groups")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
@@ -251,7 +254,7 @@ public class SecretResource {
    * @responseMessage 200 Secret information retrieved
    * @responseMessage 404 Secret not found
    */
-  @GET
+  @GET @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}/{version:.*}")
   @Produces(APPLICATION_JSON)
   public SecretDetailResponseV2 secretVersionInfo(@Auth AutomationClient automationClient,
@@ -270,7 +273,7 @@ public class SecretResource {
    * @responseMessage 204 Secret series deleted
    * @responseMessage 404 Secret series not found
    */
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}")
   public Response deleteSecretSeries(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
@@ -290,7 +293,7 @@ public class SecretResource {
    * @responseMessage 204 Secret version deleted
    * @responseMessage 404 Secret version not found
    */
-  @DELETE
+  @DELETE @Timed @Metered(name="QPS") @ExceptionMetered(name="ExceptionQPS")
   @Path("{name}/{version:.*}")
   public Response deleteSecretVersion(@Auth AutomationClient automationClient,
       @PathParam("name") String name, @PathParam("version") String version) {

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -84,7 +84,8 @@ public class SecretResource {
    * @responseMessage 201 Created secret and assigned to given groups
    * @responseMessage 409 Secret already exists
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Consumes(APPLICATION_JSON)
   public Response createSecret(@Auth AutomationClient automationClient,
       @Valid CreateSecretRequestV2 request) {
@@ -129,7 +130,8 @@ public class SecretResource {
    * @excludeParams automationClient
    * @responseMessage 200 List of secret names
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Produces(APPLICATION_JSON)
   public Iterable<String> secretListing(@Auth AutomationClient automationClient) {
     return secretController.getSanitizedSecrets().stream()
@@ -145,7 +147,8 @@ public class SecretResource {
    * @responseMessage 201 Secret series modified successfully
    * @responseMessage 404 Secret series not found
    */
-  @POST @Timed
+  @Timed
+  @POST
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public SecretDetailResponseV2 modifySecretSeries(@Auth AutomationClient automationClient,
@@ -166,7 +169,8 @@ public class SecretResource {
    * @responseMessage 200 Secret series information retrieved
    * @responseMessage 404 Secret series not found
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Path("{name}")
   @Produces(APPLICATION_JSON)
   public SecretDetailResponseV2 secretInfo(@Auth AutomationClient automationClient,
@@ -189,7 +193,8 @@ public class SecretResource {
    * @responseMessage 200 Listing succeeded
    * @responseMessage 404 Secret series not found
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Path("{name}/groups")
   public Iterable<String> secretGroupsListing(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
@@ -211,7 +216,8 @@ public class SecretResource {
    * @responseMessage 201 Group membership changed
    * @responseMessage 404 Secret series not found
    */
-  @PUT @Timed
+  @Timed
+  @PUT
   @Path("{name}/groups")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
@@ -254,7 +260,8 @@ public class SecretResource {
    * @responseMessage 200 Secret information retrieved
    * @responseMessage 404 Secret not found
    */
-  @GET @Timed
+  @Timed
+  @GET
   @Path("{name}/{version:.*}")
   @Produces(APPLICATION_JSON)
   public SecretDetailResponseV2 secretVersionInfo(@Auth AutomationClient automationClient,
@@ -273,7 +280,8 @@ public class SecretResource {
    * @responseMessage 204 Secret series deleted
    * @responseMessage 404 Secret series not found
    */
-  @DELETE @Timed
+  @Timed
+  @DELETE
   @Path("{name}")
   public Response deleteSecretSeries(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
@@ -293,7 +301,8 @@ public class SecretResource {
    * @responseMessage 204 Secret version deleted
    * @responseMessage 404 Secret version not found
    */
-  @DELETE @Timed
+  @Timed
+  @DELETE
   @Path("{name}/{version:.*}")
   public Response deleteSecretVersion(@Auth AutomationClient automationClient,
       @PathParam("name") String name, @PathParam("version") String version) {


### PR DESCRIPTION
(Updated.)

Adds a @Timed annotation to every endpoint in Keywhiz, so we get per-endpoint metrics.

It's not as fine-grained as I'd like, but it'll do.  Other Ad-hoc analysis (eg, per-client or by http status) will have to continue to use log files, but this at least gives us basic server health without munging logs.