### PR TITLE
Remove groups from secrets

### DIFF
--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,7 +31,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.nullToEmpty;
 
 /**
- * {@link Secret} object, but without the secret content and with an optional list of associated groups.
+ * {@link Secret} object, but without the secret content.
  */
 @AutoValue
 public abstract class SanitizedSecret {
@@ -47,20 +46,18 @@ public abstract class SanitizedSecret {
       @JsonProperty("metadata") @Nullable Map<String, String> metadata,
       @JsonProperty("type") @Nullable String type,
       @JsonProperty("generationOptions") @Nullable Map<String, String> generationOptions,
-      @JsonProperty("expiry") long expiry,
-      @JsonProperty("groups") @Nullable List<String> groups) {
+      @JsonProperty("expiry") long expiry) {
     ImmutableMap<String, String> meta =
         (metadata == null) ? ImmutableMap.of() : ImmutableMap.copyOf(metadata);
     ImmutableMap<String, String> genOptions =
         (generationOptions == null) ? ImmutableMap.of() : ImmutableMap.copyOf(generationOptions);
     return new AutoValue_SanitizedSecret(id, name, nullToEmpty(description), createdAt,
         nullToEmpty(createdBy), updatedAt, nullToEmpty(updatedBy), meta, Optional.ofNullable(type),
-        genOptions, expiry, groups);
+        genOptions, expiry);
   }
 
   public static SanitizedSecret of(long id, String name) {
-    return of(id, name, null, new ApiDate(0), null, new ApiDate(0), null, null, null, null, 0,
-        Collections.emptyList());
+    return of(id, name, null, new ApiDate(0), null, new ApiDate(0), null, null, null, null, 0);
   }
 
   public static SanitizedSecret fromSecretSeriesAndContent(SecretSeriesAndContent seriesAndContent) {
@@ -77,8 +74,7 @@ public abstract class SanitizedSecret {
         content.metadata(),
         series.type().orElse(null),
         series.generationOptions(),
-        content.expiry(),
-        Collections.emptyList());
+        content.expiry());
   }
 
   /**
@@ -100,32 +96,7 @@ public abstract class SanitizedSecret {
         secret.getMetadata(),
         secret.getType().orElse(null),
         secret.getGenerationOptions(),
-        secret.getExpiry(),
-        Collections.emptyList());
-  }
-
-  /**
-   * Build a matching SanitizedSecret with the given groups
-   *
-   * @param sanitizedSecret SanitizedSecret model to build from
-   * @param groups A list of group names for this secret
-   * @return A copy of this secret with group information added
-   */
-  public static SanitizedSecret fromSecretWithGroups(SanitizedSecret sanitizedSecret, List<String> groups) {
-    checkNotNull(sanitizedSecret);
-    return SanitizedSecret.of(
-        sanitizedSecret.id(),
-        sanitizedSecret.name(),
-        sanitizedSecret.description(),
-        sanitizedSecret.createdAt(),
-        sanitizedSecret.createdBy(),
-        sanitizedSecret.updatedAt(),
-        sanitizedSecret.updatedBy(),
-        sanitizedSecret.metadata(),
-        sanitizedSecret.type().orElse(null),
-        sanitizedSecret.generationOptions(),
-        sanitizedSecret.expiry(),
-        groups);
+        secret.getExpiry());
   }
 
   @JsonProperty public abstract long id();
