### PR TITLE
Add index to accessgrants to speed up groups-for-secret query

### DIFF
--- a/server/src/main/resources/db/h2/migration/V2.17__add_accessgrants_index
+++ b/server/src/main/resources/db/h2/migration/V2.17__add_accessgrants_index
@@ -1,0 +1,1 @@
+ALTER TABLE accessgrants ADD INDEX idx_secretid (secretid)

--- a/server/src/main/resources/db/mysql/migration/V1.6__add_accessgrants_index.sql
+++ b/server/src/main/resources/db/mysql/migration/V1.6__add_accessgrants_index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accessgrants ADD INDEX idx_secretid (secretid)

--- a/server/src/main/resources/db/postgres/migration/V3.5__add_accessgrants_index.sql
+++ b/server/src/main/resources/db/postgres/migration/V3.5__add_accessgrants_index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accessgrants ADD INDEX idx_secretid (secretid)


### PR DESCRIPTION
ACLDao's getGroupsFor(Secret secret) has been searching the entire Groups table.  Adding this index will significantly speed up the join of Groups and Accessgrants in this query.