### PR TITLE
Make SecretContentDAO and SecretSeriesDAO visbility package-only

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
@@ -38,7 +38,7 @@ import static keywhiz.jooq.tables.SecretsContent.SECRETS_CONTENT;
 /**
  * Interacts with 'secrets_content' table and actions on {@link SecretContent} entities.
  */
-public class SecretContentDAO {
+class SecretContentDAO {
   private final DSLContext dslContext;
   private final ObjectMapper mapper;
   private final SecretContentMapper secretContentMapper;

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -185,7 +185,7 @@ public class SecretDAO {
     checkArgument(!name.isEmpty());
 
     secretSeriesDAOFactory.using(dslContext.configuration())
-            .deleteSecretSeriesByName(name);
+        .deleteSecretSeriesByName(name);
   }
 
   public static class SecretDAOFactory implements DAOFactory<SecretDAO> {

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -41,7 +41,7 @@ import static keywhiz.jooq.tables.SecretsContent.SECRETS_CONTENT;
 /**
  * Interacts with 'secrets' table and actions on {@link SecretSeries} entities.
  */
-public class SecretSeriesDAO {
+class SecretSeriesDAO {
   private final DSLContext dslContext;
   private final ObjectMapper mapper;
   private final SecretSeriesMapper secretSeriesMapper;

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.validation.Valid;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -50,8 +49,8 @@ import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import keywhiz.service.daos.SecretController;
-import keywhiz.service.daos.SecretSeriesDAO;
-import keywhiz.service.daos.SecretSeriesDAO.SecretSeriesDAOFactory;
+import keywhiz.service.daos.SecretDAO;
+import keywhiz.service.daos.SecretDAO.SecretDAOFactory;
 import keywhiz.service.exceptions.ConflictException;
 import org.jooq.exception.DataAccessException;
 import org.slf4j.Logger;
@@ -73,20 +72,18 @@ public class SecretsResource {
 
   private final SecretController secretController;
   private final AclDAO aclDAO;
-  private final SecretSeriesDAO secretSeriesDAO;
+  private final SecretDAO secretDAO;
 
-  @Inject public SecretsResource(SecretController secretController, AclDAOFactory aclDAOFactory,
-      SecretSeriesDAOFactory secretSeriesDAOFactory) {
+  @Inject public SecretsResource(SecretController secretController, AclDAOFactory aclDAOFactory, SecretDAOFactory secretDAOFactory) {
     this.secretController = secretController;
     this.aclDAO = aclDAOFactory.readwrite();
-    this.secretSeriesDAO = secretSeriesDAOFactory.readwrite();
+    this.secretDAO = secretDAOFactory.readwrite();
   }
 
-  @VisibleForTesting SecretsResource(SecretController secretController, AclDAO aclDAO,
-      SecretSeriesDAO secretSeriesDAO) {
+  @VisibleForTesting SecretsResource(SecretController secretController, AclDAO aclDAO, SecretDAO secretDAO) {
     this.secretController = secretController;
     this.aclDAO = aclDAO;
-    this.secretSeriesDAO = secretSeriesDAO;
+    this.secretDAO = secretDAO;
   }
 
   /**
@@ -220,7 +217,7 @@ public class SecretsResource {
 
     logger.info("User '{}' deleting secret id={}, name='{}'", user, secretId, secret.get().getName());
 
-    secretSeriesDAO.deleteSecretSeriesById(secretId.get());
+    secretDAO.deleteSecretsByName(secret.get().getName());
     return Response.noContent().build();
   }
 

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
@@ -44,8 +44,8 @@ import keywhiz.api.model.Secret;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.AclDAO.AclDAOFactory;
 import keywhiz.service.daos.SecretController;
-import keywhiz.service.daos.SecretSeriesDAO;
-import keywhiz.service.daos.SecretSeriesDAO.SecretSeriesDAOFactory;
+import keywhiz.service.daos.SecretDAO;
+import keywhiz.service.daos.SecretDAO.SecretDAOFactory;
 import keywhiz.service.exceptions.ConflictException;
 import keywhiz.service.resources.automation.v2.SecretResource;
 import org.jooq.exception.DataAccessException;
@@ -67,20 +67,20 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 public class AutomationSecretResource {
   private static final Logger logger = LoggerFactory.getLogger(AutomationSecretResource.class);
   private final SecretController secretController;
-  private final SecretSeriesDAO secretSeriesDAO;
+  private final SecretDAO secretDAO;
   private final AclDAO aclDAO;
 
   @Inject public AutomationSecretResource(SecretController secretController,
-      SecretSeriesDAOFactory secretSeriesDAOFactory, AclDAOFactory aclDAOFactory) {
+                                          SecretDAOFactory secretDAOFactory, AclDAOFactory aclDAOFactory) {
     this.secretController = secretController;
-    this.secretSeriesDAO = secretSeriesDAOFactory.readwrite();
+    this.secretDAO = secretDAOFactory.readwrite();
     this.aclDAO = aclDAOFactory.readwrite();
   }
 
   @VisibleForTesting AutomationSecretResource(SecretController secretController,
-      SecretSeriesDAO secretSeriesDAO, AclDAO aclDAO) {
+                                              SecretDAO secretDAO, AclDAO aclDAO) {
     this.secretController = secretController;
-    this.secretSeriesDAO = secretSeriesDAO;
+    this.secretDAO = secretDAO;
     this.aclDAO = aclDAO;
   }
 
@@ -211,9 +211,9 @@ public class AutomationSecretResource {
       @Auth AutomationClient automationClient,
       @PathParam("secretName") String secretName) {
 
-    secretSeriesDAO.getSecretSeriesByName(secretName)
+    secretDAO.getSecretByNameOne(secretName)
         .orElseThrow(() -> new NotFoundException("Secret series not found."));
-    secretSeriesDAO.deleteSecretSeriesByName(secretName);
+    secretDAO.deleteSecretsByName(secretName);
 
     return Response.ok().build();
   }

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -37,7 +37,7 @@ import keywhiz.api.model.Secret;
 import keywhiz.auth.User;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.SecretController;
-import keywhiz.service.daos.SecretSeriesDAO;
+import keywhiz.service.daos.SecretDAO;
 import keywhiz.service.exceptions.ConflictException;
 import org.jooq.exception.DataAccessException;
 import org.junit.Before;
@@ -59,7 +59,7 @@ public class SecretsResourceTest {
   @Rule public MockitoRule mockito = MockitoJUnit.rule();
 
   @Mock AclDAO aclDAO;
-  @Mock SecretSeriesDAO secretSeriesDAO;
+  @Mock SecretDAO secretDAO;
   @Mock SecretController secretController;
 
   User user = User.named("user");
@@ -72,7 +72,7 @@ public class SecretsResourceTest {
 
   @Before
   public void setUp() {
-    resource = new SecretsResource(secretController, aclDAO, secretSeriesDAO);
+    resource = new SecretsResource(secretController, aclDAO, secretDAO);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class SecretsResourceTest {
     when(secretController.getSecretByIdOne(0xdeadbeef)).thenReturn(Optional.of(secret));
 
     Response response = resource.deleteSecret(user, new LongParam(Long.toString(0xdeadbeef)));
-    verify(secretSeriesDAO).deleteSecretSeriesById(0xdeadbeef);
+    verify(secretDAO).deleteSecretsByName("name");
     assertThat(response.getStatus()).isEqualTo(204);
   }
 

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationSecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationSecretResourceTest.java
@@ -21,13 +21,10 @@ import java.util.Optional;
 import keywhiz.api.ApiDate;
 import keywhiz.api.AutomationSecretResponse;
 import keywhiz.api.CreateSecretRequest;
-import keywhiz.api.model.AutomationClient;
-import keywhiz.api.model.Client;
-import keywhiz.api.model.Secret;
-import keywhiz.api.model.SecretSeries;
+import keywhiz.api.model.*;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.SecretController;
-import keywhiz.service.daos.SecretSeriesDAO;
+import keywhiz.service.daos.SecretDAO;
 import keywhiz.service.exceptions.ConflictException;
 import org.jooq.exception.DataAccessException;
 import org.junit.Before;
@@ -56,14 +53,14 @@ public class AutomationSecretResourceTest {
   @Mock SecretController secretController;
   @Mock SecretController.SecretBuilder secretBuilder;
   @Mock AclDAO aclDAO;
-  @Mock SecretSeriesDAO secretSeriesDAO;
+  @Mock SecretDAO secretDAO;
 
   AutomationClient automation = AutomationClient.of(
       new Client(1, "automation", "Automation client", NOW, "test", NOW, "test", true, true));
 
   @Before
   public void setUp() {
-    resource = new AutomationSecretResource(secretController, secretSeriesDAO, aclDAO);
+    resource = new AutomationSecretResource(secretController, secretDAO, aclDAO);
 
     when(secretController.builder(anyString(), anyString(), anyString(), anyLong())).thenReturn(secretBuilder);
     when(secretBuilder.withDescription(anyString())).thenReturn(secretBuilder);
@@ -114,11 +111,11 @@ public class AutomationSecretResourceTest {
         null,
         null);
 
-    when(secretSeriesDAO.getSecretSeriesByName(secretSeries.name()))
-        .thenReturn(Optional.of(secretSeries));
+    when(secretDAO.getSecretByNameOne(secretSeries.name()))
+        .thenReturn(Optional.of(SecretSeriesAndContent.of(secretSeries, SecretContent.of(123, secretSeries.id(), "meh", NOW, null, NOW, null, ImmutableMap.of()))));
 
     resource.deleteSecretSeries(automation, "mySecret");
-    verify(secretSeriesDAO).deleteSecretSeriesByName(secretSeries.name());
+    verify(secretDAO).deleteSecretsByName(secretSeries.name());
   }
 
   @Test(expected = ConflictException.class)


### PR DESCRIPTION
The code is lower level than SecretDAO and delegates some checks to SecretDAO. I think
it's cleaner to downgrade their visibiliy. Also fix up some code which was referred to these
classes instead of SecretDAO.