### PR TITLE
docker run -ti is required to allow user input with adduser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 #
 #   Initialize the database, apply migrations, and add administrative user:
 #     docker run -v keywhiz-db-devel:/data square/keywhiz migrate
-#     docker run -v keywhiz-db-devel:/data square/keywhiz add-user
+#     docker run -it -v keywhiz-db-devel:/data square/keywhiz add-user
 #
 #   Finally, run the server with the default development config:
 #     docker run -it -p 4444:4444 -v keywhiz-db-devel:/data square/keywhiz server


### PR DESCRIPTION
There was an error when the add-user is executed without ```docker run --ti```:
```
------------------------------------------------------------------------
---    No configuration file specified, using development config!    ---
--- Use the KEYWHIZ_CONFIG environment variable to set a config file ---
------------------------------------------------------------------------
New username:Exception in thread "main" java.lang.NullPointerException
        at keywhiz.commands.AddUserCommand.run(AddUserCommand.java:41)
        at keywhiz.commands.AddUserCommand.run(AddUserCommand.java:29)
        at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:76)
        at io.dropwizard.cli.Cli.run(Cli.java:70)
        at io.dropwizard.Application.run(Application.java:73)
        at keywhiz.KeywhizService.main(KeywhizService.java:71)
```