### PR TITLE
Connect to LDAP securely

### DIFF
--- a/server/src/main/java/keywhiz/auth/ldap/LdapAuthenticatorFactory.java
+++ b/server/src/main/java/keywhiz/auth/ldap/LdapAuthenticatorFactory.java
@@ -62,6 +62,16 @@ public class LdapAuthenticatorFactory implements UserAuthenticatorFactory {
   @NotNull @Valid
   private LdapLookupConfig lookup;
 
+  /** Trust store options for LDAP */
+  @NotEmpty
+  private String trustStorePath;
+
+  @NotEmpty
+  private String trustStorePassword;
+
+  @NotEmpty
+  private String trustStoreType;
+
   public String getServer() {
     return server;
   }
@@ -72,6 +82,18 @@ public class LdapAuthenticatorFactory implements UserAuthenticatorFactory {
 
   public String getUserDN() {
     return userDN;
+  }
+
+  public String getTrustStorePath() {
+    return trustStorePath;
+  }
+
+  public String getTrustStorePassword() {
+    return trustStorePassword;
+  }
+
+  public String getTrustStoreType() {
+    return trustStoreType;
   }
 
   @NotEmpty
@@ -93,7 +115,8 @@ public class LdapAuthenticatorFactory implements UserAuthenticatorFactory {
   @Override public Authenticator<BasicCredentials, User> build(DSLContext dslContext) {
     logger.debug("Creating LDAP authenticator");
     LdapConnectionFactory connectionFactory =
-        new LdapConnectionFactory(getServer(), getPort(), getUserDN(), getPassword());
+        new LdapConnectionFactory(getServer(), getPort(), getUserDN(), getPassword(),
+            getTrustStorePath(), getTrustStorePassword(), getTrustStoreType());
     return new LdapAuthenticator(connectionFactory, getLookup());
   }
 }

--- a/server/src/main/java/keywhiz/auth/ldap/LdapConnectionFactory.java
+++ b/server/src/main/java/keywhiz/auth/ldap/LdapConnectionFactory.java
@@ -16,28 +16,43 @@
 package keywhiz.auth.ldap;
 
 import com.unboundid.ldap.sdk.LDAPConnection;
+import com.unboundid.ldap.sdk.LDAPConnectionOptions;
 import com.unboundid.ldap.sdk.LDAPException;
-import javax.net.ssl.SSLSocketFactory;
+import com.unboundid.util.ssl.HostNameSSLSocketVerifier;
+import com.unboundid.util.ssl.SSLUtil;
+import com.unboundid.util.ssl.TrustStoreTrustManager;
+import java.security.GeneralSecurityException;
 
 public class LdapConnectionFactory {
   private final String server;
   private final int port;
   private final String userDN;
   private final String password;
+  private final String trustStorePath;
+  private final String trustStorePassword;
+  private final String trustStoreType;
 
-  public LdapConnectionFactory(String server, int port, String userDN, String password) {
+  public LdapConnectionFactory(String server, int port, String userDN, String password, String trustStorePath, String trustStorePassword, String trustStoreType) {
     this.server = server;
     this.port = port;
     this.userDN = userDN;
     this.password = password;
+    this.trustStorePath = trustStorePath;
+    this.trustStorePassword = trustStorePassword;
+    this.trustStoreType = trustStoreType;
   }
 
-  public LDAPConnection getLDAPConnection() throws LDAPException {
+  public LDAPConnection getLDAPConnection() throws LDAPException, GeneralSecurityException {
     return getLDAPConnection(userDN, password);
   }
 
-  public LDAPConnection getLDAPConnection(String userDN, String password) throws LDAPException {
-    LDAPConnection ldapConnection = new LDAPConnection(SSLSocketFactory.getDefault());
+  public LDAPConnection getLDAPConnection(String userDN, String password)
+      throws LDAPException, GeneralSecurityException {
+    TrustStoreTrustManager trust = new TrustStoreTrustManager(trustStorePath, trustStorePassword.toCharArray(), trustStoreType, false);
+    LDAPConnectionOptions options = new LDAPConnectionOptions();
+    options.setSSLSocketVerifier(new HostNameSSLSocketVerifier(false));
+    SSLUtil sslUtil = new SSLUtil(trust);
+    LDAPConnection ldapConnection = new LDAPConnection(sslUtil.createSSLSocketFactory("TLSv1.2"), options);
 
     // Connect, retrieve the DN of the user (if any)
     ldapConnection.connect(server, port);


### PR DESCRIPTION
Tell Keywhiz to validate LDAP hostnames
configure a trustStoreTrustManager with a given trust store.
Only use TLSv1.2 (hardcoded - do we want a config here too? We could have supportedProtocols, supportedCipherSuites)

Fixes #165 