### PR TITLE
Instruct people to add-user instead of db-seed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@
 #   Create a persistent data volume:
 #     docker volume create --name keywhiz-db-devel
 #
-#   Initialize the database, apply migrations, and add seed data:
+#   Initialize the database, apply migrations, and add administrative user:
 #     docker run -v keywhiz-db-devel:/data square/keywhiz migrate
-#     docker run -v keywhiz-db-devel:/data square/keywhiz db-seed
+#     docker run -v keywhiz-db-devel:/data square/keywhiz add-user
 #
 #   Finally, run the server with the default development config:
 #     docker run -it -p 4444:4444 -v keywhiz-db-devel:/data square/keywhiz server

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run Keywhiz:
 
     java -jar server/target/keywhiz-server-*-shaded.jar [COMMAND] [OPTIONS] 
 
-Useful commands to get started are `migrate`, `db-seed` and `server`. Use with
+Useful commands to get started are `migrate`, `add-user` and `server`. Use with
 `--help` for a list of all available commands. Use with `[COMMAND] --help` to
 get help on a particular command.
 
@@ -38,8 +38,8 @@ For example, to run Keywhiz with an H2 database in development mode:
     # Initialize dev database (H2)
     java -jar $SERVER_JAR migrate $KEYWHIZ_CONFIG
 
-    # Seed database with development data
-    java -jar $SERVER_JAR db-seed $KEYWHIZ_CONFIG
+    # Add an administrative user
+    java -jar $SERVER_JAR add-user $KEYWHIZ_CONFIG
 
     # Run server
     java -jar $SERVER_JAR server $KEYWHIZ_CONFIG

--- a/website/index.html
+++ b/website/index.html
@@ -153,8 +153,8 @@
             <pre class="prettyprint">$ java -jar server/target/keywhiz-server-*-SNAPSHOT-shaded.jar preview-migrate server/src/main/resources/keywhiz-development.yaml
 $ java -jar server/target/keywhiz-server-*-SNAPSHOT-shaded.jar migrate server/src/main/resources/keywhiz-development.yaml</pre>
 
-            <p>(Optional) Import some development data:</p>
-            <pre class="prettyprint">$ java -jar server/target/keywhiz-server-*-SNAPSHOT-shaded.jar db-seed server/src/main/resources/keywhiz-development.yaml</pre>
+            <p>Add an administrative user:</p>
+            <pre class="prettyprint">$ java -jar server/target/keywhiz-server-*-SNAPSHOT-shaded.jar add-user server/src/main/resources/keywhiz-development.yaml</pre>
 
             <p>Start the server:</p>
             <pre class="prettyprint">$ java -jar server/target/keywhiz-server-*-SNAPSHOT-shaded.jar server server/src/main/resources/keywhiz-development.yaml</pre>


### PR DESCRIPTION
db-seed puts a bunch of crap data in your database.  It's useful for unit tests, but not for users.

However, some people rely on it for adding an admin user.  We should explicitly say to do that instead.