### PR TITLE
Fixing missing annotation in automation v2 API for secrets

### DIFF
--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -226,6 +226,7 @@ public class SecretResource {
   @Timed @ExceptionMetered
   @GET
   @Path("{name}/groups")
+  @Produces(APPLICATION_JSON)
   public Iterable<String> secretGroupsListing(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
     // TODO: Use latest version instead of non-versioned


### PR DESCRIPTION
The missing annotation cause the serializer to fall back to the default media type which might not be supported.

```
127.0.0.1 - - [06/Aug/2016:03:14:25 +0000] "GET /automation/v2/secrets/secret.key HTTP/1.1" 200 135 "-" "Apache-HttpClient/4.5.1 (Java/1.8.0_60)" 46
ERROR [2016-08-06 03:14:25,518] org.glassfish.jersey.message.internal.WriterInterceptorExecutor: MessageBodyWriter not found for media type=application/xml, type=class java.util.HashSet, genericType=java.lang.Iterable<java.lang.String>.
```


