### PR TITLE
Alter SanitizedSecret to contain group names for secret

### DIFF
--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -48,7 +48,7 @@ public abstract class SanitizedSecret {
       @JsonProperty("type") @Nullable String type,
       @JsonProperty("generationOptions") @Nullable Map<String, String> generationOptions,
       @JsonProperty("expiry") long expiry,
-      @JsonProperty("groups") @Nullable List<String> groups) {
+      @JsonProperty("groups") List<String> groups) {
     ImmutableMap<String, String> meta =
         (metadata == null) ? ImmutableMap.of() : ImmutableMap.copyOf(metadata);
     ImmutableMap<String, String> genOptions =

--- a/api/src/test/java/keywhiz/api/SecretsResponseTest.java
+++ b/api/src/test/java/keywhiz/api/SecretsResponseTest.java
@@ -18,6 +18,8 @@ package keywhiz.api;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Collections;
 import keywhiz.api.model.SanitizedSecret;
 import org.junit.Test;
 
@@ -39,7 +41,8 @@ public class SecretsResponseTest {
             ImmutableMap.of("owner", "the king"),
             "password",
             ImmutableMap.of("param1", "value1"),
-            1136214245),
+            1136214245,
+            Collections.singletonList("empire")),
         SanitizedSecret.of(
             768,
             "anotherSecret",
@@ -51,7 +54,8 @@ public class SecretsResponseTest {
             null,
             "upload",
             null,
-            1136214245)
+            1136214245,
+            Collections.singletonList("empire"))
     ));
 
     assertThat(asJson(secretsResponse))

--- a/api/src/test/java/keywhiz/api/model/SanitizedSecretTest.java
+++ b/api/src/test/java/keywhiz/api/model/SanitizedSecretTest.java
@@ -17,6 +17,7 @@
 package keywhiz.api.model;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import keywhiz.api.ApiDate;
 import org.junit.Test;
 
@@ -37,7 +38,8 @@ public class SanitizedSecretTest {
         ImmutableMap.of("owner", "the king"),
         "password",
         ImmutableMap.of("favoriteFood", "PB&J sandwich"),
-        1136214245);
+        1136214245,
+        Collections.singletonList("empire"));
 
     assertThat(asJson(sanitizedSecret))
         .isEqualTo(jsonFixture("fixtures/sanitizedSecret.json"));

--- a/api/src/test/resources/fixtures/sanitizedSecret.json
+++ b/api/src/test/resources/fixtures/sanitizedSecret.json
@@ -13,5 +13,6 @@
   "generationOptions" : {
     "favoriteFood" : "PB&J sandwich"
   },
-  "expiry": 1136214245
+  "expiry": 1136214245,
+  "groups": ["empire"]
 }

--- a/api/src/test/resources/fixtures/secretsResponse.json
+++ b/api/src/test/resources/fixtures/secretsResponse.json
@@ -15,7 +15,8 @@
       "generationOptions" : {
         "param1" : "value1"
       },
