### PR TITLE
Allows for custom metadata entries on new secrets in CLI

### DIFF
--- a/cli/src/main/java/keywhiz/cli/commands/AddAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/AddAction.java
@@ -189,9 +189,9 @@ public class AddAction implements Runnable {
           throw new IllegalArgumentException(
               format("Illegal metadata key %s: custom metadata keys must start with an underscore", key));
         }
-        if(!key.matches("^[a-zA-Z0-9_]*$")) {
+        if(!key.matches("^[a-zA-Z_0-9\\-.:]+$")) {
           throw new IllegalArgumentException(
-              format("Illegal metadata key %s: metadata keys can only contain letters, numbers, and underscores", key));
+              format("Illegal metadata key %s: metadata keys can only contain: a-z A-Z 0-9 _ - . :", key));
         }
       }
 

--- a/cli/src/main/java/keywhiz/cli/commands/AddAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/AddAction.java
@@ -185,7 +185,14 @@ public class AddAction implements Runnable {
 
       // We want to perform strong validation of the metadata to make sure it is well formed.
       if (!key.matches("(owner|group|mode)")) {
-        throw new IllegalArgumentException(format("Illegal metadata key %s", key));
+        if(!key.startsWith("_")) {
+          throw new IllegalArgumentException(
+              format("Illegal metadata key %s: custom metadata keys must start with an underscore", key));
+        }
+        if(!key.matches("^[a-zA-Z0-9_]*$")) {
+          throw new IllegalArgumentException(
+              format("Illegal metadata key %s: metadata keys can only contain letters, numbers, and underscores", key));
+        }
       }
 
       if (key.equals("mode") && !value.matches("0[0-7]+")) {

--- a/cli/src/main/java/keywhiz/cli/commands/CreateOrUpdateAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/CreateOrUpdateAction.java
@@ -117,7 +117,14 @@ public class CreateOrUpdateAction implements Runnable {
 
       // We want to perform strong validation of the metadata to make sure it is well formed.
       if (!key.matches("(owner|group|mode)")) {
-        throw new IllegalArgumentException(format("Illegal metadata key %s", key));
+        if(!key.startsWith("_")) {
+          throw new IllegalArgumentException(
+              format("Illegal metadata key %s: custom metadata keys must start with an underscore", key));
+        }
+        if(!key.matches("^[a-zA-Z0-9_]*$")) {
+          throw new IllegalArgumentException(
+              format("Illegal metadata key %s: metadata keys can only contain letters, numbers, and underscores", key));
+        }
       }
 
       if (key.equals("mode") && !value.matches("0[0-7]+")) {

--- a/cli/src/main/java/keywhiz/cli/commands/CreateOrUpdateAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/CreateOrUpdateAction.java
@@ -121,9 +121,9 @@ public class CreateOrUpdateAction implements Runnable {
           throw new IllegalArgumentException(
               format("Illegal metadata key %s: custom metadata keys must start with an underscore", key));
         }
-        if(!key.matches("^[a-zA-Z0-9_]*$")) {
+        if(!key.matches("^[a-zA-Z_0-9\\-.:]+$")) {
           throw new IllegalArgumentException(
-              format("Illegal metadata key %s: metadata keys can only contain letters, numbers, and underscores", key));
+              format("Illegal metadata key %s: metadata keys can only contain: a-z A-Z 0-9 _ - . :", key));
         }
       }
 


### PR DESCRIPTION
Includes some restrictions on naming keys.

This is the only place I could find that put any restriction on what could be included in metadata.

r: @csstaub @worldwise001 @mcpherrinm @jbpeirce 