@@ -139,7 +110,6 @@ public abstract class SanitizedSecret {
   @JsonProperty public abstract Optional<String> type();
   @JsonProperty public abstract ImmutableMap<String, String> generationOptions();
   @JsonProperty public abstract long expiry();
-  @JsonProperty public abstract List<String> groups();
 
   /** @return Name to serialize for clients. */
   public static String displayName(SanitizedSecret sanitizedSecret) {

--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -48,7 +48,7 @@ public abstract class SanitizedSecret {
       @JsonProperty("type") @Nullable String type,
       @JsonProperty("generationOptions") @Nullable Map<String, String> generationOptions,
       @JsonProperty("expiry") long expiry,
-      @JsonProperty("groups") List<String> groups) {
+      @JsonProperty("groups") @Nullable List<String> groups) {
     ImmutableMap<String, String> meta =
         (metadata == null) ? ImmutableMap.of() : ImmutableMap.copyOf(metadata);
     ImmutableMap<String, String> genOptions =

--- a/api/src/test/java/keywhiz/api/SecretsResponseTest.java
+++ b/api/src/test/java/keywhiz/api/SecretsResponseTest.java
@@ -18,8 +18,6 @@ package keywhiz.api;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.Arrays;
-import java.util.Collections;
 import keywhiz.api.model.SanitizedSecret;
 import org.junit.Test;
 
@@ -41,8 +39,7 @@ public class SecretsResponseTest {
             ImmutableMap.of("owner", "the king"),
             "password",
             ImmutableMap.of("param1", "value1"),
-            1136214245,
-            Collections.singletonList("empire")),
+            1136214245),
         SanitizedSecret.of(
             768,
             "anotherSecret",
@@ -54,8 +51,7 @@ public class SecretsResponseTest {
             null,
             "upload",
             null,
-            1136214245,
-            Collections.singletonList("empire"))
+            1136214245)
     ));
 
     assertThat(asJson(secretsResponse))

--- a/api/src/test/java/keywhiz/api/model/SanitizedSecretTest.java
+++ b/api/src/test/java/keywhiz/api/model/SanitizedSecretTest.java
@@ -17,7 +17,6 @@
 package keywhiz.api.model;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
 import keywhiz.api.ApiDate;
 import org.junit.Test;
 
@@ -38,8 +37,7 @@ public class SanitizedSecretTest {
         ImmutableMap.of("owner", "the king"),
         "password",
         ImmutableMap.of("favoriteFood", "PB&J sandwich"),
-        1136214245,
-        Collections.singletonList("empire"));
+        1136214245);
 
     assertThat(asJson(sanitizedSecret))
         .isEqualTo(jsonFixture("fixtures/sanitizedSecret.json"));

--- a/api/src/test/resources/fixtures/sanitizedSecret.json
+++ b/api/src/test/resources/fixtures/sanitizedSecret.json
@@ -13,6 +13,5 @@
   "generationOptions" : {
     "favoriteFood" : "PB&J sandwich"
   },
-  "expiry": 1136214245,
-  "groups": ["empire"]
+  "expiry": 1136214245
 }

--- a/api/src/test/resources/fixtures/secretsResponse.json
+++ b/api/src/test/resources/fixtures/secretsResponse.json
@@ -15,8 +15,7 @@
       "generationOptions" : {
         "param1" : "value1"
       },
