### PR TITLE
Manual status healthcheck & admin servlet to control it

### DIFF
--- a/server/src/main/java/keywhiz/KeywhizService.java
+++ b/server/src/main/java/keywhiz/KeywhizService.java
@@ -202,9 +202,14 @@ public class KeywhizService extends Application<KeywhizConfig> {
     jersey.register(injector.getInstance(AutomationSecretAccessResource.class));
     jersey.register(injector.getInstance(AutomationSecretGeneratorsResource.class));
     jersey.register(injector.getInstance(StatusResource.class));
-    logger.debug("Keywhiz configuration complete");
+
+    ManualStatusHealthCheck mshc = new ManualStatusHealthCheck();
+    environment.healthChecks().register("manualStatus", mshc);
+    environment.admin().addServlet("manualStatus", new ManualStatusServlet(mshc)).addMapping("/status/*");
 
     validateDatabase(config);
+
+    logger.debug("Keywhiz configuration complete");
   }
 
   private void validateDatabase(KeywhizConfig config) {

--- a/server/src/main/java/keywhiz/ManualStatusHealthCheck.java
+++ b/server/src/main/java/keywhiz/ManualStatusHealthCheck.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keywhiz;
+
+import com.codahale.metrics.health.HealthCheck;
+import java.io.Serializable;
+
+/**  Returns unhealthy when the ManualStatus servlet gets called */
+public class ManualStatusHealthCheck extends HealthCheck implements Serializable {
+  private boolean healthy = true;
+
+  void setHealthy(boolean healthy) {
+    this.healthy = healthy;
+  }
+
+  @Override protected Result check() throws Exception {
+    if(this.healthy) {
+      return Result.healthy();
+    }
+    return Result.unhealthy("Server set unhealthy");
+  }
+}

--- a/server/src/main/java/keywhiz/ManualStatusServlet.java
+++ b/server/src/main/java/keywhiz/ManualStatusServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Square, Inc.
+ * Copyright (C) 2016 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/keywhiz/ManualStatusServlet.java
+++ b/server/src/main/java/keywhiz/ManualStatusServlet.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keywhiz;
+
+import java.io.IOException;
+import java.io.Serializable;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** A Servlet added to the Admin Connector for manually making _status report unhealthy */
+public class ManualStatusServlet extends HttpServlet implements Serializable {
+  private final ManualStatusHealthCheck mshc;
+
+  public ManualStatusServlet(ManualStatusHealthCheck mshc) {
+    this.mshc = mshc;
+  }
+
+  @Override protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    String path = req.getPathInfo();
+    if(path != null && path.equals("/enable")){
+      mshc.setHealthy(true);
+    } else if(path != null && path.equals("/disable")) {
+      mshc.setHealthy(false);
+    } else {
+      resp.sendError(HttpServletResponse.SC_NOT_FOUND,
+          "Need to pass /status/enable or /status/disable, not /status" + path);
+    }
+  }
+
+}


### PR DESCRIPTION
You can cause this healthcheck to go unhealthy with:
~ curl -X POST 'http://localhost:8085/status/disable'
And make it go healthy again:
~ curl -X POST 'http://localhost:8085/status/enable'

We add a servlet to the admin connector, so it's only available to localhost.

Note this doesn't change any behaviour of the server - it keeps accepting
requests.  It just causes the status check to return not-ok.

This is useful if, for example, your load balancer checks health and you want
to take a node out of the pool, perhaps because P2 is about to turn your node
off.