### PR TITLE
Change to using /dev/urandom instead of /dev/random so we don't block…

### DIFF
--- a/server/src/main/java/keywhiz/commands/GenerateAesKeyCommand.java
+++ b/server/src/main/java/keywhiz/commands/GenerateAesKeyCommand.java
@@ -72,15 +72,15 @@ public class GenerateAesKeyCommand extends Command {
     int keySize = namespace.getInt("keysize");
     String alias = namespace.getString("alias");
 
-    generate(password, destination, keySize, alias);
+    generate(password, destination, keySize, alias, SecureRandom.getInstanceStrong());
     System.out.println(format("Generated a %d-bit AES key at %s with alias %s", keySize,
         destination.toAbsolutePath(), alias));
   }
 
   @VisibleForTesting
-  static void generate(char[] password, Path destination, int keySize, String alias) throws Exception {
+  static void generate(char[] password, Path destination, int keySize, String alias, SecureRandom random) throws Exception {
     KeyGenerator generator = KeyGenerator.getInstance("AES");
-    generator.init(keySize, SecureRandom.getInstanceStrong());
+    generator.init(keySize, random);
     SecretKey key = generator.generateKey();
 
     KeyStore keyStore = KeyStore.getInstance("JCEKS");

--- a/server/src/test/java/keywhiz/commands/GenerateAesKeyCommandTest.java
+++ b/server/src/test/java/keywhiz/commands/GenerateAesKeyCommandTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Key;
 import java.security.KeyStore;
+import java.security.SecureRandom;
 import javax.crypto.SecretKey;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,7 +39,7 @@ public class GenerateAesKeyCommandTest {
     int keySize = 128;
     String alias = "baseKey";
 
-    GenerateAesKeyCommand.generate(password, destination, keySize, alias);
+    GenerateAesKeyCommand.generate(password, destination, keySize, alias, new SecureRandom());
     assertThat(destination).exists();
 
     KeyStore keyStore = KeyStore.getInstance("JCEKS");


### PR DESCRIPTION
… unnecessarily on the GenerateAesKeyCommandTest.

P.S. csstaub wrote this

r: @csstaub @mcpherrinm @alokmenghrajani @jbpeirce @worldwise001 