### PR TITLE
Fix bug in setCurrentVersion's handling of invalid version numbers

### DIFF
--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -257,6 +257,7 @@ public class SecretResource {
    * @param versionId The desired current version
    * @excludeParams automationClient
    * @responseMessage 200 Secret series current version updated successfully
+   * @responseMessage 400 Invalid secret version specified
    * @responseMessage 404 Secret series not found
    */
   @Timed @ExceptionMetered
@@ -266,7 +267,8 @@ public class SecretResource {
       @PathParam("name") String name, @PathParam("versionId") long versionId) {
     secretDAO.setCurrentSecretVersionByName(name, versionId);
 
-    // If the secret wasn't found, setCurrentSecretVersionByName already threw a NotFoundException
+    // If the secret wasn't found or the request was misformed, setCurrentSecretVersionByName
+    // already threw an exception
     return Response.status(Response.Status.OK).build();
   }
 


### PR DESCRIPTION
If `setCurrentVersion` had been called with a version number that did not correspond to an ID in the `secrets_content` table, it would have thrown a `NullPointerException` when `fetchOne()` returned `null`.  This is now checked for.