### PR TITLE
Log if versioned api is being used.

### DIFF
--- a/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
@@ -101,6 +101,9 @@ public class SecretDeliveryResource {
     }
     String name = parts[0];
     String version = parts[1];
+    if (!version.equals("")) {
+      logger.error("Deprecated version feature still in use for %s!", secretName);
+    }
 
     Optional<SanitizedSecret> sanitizedSecret = aclDAO.getSanitizedSecretFor(client, name, version);
     Optional<Secret> secret = secretController.getSecretByNameAndVersion(name, version);

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -117,6 +117,9 @@ public class SecretsResource {
         return Response.ok().entity(listSecretsNameOnly(user)).build();
       }
     }
+    if (!version.equals("")) {
+      logger.error("Deprecated version feature still in use for %s!", name);
+    }
     return Response.ok().entity(retrieveSecret(user, name, version)).build();
   }
 
@@ -155,6 +158,7 @@ public class SecretsResource {
       // Must supply a secret name to find versions for
       throw new BadRequestException("Must supply secret name to find versions.");
     }
+    logger.error("Deprecated version feature still in use for %s!", name);
     return retrieveSecretVersions(user, name);
   }
 
@@ -197,6 +201,7 @@ public class SecretsResource {
       }
 
       if (request.withVersion) {
+        logger.error("Deprecated version feature still in use for %s!", request.name);
         builder.withVersion(VersionGenerator.now().toHex());
       }
 

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -98,6 +98,7 @@ public class SecretResource {
         .withType(request.type());
 
     if (request.versioned()) {
+      logger.error("Deprecated version feature still in use for %s!", name);
       builder.withVersion(VersionGenerator.now().toHex());
     }
 
@@ -265,6 +266,8 @@ public class SecretResource {
   @Produces(APPLICATION_JSON)
   public SecretDetailResponseV2 secretVersionInfo(@Auth AutomationClient automationClient,
       @PathParam("name") String name, @PathParam("version") String version) {
+    logger.error("Deprecated version feature still in use for %s!", name);
+
     Secret secret = secretController.getSecretByNameAndVersion(name, version)
         .orElseThrow(NotFoundException::new);
     return SecretDetailResponseV2.builder().secret(secret).build();
@@ -305,6 +308,9 @@ public class SecretResource {
   @Path("{name}/{version:.*}")
   public Response deleteSecretVersion(@Auth AutomationClient automationClient,
       @PathParam("name") String name, @PathParam("version") String version) {
+
+    logger.error("Deprecated version feature still in use for %s!", name);
+
     secretController.getSecretByNameAndVersion(name, version)
         .orElseThrow(NotFoundException::new);
     secretDAO.deleteSecretByNameAndVersion(name, version);


### PR DESCRIPTION
We are deleting all the secret versioning logic and replacing it with
transparent versioning. It's going to result in a simpler and easier to
use API.

If you depend on the current versioned secrets logic, you might end
up having to manually migrate data. We can try to help you on our
mailing list.

- [ ] @csstaub 
- [x] @mcpherrinm 