### PR TITLE
Fixes the test secretListingExpiry_success

### DIFF
--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -236,38 +236,41 @@ public class SecretResourceTest {
     createGroup("group15a");
     createGroup("group15b");
 
+    // get current time to calculate timestamps off for expiry
+    long now = System.currentTimeMillis() / 1000L;
+
     // add some secrets
     create(CreateSecretRequestV2.builder()
         .name("secret17")
         .content(encoder.encodeToString("supa secret17".getBytes(UTF_8)))
-        .expiry(1470096000)
+        .expiry(now+86400*3)
         .groups("group15a", "group15b")
         .build());
 
     create(CreateSecretRequestV2.builder()
         .name("secret18")
         .content(encoder.encodeToString("supa secret18".getBytes(UTF_8)))
-        .expiry(1469923200)
+        .expiry(now+86400)
         .groups("group15a")
         .build());
 
     create(CreateSecretRequestV2.builder()
         .name("secret19")
         .content(encoder.encodeToString("supa secret19".getBytes(UTF_8)))
-        .expiry(1470009600)
+        .expiry(now+86400*2)
         .groups("group15b")
         .build());
 
     // check limiting by group and expiry
-    List<String> s1 = listExpiring(1470355200L, "group15a");
+    List<String> s1 = listExpiring(now+86400*4, "group15a");
     assertThat(s1).contains("secret17");
     assertThat(s1).contains("secret18");
 
-    List<String> s2 = listExpiring(1470355200L, "group15b");
+    List<String> s2 = listExpiring(now+86400*4, "group15b");
     assertThat(s2).contains("secret19");
     assertThat(s2).doesNotContain("secret18");
 
-    List<String> s3 = listExpiring(1470009600L, null);
+    List<String> s3 = listExpiring(now+86400*2, null);
     assertThat(s3).contains("secret18");
     assertThat(s3).doesNotContain("secret17");
   }


### PR DESCRIPTION
Original version of this test had hardcoded timestamps, which are now in the past. Thus, all the secrets added in the test are already expired when the test runs, so none are retrieved and the test fails. The person who wrote this test is clearly an idiot.

Yes, it was me... :(

Fixed to use times relative to current time.

r: @csstaub @worldwise001