-      "expiry" : 1136214245,
-      "groups" : ["empire"]
+      "expiry" : 1136214245
     },
     {
       "id" : 768,
@@ -29,8 +28,7 @@
       "metadata" : {},
       "type" : "upload",
       "generationOptions" : {},
-      "expiry" : 1136214245,
-      "groups" : ["empire"]
+      "expiry" : 1136214245
     }
   ]
 }

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -198,16 +198,12 @@ public class AclDAO {
   }
 
   public Set<Group> getGroupsFor(Secret secret) {
-    return getGroupsFor(secret.getName());
-  }
-
-  public Set<Group> getGroupsFor(String secretName) {
     List<Group> r = dslContext
         .select(GROUPS.fields())
         .from(GROUPS)
         .join(ACCESSGRANTS).on(GROUPS.ID.eq(ACCESSGRANTS.GROUPID))
         .join(SECRETS).on(ACCESSGRANTS.SECRETID.eq(SECRETS.ID))
-        .where(SECRETS.NAME.eq(secretName))
+        .where(SECRETS.NAME.eq(secret.getName()))
         .fetchInto(GROUPS)
         .map(groupMapper);
     return new HashSet<>(r);
@@ -273,7 +269,11 @@ public class AclDAO {
               row.getValue(SECRETS_CONTENT.EXPIRY),
               Collections.emptyList()
           );
-          Set<Group> groups = getGroupsFor(secret.name());
+          LazyString lazyString = () -> "";
+          Set<Group> groups = getGroupsFor(
+              new Secret(secret.id(), secret.name(), secret.description(), lazyString, secret.createdAt(),
+                  secret.createdBy(), secret.updatedAt(), secret.updatedBy(), secret.metadata(), secret.type().orElse(null), secret.generationOptions(),
+                  secret.expiry()));
           List<String> groupNames = groups.stream().map(Group::getName).collect(
               Collectors.toList());
           return SanitizedSecret.fromSecretWithGroups(secret, groupNames);
@@ -333,7 +333,11 @@ public class AclDAO {
               series.generationOptions(),
               row.getValue(SECRETS_CONTENT.EXPIRY),
               Collections.emptyList());
-          Set<Group> groups = getGroupsFor(secret.name());
+          LazyString lazyString = () -> "";
+          Set<Group> groups = getGroupsFor(
+              new Secret(secret.id(), secret.name(), secret.description(), lazyString, secret.createdAt(),
+                  secret.createdBy(), secret.updatedAt(), secret.updatedBy(), secret.metadata(), secret.type().orElse(null), secret.generationOptions(),
+                  secret.expiry()));
           List<String> groupNames = groups.stream().map(Group::getName).collect(
               Collectors.toList());
           return SanitizedSecret.fromSecretWithGroups(secret, groupNames);

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -18,12 +18,10 @@ package keywhiz.service.daos;
 
 import com.google.common.collect.ImmutableSet;
 import java.time.OffsetDateTime;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import keywhiz.api.ApiDate;
@@ -31,7 +29,6 @@ import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.api.model.Secret;
-import keywhiz.api.model.Secret.LazyString;
 import keywhiz.api.model.SecretContent;
 import keywhiz.api.model.SecretSeries;
 import keywhiz.api.model.SecretSeriesAndContent;
@@ -255,7 +252,7 @@ public class AclDAO {
     query.fetch()
         .map(row -> {
           SecretSeries series = secretSeriesMapper.map(row.into(SECRETS));
-          SanitizedSecret secret = SanitizedSecret.of(
+          return SanitizedSecret.of(
               series.id(),
               series.name(),
               series.description(),
@@ -266,17 +263,7 @@ public class AclDAO {
               secretContentMapper.tryToReadMapFromMetadata(row.getValue(SECRETS_CONTENT.METADATA)),
               series.type().orElse(null),
               series.generationOptions(),
-              row.getValue(SECRETS_CONTENT.EXPIRY),
-              Collections.emptyList()
-          );
-          LazyString lazyString = () -> "";
-          Set<Group> groups = getGroupsFor(
-              new Secret(secret.id(), secret.name(), secret.description(), lazyString, secret.createdAt(),
-                  secret.createdBy(), secret.updatedAt(), secret.updatedBy(), secret.metadata(), secret.type().orElse(null), secret.generationOptions(),
-                  secret.expiry()));
-          List<String> groupNames = groups.stream().map(Group::getName).collect(
-              Collectors.toList());
-          return SanitizedSecret.fromSecretWithGroups(secret, groupNames);
+              row.getValue(SECRETS_CONTENT.EXPIRY));
         })
         .forEach(row -> sanitizedSet.add(row));
 
@@ -320,7 +307,7 @@ public class AclDAO {
     return Optional.ofNullable(query.fetchOne())
         .map(row -> {
           SecretSeries series = secretSeriesMapper.map(row.into(SECRETS));
-          SanitizedSecret secret = SanitizedSecret.of(
+          return SanitizedSecret.of(
               series.id(),
               series.name(),
               series.description(),
@@ -331,16 +318,7 @@ public class AclDAO {
               secretContentMapper.tryToReadMapFromMetadata(row.getValue(SECRETS_CONTENT.METADATA)),
               series.type().orElse(null),
               series.generationOptions(),
-              row.getValue(SECRETS_CONTENT.EXPIRY),
-              Collections.emptyList());
-          LazyString lazyString = () -> "";
-          Set<Group> groups = getGroupsFor(
-              new Secret(secret.id(), secret.name(), secret.description(), lazyString, secret.createdAt(),
-                  secret.createdBy(), secret.updatedAt(), secret.updatedBy(), secret.metadata(), secret.type().orElse(null), secret.generationOptions(),
-                  secret.expiry()));
-          List<String> groupNames = groups.stream().map(Group::getName).collect(
-              Collectors.toList());
-          return SanitizedSecret.fromSecretWithGroups(secret, groupNames);
+              row.getValue(SECRETS_CONTENT.EXPIRY));
         });
   }
 

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -17,8 +17,6 @@
 package keywhiz.service.daos;
 
 import com.google.common.collect.Iterables;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import javax.inject.Inject;
@@ -163,8 +161,7 @@ public class AclDAOTest {
 
     aclDAO.allowAccess(jooqContext.configuration(), secret2.getId(), group1.getId());
     Set<SanitizedSecret> secrets = aclDAO.getSanitizedSecretsFor(group1);
-    assertThat(Iterables.getOnlyElement(secrets)).isEqualToIgnoringGivenFields(sanitizedSecret2,
-        "id");
+    assertThat(Iterables.getOnlyElement(secrets)).isEqualToIgnoringGivenFields(sanitizedSecret2, "id");
 
     aclDAO.allowAccess(jooqContext.configuration(), secret1.getId(), group1.getId());
     secrets = aclDAO.getSanitizedSecretsFor(group1);
@@ -210,9 +207,7 @@ public class AclDAOTest {
     aclDAO.allowAccess(jooqContext.configuration(), secret2.getId(), group2.getId());
     Set<SanitizedSecret> secrets = aclDAO.getSanitizedSecretsFor(client2);
     assertThat(Iterables.getOnlyElement(secrets))
-        .isEqualToIgnoringGivenFields(
-            SanitizedSecret.fromSecretWithGroups(SanitizedSecret.fromSecret(secret2),
-                Collections.singletonList("group2")), "id");
+        .isEqualToIgnoringGivenFields(SanitizedSecret.fromSecret(secret2), "id");
 
     aclDAO.allowAccess(jooqContext.configuration(), secret1.getId(), group2.getId());
     secrets = aclDAO.getSanitizedSecretsFor(client2);
@@ -220,13 +215,9 @@ public class AclDAOTest {
 
     for (SanitizedSecret secret : secrets) {
       if (secret.name().equals(secret1.getName())) {
-        assertThat(secret).isEqualToIgnoringGivenFields(
-            SanitizedSecret.fromSecretWithGroups(SanitizedSecret.fromSecret(secret1),
-                Collections.singletonList("group2")), "id");
+        assertThat(secret).isEqualToIgnoringGivenFields(SanitizedSecret.fromSecret(secret1), "id");
       } else {
-        assertThat(secret).isEqualToIgnoringGivenFields(
-            SanitizedSecret.fromSecretWithGroups(SanitizedSecret.fromSecret(secret2),
-                Collections.singletonList("group2")), "id");
+        assertThat(secret).isEqualToIgnoringGivenFields(SanitizedSecret.fromSecret(secret2), "id");
       }
     }
 
@@ -267,9 +258,8 @@ public class AclDAOTest {
     aclDAO.allowAccess(jooqContext.configuration(), secret1.getId(), group1.getId());
     aclDAO.allowAccess(jooqContext.configuration(), secret1.getId(), group2.getId());
 
-    SecretSeries secretSeries =
-        aclDAO.getSecretSeriesFor(jooqContext.configuration(), client2, secret1.getName())
-            .orElseThrow(RuntimeException::new);
+    SecretSeries secretSeries = aclDAO.getSecretSeriesFor(jooqContext.configuration(), client2, secret1.getName())
+        .orElseThrow(RuntimeException::new);
     assertThat(secretSeries).isEqualToIgnoringGivenFields(secretSeries1, "id");
 
     aclDAO.evictClient(jooqContext.configuration(), client2.getId(), group1.getId());
@@ -279,9 +269,8 @@ public class AclDAOTest {
 
     aclDAO.allowAccess(jooqContext.configuration(), secret1.getId(), group3.getId());
 
-    secretSeries =
-        aclDAO.getSecretSeriesFor(jooqContext.configuration(), client2, secret1.getName())
-            .orElseThrow(RuntimeException::new);
+    secretSeries = aclDAO.getSecretSeriesFor(jooqContext.configuration(), client2, secret1.getName())
+        .orElseThrow(RuntimeException::new);
     assertThat(secretSeries).isEqualToIgnoringGivenFields(secretSeries1, "id");
   }
 
@@ -304,8 +293,7 @@ public class AclDAOTest {
 
     SanitizedSecret secret = aclDAO.getSanitizedSecretFor(client2, sanitizedSecret1.name())
         .orElseThrow(RuntimeException::new);
-    // The ordering of the returned groups is unreliable
-    assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret1, "id", "groups");
+    assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret1, "id");
 
     aclDAO.evictClient(jooqContext.configuration(), client2.getId(), group1.getId());
     Optional<SanitizedSecret> missingSecret =
@@ -316,7 +304,7 @@ public class AclDAOTest {
 
     secret = aclDAO.getSanitizedSecretFor(client2, sanitizedSecret1.name())
         .orElseThrow(RuntimeException::new);
-    assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret1, "id", "groups");
+    assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret1, "id");
   }
 
   @Test public void getSecretsReturnsDistinct() {

--- a/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
@@ -17,7 +17,6 @@ package keywhiz.service.resources.admin;
 
 import com.google.common.collect.ImmutableSet;
 import io.dropwizard.jersey.params.LongParam;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.ws.rs.BadRequestException;
@@ -91,9 +90,8 @@ public class GroupsResourceTest {
   @Test public void getSpecificIncludesAllTheThings() {
     when(groupDAO.getGroupById(4444)).thenReturn(Optional.of(group));
 
-    SanitizedSecret secret =
-        SanitizedSecret.of(1, "name", null, now, "creator", now, "creator", null, null, null,
-            1136214245, Collections.emptyList());
+    SanitizedSecret secret = SanitizedSecret.of(1, "name", null, now, "creator", now, "creator", null, null, null,
+        1136214245);
     when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of(secret));
 
     Client client = new Client(1, "client", "desc", now, "creator", now, "creator", true, false);

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -80,9 +80,9 @@ public class SecretsResourceTest {
   @Test
   public void listSecrets() {
     SanitizedSecret secret1 = SanitizedSecret.of(1, "name1", "desc", NOW, "user", NOW, "user",
-        emptyMap, null, null, 1136214245, Collections.emptyList());
+        emptyMap, null, null, 1136214245);
     SanitizedSecret secret2 = SanitizedSecret.of(2, "name2", "desc", NOW, "user", NOW, "user",
-        emptyMap, null, null, 1136214245, Collections.emptyList());
+        emptyMap, null, null, 1136214245);
     when(secretController.getSanitizedSecrets(null, null)).thenReturn(ImmutableList.of(secret1, secret2));
 
     List<SanitizedSecret> response = resource.listSecrets(user);

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationGroupResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationGroupResourceTest.java
@@ -19,7 +19,6 @@ package keywhiz.service.resources.automation;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.dropwizard.jersey.params.LongParam;
-import java.util.Collections;
 import java.util.Optional;
 import javax.ws.rs.core.Response;
 import keywhiz.api.ApiDate;
@@ -81,16 +80,13 @@ public class AutomationGroupResourceTest {
   }
 
   @Test public void groupIncludesClientsAndSecrets() {
-    Group group = new Group(50, "testGroup", "testing group", now, "automation client", now,
-        "automation client");
+    Group group = new Group(50, "testGroup", "testing group", now, "automation client", now, "automation client");
     Client groupClient =
         new Client(1, "firstClient", "Group client", now, "test", now, "test", true, true);
     SanitizedSecret firstGroupSecret =
-        SanitizedSecret.of(1, "name1", "desc", now, "test", now, "test", null, "", null, 1136214245,
-            Collections.emptyList());
+        SanitizedSecret.of(1, "name1", "desc", now, "test", now, "test", null, "", null, 1136214245);
     SanitizedSecret secondGroupSecret =
-        SanitizedSecret.of(2, "name2", "desc", now, "test", now, "test", null, "", null, 1136214245,
-            Collections.emptyList());
+        SanitizedSecret.of(2, "name2", "desc", now, "test", now, "test", null, "", null, 1136214245);
 
     when(groupDAO.getGroup("testGroup")).thenReturn(Optional.of(group));
     when(aclDAO.getClientsFor(group)).thenReturn(ImmutableSet.of(groupClient));


### PR DESCRIPTION
Retrieving a group list with all SanitizedSecrets significantly slows down Keywhiz operations, so this reverts the earlier PR.