-      "expiry" : 1136214245
+      "expiry" : 1136214245,
+      "groups" : ["empire"]
     },
     {
       "id" : 768,
@@ -28,7 +29,8 @@
       "metadata" : {},
       "type" : "upload",
       "generationOptions" : {},
-      "expiry" : 1136214245
+      "expiry" : 1136214245,
+      "groups" : ["empire"]
     }
   ]
 }

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -198,12 +198,16 @@ public class AclDAO {
   }
 
   public Set<Group> getGroupsFor(Secret secret) {
+    return getGroupsFor(secret.getName());
+  }
+
+  public Set<Group> getGroupsFor(String secretName) {
     List<Group> r = dslContext
         .select(GROUPS.fields())
         .from(GROUPS)
         .join(ACCESSGRANTS).on(GROUPS.ID.eq(ACCESSGRANTS.GROUPID))
         .join(SECRETS).on(ACCESSGRANTS.SECRETID.eq(SECRETS.ID))
-        .where(SECRETS.NAME.eq(secret.getName()))
+        .where(SECRETS.NAME.eq(secretName))
         .fetchInto(GROUPS)
         .map(groupMapper);
     return new HashSet<>(r);
@@ -269,11 +273,7 @@ public class AclDAO {
               row.getValue(SECRETS_CONTENT.EXPIRY),
               Collections.emptyList()
           );
-          LazyString lazyString = () -> "";
-          Set<Group> groups = getGroupsFor(
-              new Secret(secret.id(), secret.name(), secret.description(), lazyString, secret.createdAt(),
-                  secret.createdBy(), secret.updatedAt(), secret.updatedBy(), secret.metadata(), secret.type().orElse(null), secret.generationOptions(),
-                  secret.expiry()));
+          Set<Group> groups = getGroupsFor(secret.name());
           List<String> groupNames = groups.stream().map(Group::getName).collect(
               Collectors.toList());
           return SanitizedSecret.fromSecretWithGroups(secret, groupNames);
@@ -333,11 +333,7 @@ public class AclDAO {
               series.generationOptions(),
               row.getValue(SECRETS_CONTENT.EXPIRY),
               Collections.emptyList());
-          LazyString lazyString = () -> "";
-          Set<Group> groups = getGroupsFor(
-              new Secret(secret.id(), secret.name(), secret.description(), lazyString, secret.createdAt(),
-                  secret.createdBy(), secret.updatedAt(), secret.updatedBy(), secret.metadata(), secret.type().orElse(null), secret.generationOptions(),
-                  secret.expiry()));
+          Set<Group> groups = getGroupsFor(secret.name());
           List<String> groupNames = groups.stream().map(Group::getName).collect(
               Collectors.toList());
           return SanitizedSecret.fromSecretWithGroups(secret, groupNames);

--- a/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
@@ -17,6 +17,7 @@ package keywhiz.service.resources.admin;
 
 import com.google.common.collect.ImmutableSet;
 import io.dropwizard.jersey.params.LongParam;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.ws.rs.BadRequestException;
@@ -90,8 +91,9 @@ public class GroupsResourceTest {
   @Test public void getSpecificIncludesAllTheThings() {
     when(groupDAO.getGroupById(4444)).thenReturn(Optional.of(group));
 
-    SanitizedSecret secret = SanitizedSecret.of(1, "name", null, now, "creator", now, "creator", null, null, null,
-        1136214245);
+    SanitizedSecret secret =
+        SanitizedSecret.of(1, "name", null, now, "creator", now, "creator", null, null, null,
+            1136214245, Collections.emptyList());
     when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of(secret));
 
     Client client = new Client(1, "client", "desc", now, "creator", now, "creator", true, false);

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -80,9 +80,9 @@ public class SecretsResourceTest {
   @Test
   public void listSecrets() {
     SanitizedSecret secret1 = SanitizedSecret.of(1, "name1", "desc", NOW, "user", NOW, "user",
-        emptyMap, null, null, 1136214245);
+        emptyMap, null, null, 1136214245, Collections.emptyList());
     SanitizedSecret secret2 = SanitizedSecret.of(2, "name2", "desc", NOW, "user", NOW, "user",
-        emptyMap, null, null, 1136214245);
+        emptyMap, null, null, 1136214245, Collections.emptyList());
     when(secretController.getSanitizedSecrets(null, null)).thenReturn(ImmutableList.of(secret1, secret2));
 
     List<SanitizedSecret> response = resource.listSecrets(user);

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationGroupResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationGroupResourceTest.java
@@ -19,6 +19,7 @@ package keywhiz.service.resources.automation;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.dropwizard.jersey.params.LongParam;
+import java.util.Collections;
 import java.util.Optional;
 import javax.ws.rs.core.Response;
 import keywhiz.api.ApiDate;
@@ -80,13 +81,16 @@ public class AutomationGroupResourceTest {
   }
 
   @Test public void groupIncludesClientsAndSecrets() {
-    Group group = new Group(50, "testGroup", "testing group", now, "automation client", now, "automation client");
+    Group group = new Group(50, "testGroup", "testing group", now, "automation client", now,
+        "automation client");
     Client groupClient =
         new Client(1, "firstClient", "Group client", now, "test", now, "test", true, true);
     SanitizedSecret firstGroupSecret =
-        SanitizedSecret.of(1, "name1", "desc", now, "test", now, "test", null, "", null, 1136214245);
+        SanitizedSecret.of(1, "name1", "desc", now, "test", now, "test", null, "", null, 1136214245,
+            Collections.emptyList());
     SanitizedSecret secondGroupSecret =
-        SanitizedSecret.of(2, "name2", "desc", now, "test", now, "test", null, "", null, 1136214245);
+        SanitizedSecret.of(2, "name2", "desc", now, "test", now, "test", null, "", null, 1136214245,
+            Collections.emptyList());
 
     when(groupDAO.getGroup("testGroup")).thenReturn(Optional.of(group));
     when(aclDAO.getClientsFor(group)).thenReturn(ImmutableSet.of(groupClient));


### PR DESCRIPTION
SanitizedSecret responses now include a list of the names of the groups with which a secret is associated.  