### PR TITLE
Fix docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ COPY hkdf/pom.xml /usr/src/app/hkdf/
 COPY model/pom.xml /usr/src/app/model/
 COPY server/pom.xml /usr/src/app/server/
 COPY testing/pom.xml /usr/src/app/testing/
+COPY log/pom.xml /usr/src/app/log/
 RUN mvn dependency:copy-dependencies -P docker --fail-never
 
 # copy source required for build and install
@@ -72,6 +73,7 @@ COPY hkdf /usr/src/app/hkdf/
 COPY model /usr/src/app/model/
 COPY server /usr/src/app/server/
 COPY testing /usr/src/app/testing/
+COPY log /usr/src/app/log/
 RUN mvn install -P docker
 
 # Drop privs inside container

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #   docker run -e KEYWHIZ_CONFIG=/path/to/config [COMMAND]
 #
 # If the KEYWHIZ_CONFIG environment variable is omitted, keywhiz
-# will run with the default development config. If COMMAND is 
+# will run with the default development config. If COMMAND is
 # omitted, keywhiz will print a help message.
 #
 # *** Development ***
@@ -41,7 +41,7 @@
 # in development is keywhizAdmin and the default password is adminPass.
 #
 # Note that for a production deployment, you'll probably want to setup
-# your own config to make sure you're not using development secrets. 
+# your own config to make sure you're not using development secrets.
 #
 FROM maven:3.3-jdk-8
 
@@ -83,7 +83,7 @@ RUN useradd -ms /bin/false keywhiz && \
 USER keywhiz
 
 # Expose API port by default. Note that the admin console port
-# is NOT exposed by default, can be exposed manually if desired. 
+# is NOT exposed by default, can be exposed manually if desired.
 EXPOSE 4444
 
 VOLUME ["/data", "/secrets"]


### PR DESCRIPTION
Added the missing files to docker (including the log related files), so it now builds correctly.
Unfortunately the travis tests doesn't cover it, so I've created a docker build test for now; it seems ok
http://jenkins.opstack.info:8080/job/keywhiz-server/12/consoleFull
```
[INFO] Reactor Summary:
[INFO] 
[INFO] Keywhiz (Parent) ................................... SUCCESS [ 21.573 s]
[INFO] Keywhiz Testing .................................... SUCCESS [ 18.931 s]
[INFO] Keywhiz API ........................................ SUCCESS [ 16.231 s]
[INFO] Keywhiz Client ..................................... SUCCESS [  0.943 s]
[INFO] Keywhiz CLI ........................................ SUCCESS [ 18.346 s]
[INFO] Keywhiz HKDF ....................................... SUCCESS [  2.556 s]
[INFO] Keywhiz Model ...................................... SUCCESS [  8.372 s]
[INFO] Keywhiz Log ........................................ SUCCESS [  0.335 s]
[INFO] Keywhiz Server ..................................... SUCCESS [02:46 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```