### PR TITLE
Fixed 404 on Docs

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -55,7 +55,7 @@
             <p>Feel free to join and post questions on our <a href="https://groups.google.com/forum/#!forum/keywhiz-users">mailing list</a>,
               we &#x2665; new users!</p>
             <h3 id="source">Source code</h3>
-            <p>Keywhiz is open source and available on <a href="github.com/square/keywhiz">github.com/square/keywhiz</a>.</p>
+            <p>Keywhiz is open source and available on <a href="https://github.com/square/keywhiz">github.com/square/keywhiz</a>.</p>
           </div>
         </div>
         <div class="row">


### PR DESCRIPTION
The link to the github code is missing the protocol, causing a 404 final address.

Prefixed `https://` to the address.