### PR TITLE
Allow -Dcustom.build.directory=foo to override the normal target folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
     <pgjdbc-ng.version>0.5</pgjdbc-ng.version>
     <mysql.version>5.1.35</mysql.version>
     <logback.version>1.1.3</logback.version>
+
+    <custom.build.directory>target</custom.build.directory>
   </properties>
 
   <scm>
@@ -329,6 +331,7 @@
   </dependencyManagement>
 
   <build>
+    <directory>${custom.build.directory}</directory>
     <plugins>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
This is useful if you want to do multiple builds in the same source tree (but perhaps, with different profiles)

Example usage:
mvn package -am -pl server -pl cli -P h2 -Dcustom.build.directory=h2-target