### PR TITLE
Add endpoint to list secrets in batches

### DIFF
--- a/cli/src/main/java/keywhiz/cli/configs/ListActionConfig.java
+++ b/cli/src/main/java/keywhiz/cli/configs/ListActionConfig.java
@@ -24,5 +24,14 @@ import java.util.List;
 public class ListActionConfig {
 
   @Parameter(description = "[<groups|clients|secrets>]")
-  public List<String> listOptions;
+  public List<String> listType;
+
+  @Parameter(names = "--idx", description = "Index to start retrieving secrets (valid only with 'secrets'; requires --num to also be specified)")
+  public Integer idx;
+
+  @Parameter(names = "--num", description = "Number of secrets to retrieve after index (valid only with 'secrets'; requires --idx to also be specified)")
+  public Integer num;
+
+  @Parameter(names = "--newestFirst", description = "Whether to batch the secrets from newest creation date first.  Defaults to 'true' (valid only with 'secrets'; requires --idx and --num to also be specified)")
+  public Boolean newestFirst;
 }

--- a/cli/src/test/java/keywhiz/cli/commands/ListActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/ListActionTest.java
@@ -46,14 +46,14 @@ public class ListActionTest {
 
   @Test
   public void listCallsPrintForListAll() throws Exception {
-    listActionConfig.listOptions = null;
+    listActionConfig.listType = null;
     listAction.run();
     verify(printing).printAllSanitizedSecrets(keywhizClient.allSecrets());
   }
 
   @Test
   public void listCallsPrintForListGroups() throws Exception {
-    listActionConfig.listOptions = Arrays.asList("groups");
+    listActionConfig.listType = Arrays.asList("groups");
     listAction.run();
 
     verify(printing).printAllGroups(keywhizClient.allGroups());
@@ -61,7 +61,7 @@ public class ListActionTest {
 
   @Test
   public void listCallsPrintForListClients() throws Exception {
-    listActionConfig.listOptions = Arrays.asList("clients");
+    listActionConfig.listType = Arrays.asList("clients");
     listAction.run();
 
     verify(printing).printAllClients(keywhizClient.allClients());
@@ -69,15 +69,60 @@ public class ListActionTest {
 
   @Test
   public void listCallsPrintForListSecrets() throws Exception {
-    listActionConfig.listOptions = Arrays.asList("secrets");
+    listActionConfig.listType = Arrays.asList("secrets");
     listAction.run();
 
     verify(printing).printAllSanitizedSecrets(keywhizClient.allSecrets());
   }
 
+  @Test
+  public void listCallsPrintForListSecretsBatched() throws Exception {
+    listActionConfig.listType = Arrays.asList("secrets");
+    listActionConfig.idx = 0;
+    listActionConfig.num = 10;
+    listActionConfig.newestFirst = false;
+    listAction.run();
+
+    verify(printing).printAllSanitizedSecrets(keywhizClient.allSecretsBatched(0, 10, false));
+  }
+
+  @Test
+  public void listCallsPrintForListSecretsBatchedWithDefault() throws Exception {
+    listActionConfig.listType = Arrays.asList("secrets");
+    listActionConfig.idx = 5;
+    listActionConfig.num = 10;
+    listAction.run();
+
+    verify(printing).printAllSanitizedSecrets(keywhizClient.allSecretsBatched(5, 10, true));
+  }
+
+  @Test
+  public void listCallsErrorsCorrectly() throws Exception {
+    listActionConfig.listType = Arrays.asList("secrets");
+    listActionConfig.idx = 5;
+    boolean error = false;
+    try {
+      listAction.run();
+    } catch (AssertionError e) {
+      error = true;
+    }
+    assert(error);
+
+    listActionConfig.listType = Arrays.asList("secrets");
+    listActionConfig.idx = 5;
+    listActionConfig.num = -5;
+    error = false;
+    try {
+      listAction.run();
+    } catch (IllegalArgumentException e) {
+      error = true;
+    }
+    assert(error);
+  }
+
   @Test(expected = AssertionError.class)
   public void listThrowsIfInvalidType() throws Exception {
-    listActionConfig.listOptions = Arrays.asList("invalid_type");
+    listActionConfig.listType = Arrays.asList("invalid_type");
     listAction.run();
   }
 }

--- a/client/src/main/java/keywhiz/client/KeywhizClient.java
+++ b/client/src/main/java/keywhiz/client/KeywhizClient.java
@@ -145,6 +145,11 @@ public class KeywhizClient {
     return mapper.readValue(response, new TypeReference<List<SanitizedSecret>>() {});
   }
 
+  public List<SanitizedSecret> allSecretsBatched(int idx, int num, boolean newestFirst) throws IOException {
+    String response = httpGet(baseUrl.resolve(String.format("/admin/secrets?idx=%d&num=%d&newestFirst=%s", idx, num, newestFirst)));
+    return mapper.readValue(response, new TypeReference<List<SanitizedSecret>>() {});
+  }
+
   public SecretDetailResponse createSecret(String name, String description, byte[] content,
       ImmutableMap<String, String> metadata, long expiry) throws IOException {
     checkArgument(!name.isEmpty());

--- a/server/src/main/java/keywhiz/service/daos/SecretController.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretController.java
@@ -83,6 +83,20 @@ public class SecretController {
         .collect(toList());
   }
 
+  /**
+   * @param idx the first index to select in a list of secrets sorted by creation time
+   * @param num the number of secrets after idx to select in the list of secrets
+   * @param newestFirst if true, order the secrets from newest creation time to oldest
+   * @return A list of secret names
+   */
+  public List<SanitizedSecret> getSecretsBatched(int idx, int num, boolean newestFirst) {
+    checkArgument(idx >= 0, "Index must be positive when getting batched secret names!");
+    checkArgument(num >= 0, "Num must be positive when getting batched secret names!");
+    return secretDAO.getSecretsBatched(idx, num, newestFirst).stream()
+        .map(SanitizedSecret::fromSecretSeriesAndContent)
+        .collect(toList());
+  }
+
   public SecretBuilder builder(String name, String secret, String creator, long expiry) {
     checkArgument(!name.isEmpty());
     checkArgument(!secret.isEmpty());

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -58,7 +58,8 @@ public class SecretSeriesDAO {
   private final ObjectMapper mapper;
   private final SecretSeriesMapper secretSeriesMapper;
 
-  private SecretSeriesDAO(DSLContext dslContext, ObjectMapper mapper, SecretSeriesMapper secretSeriesMapper) {
+  private SecretSeriesDAO(DSLContext dslContext, ObjectMapper mapper,
+      SecretSeriesMapper secretSeriesMapper) {
     this.dslContext = dslContext;
     this.mapper = mapper;
     this.secretSeriesMapper = secretSeriesMapper;
@@ -92,8 +93,9 @@ public class SecretSeriesDAO {
     return r.getId();
   }
 
-  void updateSecretSeries(long secretId, String name, String creator, String description, @Nullable String type,
-                          @Nullable Map<String, String> generationOptions) {
+  void updateSecretSeries(long secretId, String name, String creator, String description,
+      @Nullable String type,
+      @Nullable Map<String, String> generationOptions) {
     long now = OffsetDateTime.now().toEpochSecond();
     if (generationOptions == null) {
       generationOptions = ImmutableMap.of();
@@ -189,6 +191,25 @@ public class SecretSeriesDAO {
     return ImmutableList.copyOf(r);
   }
 
+  public ImmutableList<SecretSeries> getSecretSeriesBatched(int idx, int num, boolean newestFirst) {
+    SelectQuery<Record> select = dslContext
+        .select()
+        .from(SECRETS)
+        .join(SECRETS_CONTENT)
+        .on(SECRETS.CURRENT.equal(SECRETS_CONTENT.ID))
+        .where(SECRETS.CURRENT.isNotNull())
+        .getQuery();
+    if (newestFirst) {
+      select.addOrderBy(SECRETS.CREATEDAT.desc());
+    } else {
+      select.addOrderBy(SECRETS.CREATEDAT.asc());
+    }
+    select.addLimit(idx, num);
+
+    List<SecretSeries> r = select.fetchInto(SECRETS).map(secretSeriesMapper);
+    return ImmutableList.copyOf(r);
+  }
+
   public void deleteSecretSeriesByName(String name) {
     long now = OffsetDateTime.now().toEpochSecond();
     dslContext.transaction(configuration -> {
@@ -214,16 +235,16 @@ public class SecretSeriesDAO {
     dslContext.transaction(configuration -> {
       DSL.using(configuration)
           .update(SECRETS)
-          .set(SECRETS.CURRENT, (Long)null)
+          .set(SECRETS.CURRENT, (Long) null)
           .set(SECRETS.UPDATEDAT, now)
           .where(SECRETS.ID.eq(id))
           .execute();
 
-       DSL.using(configuration)
-           .delete(ACCESSGRANTS)
-           .where(ACCESSGRANTS.SECRETID.eq(id))
-           .execute();
-      });
+      DSL.using(configuration)
+          .delete(ACCESSGRANTS)
+          .where(ACCESSGRANTS.SECRETID.eq(id))
+          .execute();
+    });
   }
 
   public static class SecretSeriesDAOFactory implements DAOFactory<SecretSeriesDAO> {

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.validation.Valid;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -105,6 +106,9 @@ public class SecretsResource {
    * @param name the name of the Secret to retrieve, if provided
    * @optionalParams version
    * @param nameOnly if set, the result only contains the id and name for the secrets.
+   * @param idx if set, the desired starting index in a list of secrets to be retrieved
+   * @param num if set, the number of secrets to retrieve
+   * @param newestFirst whether to order the secrets by creation date with newest first; defaults to true
    *
    * @description Returns a single Secret or a set of all Secrets for this user.
    * Used by Keywhiz CLI and the web ui.
@@ -114,15 +118,39 @@ public class SecretsResource {
   @Timed @ExceptionMetered
   @GET
   public Response findSecrets(@Auth User user, @DefaultValue("") @QueryParam("name") String name,
-      @DefaultValue("") @QueryParam("nameOnly") String nameOnly) {
+      @DefaultValue("") @QueryParam("nameOnly") String nameOnly, @QueryParam("idx") Integer idx,
+      @QueryParam("num") Integer num,
+      @DefaultValue("true") @QueryParam("newestFirst") Boolean newestFirst) {
+    if (!name.isEmpty() && idx != null && num != null) {
+      throw new BadRequestException("Name and idx/num cannot both be specified");
+    }
+
+    validateArguments(name, nameOnly, idx, num);
+
     if (name.isEmpty()) {
       if (nameOnly.isEmpty()) {
-        return Response.ok().entity(listSecrets(user)).build();
+        if (idx == null || num == null) {
+          return Response.ok().entity(listSecrets(user)).build();
+        } else {
+          return Response.ok().entity(listSecretsBatched(user, idx, num, newestFirst)).build();
+        }
       } else {
         return Response.ok().entity(listSecretsNameOnly(user)).build();
       }
     }
     return Response.ok().entity(retrieveSecret(user, name)).build();
+  }
+
+  private void validateArguments(String name, String nameOnly, Integer idx, Integer num) {
+    if (idx == null && num != null || idx != null && num != null) {
+      throw new IllegalArgumentException("Both idx and num must be specified");
+    }
+    if (!name.isEmpty() && idx != null && num != null) {
+      throw new IllegalArgumentException("Name, idx, and num must not all be specified");
+    }
+    if (nameOnly.isEmpty() && idx != null && num != null) {
+      throw new IllegalArgumentException("nameOnly option is not valid for batched secret retrieval");
+    }
   }
 
   protected List<SanitizedSecret> listSecrets(@Auth User user) {
@@ -133,6 +161,11 @@ public class SecretsResource {
   protected List<SanitizedSecret> listSecretsNameOnly(@Auth User user) {
     logger.info("User '{}' listing secrets.", user);
     return secretController.getSecretsNameOnly();
+  }
+
+  protected List<SanitizedSecret> listSecretsBatched(@Auth User user, int idx, int num, boolean newestFirst) {
+    logger.info("User '{}' listing secrets with idx '{}', num '{}', newestFirst '{}'.", user, idx, num, newestFirst);
+    return secretController.getSecretsBatched(idx, num, newestFirst);
   }
 
   protected SanitizedSecret retrieveSecret(@Auth User user, String name) {

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -15,8 +15,10 @@ import java.util.Set;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.validation.Valid;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
@@ -24,6 +26,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import keywhiz.api.automation.v2.CreateOrUpdateSecretRequestV2;
@@ -172,18 +175,64 @@ public class SecretResource {
   }
 
   /**
-   * Retrieve listing of secrets and metadata
+   * Retrieve listing of secret names.  If "idx" and "num" are both provided, retrieve "num"
+   * names starting at "idx" from a list of secret names ordered by creation date, with
+   * order depending on "newestFirst" (which defaults to "true")
    *
    * @excludeParams automationClient
-   * @responseMessage 200 List of secrets and metadata
+   * @param idx the index from which to start retrieval in the list of secret names
+   * @param num the number of names to retrieve
+   * @param newestFirst whether to list the most-recently-created names first
+   * @responseMessage 200 List of secret names
+   * @responseMessage 400 Invalid (negative) idx or num
    */
   @Timed @ExceptionMetered
   @GET
   @Produces(APPLICATION_JSON)
-  public Iterable<String> secretListing(@Auth AutomationClient automationClient) {
+  public Iterable<String> secretListing(@Auth AutomationClient automationClient,
+      @QueryParam("idx") Integer idx, @QueryParam("num") Integer num,
+      @DefaultValue("true") @QueryParam("newestFirst") boolean newestFirst) {
+    if (idx != null && num != null) {
+      if (idx < 0 || num < 0) {
+        throw new BadRequestException(
+            "Index and num must both be positive when retrieving batched secrets!");
+      }
+      return secretController.getSecretsBatched(idx, num, newestFirst).stream()
+          .map(SanitizedSecret::name)
+          .collect(toList());
+    }
     return secretController.getSanitizedSecrets(null, null).stream()
         .map(SanitizedSecret::name)
         .collect(toSet());
+  }
+
+  /**
+   * Retrieve listing of secrets.  If "idx" and "num" are both provided, retrieve "num"
+   * names starting at "idx" from a list of secrets ordered by creation date, with
+   * order depending on "newestFirst" (which defaults to "true")
+   *
+   * @excludeParams automationClient
+   * @param idx the index from which to start retrieval in the list of secrets
+   * @param num the number of names to retrieve
+   * @param newestFirst whether to list the most-recently-created names first
+   * @responseMessage 200 List of secret names
+   * @responseMessage 400 Invalid (negative) idx or num
+   */
+  @Timed @ExceptionMetered
+  @Path("/v2")
+  @GET
+  @Produces(APPLICATION_JSON)
+  public Iterable<SanitizedSecret> secretListingV2(@Auth AutomationClient automationClient,
+      @QueryParam("idx") Integer idx, @QueryParam("num") Integer num,
+      @DefaultValue("true") @QueryParam("newestFirst") boolean newestFirst) {
+    if (idx != null && num != null) {
+      if (idx < 0 || num < 0) {
+        throw new BadRequestException(
+            "Index and num must both be positive when retrieving batched secrets!");
+      }
+      return secretController.getSecretsBatched(idx, num, newestFirst);
+    }
+    return secretController.getSanitizedSecrets(null, null);
   }
 
   /**

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.when;
 
 public class SecretsResourceTest {
   private static final ApiDate NOW = ApiDate.now();
+  private static final ApiDate NOWPLUS = new ApiDate(NOW.toEpochSecond() + 10000);
 
   @Rule public MockitoRule mockito = MockitoJUnit.rule();
 
@@ -91,6 +92,26 @@ public class SecretsResourceTest {
 
     List<SanitizedSecret> response = resource.listSecrets(user);
     assertThat(response).containsOnly(secret1, secret2);
+  }
+
+  @Test
+  public void listSecretsBatched() {
+    SanitizedSecret secret1 = SanitizedSecret.of(1, "name1", "desc", "checksum", NOW, "user", NOW, "user",
+        emptyMap, null, null, 1136214245);
+    SanitizedSecret secret2 = SanitizedSecret.of(2, "name2", "desc", "checksum", NOWPLUS, "user", NOWPLUS, "user",
+        emptyMap, null, null, 1136214245);
+    when(secretController.getSecretsBatched(0, 1, false)).thenReturn(ImmutableList.of(secret1));
+    when(secretController.getSecretsBatched(0, 1, true)).thenReturn(ImmutableList.of(secret2));
+    when(secretController.getSecretsBatched(1, 1, false)).thenReturn(ImmutableList.of(secret2));
+
+    List<SanitizedSecret> response = resource.listSecretsBatched(user, 0, 1, false);
+    assertThat(response).containsOnly(secret1);
+
+    response = resource.listSecretsBatched(user, 1, 1, false);
+    assertThat(response).containsOnly(secret2);
+
+    response = resource.listSecretsBatched(user, 0, 1, true);
+    assertThat(response).containsOnly(secret2);
   }
 
   @Test

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -8,6 +8,7 @@ import com.google.common.io.Resources;
 import io.dropwizard.jackson.Jackson;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Base64.Decoder;
 import java.util.Base64.Encoder;
@@ -16,6 +17,7 @@ import java.util.Optional;
 import keywhiz.IntegrationTestRule;
 import keywhiz.KeywhizService;
 import keywhiz.TestClients;
+import keywhiz.api.ApiDate;
 import keywhiz.api.automation.v2.CreateGroupRequestV2;
 import keywhiz.api.automation.v2.CreateOrUpdateSecretRequestV2;
 import keywhiz.api.automation.v2.CreateSecretRequestV2;
@@ -124,6 +126,11 @@ public class SecretResourceTest {
     // TODO: check different metadata, name, location
   }
 
+
+  //---------------------------------------------------------------------------------------
+  // secretInfo
+  //---------------------------------------------------------------------------------------
+
   @Test public void secretInfo_notFound() throws Exception {
     Request get = clientRequest("/automation/v2/secrets/non-existent").get().build();
     Response httpResponse = mutualSslClient.newCall(get).execute();
@@ -152,6 +159,10 @@ public class SecretResourceTest {
     assertThat(response.metadata()).isEmpty();
   }
 
+  //---------------------------------------------------------------------------------------
+  // secretGroupsListing
+  //---------------------------------------------------------------------------------------
+
   @Test public void secretGroupsListing_notFound() throws Exception {
     Request get = clientRequest("/automation/v2/secrets/non-existent/groups").get().build();
     Response httpResponse = mutualSslClient.newCall(get).execute();
@@ -171,6 +182,10 @@ public class SecretResourceTest {
 
     assertThat(groupsListing("secret7")).containsOnly("group7a", "group7b");
   }
+
+  //---------------------------------------------------------------------------------------
+  // modifySecretGroups
+  //---------------------------------------------------------------------------------------
 
   @Test public void modifySecretGroups_notFound() throws Exception {
     ModifyGroupsRequestV2 request = ModifyGroupsRequestV2.builder().build();
@@ -200,6 +215,10 @@ public class SecretResourceTest {
     assertThat(groups).containsOnly("group8b", "group8c");
   }
 
+  //---------------------------------------------------------------------------------------
+  // deleteSecretSeries
+  //---------------------------------------------------------------------------------------
+
   @Test public void deleteSecretSeries_notFound() throws Exception {
     assertThat(deleteSeries("non-existent").code()).isEqualTo(404);
   }
@@ -218,6 +237,10 @@ public class SecretResourceTest {
     assertThat(deleteSeries("secret12").code()).isEqualTo(404);
   }
 
+  //---------------------------------------------------------------------------------------
+  // secretListing
+  //---------------------------------------------------------------------------------------
+
   @Test public void secretListing_success() throws Exception {
     // Listing without secret16
     assertThat(listing()).doesNotContain("secret16");
@@ -225,12 +248,95 @@ public class SecretResourceTest {
     // Sample secret
     create(CreateSecretRequestV2.builder()
         .name("secret16")
+        .description("test secret 16")
         .content(encoder.encodeToString("supa secret16".getBytes(UTF_8)))
         .build());
 
     // Listing with secret16
     assertThat(listing()).contains("secret16");
+
+    List<SanitizedSecret> secrets = listingV2();
+    boolean found = false;
+    for (SanitizedSecret s : secrets) {
+      if (s.name().equals("secret16")) {
+        found = true;
+        assertThat(s.description().equals("test secret 16"));
+      }
+    }
+    assertThat(found).isTrue();
   }
+
+  @Test public void secretListingBatch_success() throws Exception {
+    // Listing without secret23, 24, 25
+    String name1 = "secret23";
+    String name2 = "secret24";
+    String name3 = "secret25";
+    List<String> s = listing();
+    assertThat(s).doesNotContain(name1);
+    assertThat(s).doesNotContain(name2);
+    assertThat(s).doesNotContain(name3);
+
+    // create groups
+    createGroup("group16a");
+    createGroup("group16b");
+
+    // get current time to calculate timestamps off for expiry
+    long now = System.currentTimeMillis() / 1000L;
+
+    // add some secrets
+    create(CreateSecretRequestV2.builder()
+        .name(name1)
+        .content(encoder.encodeToString("supa secret17".getBytes(UTF_8)))
+        .expiry(now + 86400 * 3)
+        .groups("group16a", "group16b")
+        .build());
+
+    create(CreateSecretRequestV2.builder()
+        .name(name2)
+        .content(encoder.encodeToString("supa secret18".getBytes(UTF_8)))
+        .expiry(now + 86400)
+        .groups("group16a")
+        .build());
+
+    create(CreateSecretRequestV2.builder()
+        .name(name3)
+        .content(encoder.encodeToString("supa secret19".getBytes(UTF_8)))
+        .expiry(now + 86400 * 2)
+        .groups("group16b")
+        .build());
+
+    // check limiting by batch (hard to test because the batch results heavily depend on other
+    // tests, which may be run in parallel and often execute fast enough that different tests'
+    // secrets have the same creation time as the secrets created in this test)
+    List<String> s1 = listBatch(0, 2, false);
+    assertThat(s1.size()).isEqualTo(2);
+
+    List<SanitizedSecret> s3 = listBatchV2(0, 2, true);
+    assertThat(s3.size()).isEqualTo(2);
+  }
+
+  @Test public void secretListingBatch_failure() throws Exception {
+    // check that negative inputs fail
+    Request get = clientRequest(String.format("/automation/v2/secrets?idx=%d&num=%d&newestFirst=%s", -1, 3, false)).get().build();
+    Response httpResponse = mutualSslClient.newCall(get).execute();
+    assertThat(httpResponse.code()).isEqualTo(400);
+
+    get = clientRequest(String.format("/automation/v2/secrets?idx=%d&num=%d&newestFirst=%s", 0, -3, true)).get().build();
+    httpResponse = mutualSslClient.newCall(get).execute();
+    assertThat(httpResponse.code()).isEqualTo(400);
+
+    get = clientRequest(String.format("/automation/v2/secrets/v2?idx=%d&num=%d&newestFirst=%s", -1, 3, false)).get().build();
+    httpResponse = mutualSslClient.newCall(get).execute();
+    assertThat(httpResponse.code()).isEqualTo(400);
+
+    get = clientRequest(String.format("/automation/v2/secrets/v2?idx=%d&num=%d&newestFirst=%s", 0, -3, true)).get().build();
+    httpResponse = mutualSslClient.newCall(get).execute();
+    assertThat(httpResponse.code()).isEqualTo(400);
+  }
+
+  //---------------------------------------------------------------------------------------
+  // backfillExpiration
+  //---------------------------------------------------------------------------------------
 
   @Test
   public void backfillExpirationTest() throws Exception {
@@ -283,6 +389,10 @@ public class SecretResourceTest {
     details = lookup("keystore.jceks");
     assertThat(details.expiry()).isEqualTo(1681596851);
   }
+
+  //---------------------------------------------------------------------------------------
+  // secretListingExpiry
+  //---------------------------------------------------------------------------------------
 
   @Test public void secretListingExpiry_success() throws Exception {
     // Listing without secret17,18,19
@@ -341,6 +451,10 @@ public class SecretResourceTest {
     assertThat(s4.get(1).expiry()).isEqualTo(now + 86400 * 2);
   }
 
+  //---------------------------------------------------------------------------------------
+  // secretVersions
+  //---------------------------------------------------------------------------------------
+
   @Test public void secretVersionListing_notFound() throws Exception {
     Request put = clientRequest("/automation/v2/secrets/non-existent/versions/0-0").build();
     Response httpResponse = mutualSslClient.newCall(put).execute();
@@ -389,6 +503,10 @@ public class SecretResourceTest {
     checkSecretVersions(versions, "secret20", totalVersions, totalVersions / 4,
         totalVersions / 2);
   }
+
+  //---------------------------------------------------------------------------------------
+  // resetSecretVersion
+  //---------------------------------------------------------------------------------------
 
   @Test public void secretChangeVersion_notFound() throws Exception {
     Request post =
@@ -473,11 +591,11 @@ public class SecretResourceTest {
 
     // Get an invalid version of this secret
     versions = listVersions(name, 0, totalVersions);
-    Optional<Long> maxValidVersion = versions.stream().map(v -> v.version()).max(Long::compare);
+    Optional<Long> maxValidVersion = versions.stream().map(SecretDetailResponseV2::version).max(Long::compare);
 
     if (maxValidVersion.isPresent()) {
       // Reset the current version to this version
-      Request post = clientRequest("/automation/v2/secrets/secret22/setversion").post(
+      Request post = clientRequest(String.format("/automation/v2/secrets/%s/setversion", name)).post(
           RequestBody.create(JSON, mapper.writeValueAsString(SetSecretVersionRequestV2.builder()
               .name(name)
               .version(maxValidVersion.get() + 1)
@@ -524,6 +642,10 @@ public class SecretResourceTest {
     }
   }
 
+  //---------------------------------------------------------------------------------------
+  // helper functions for tests
+  //---------------------------------------------------------------------------------------
+
   private Response createGroup(String name) throws IOException {
     GroupResourceTest groupResourceTest = new GroupResourceTest();
     groupResourceTest.mutualSslClient = mutualSslClient;
@@ -554,6 +676,30 @@ public class SecretResourceTest {
     Response httpResponse = mutualSslClient.newCall(get).execute();
     assertThat(httpResponse.code()).isEqualTo(200);
     return mapper.readValue(httpResponse.body().byteStream(), new TypeReference<List<String>>() {
+    });
+  }
+
+  List<String> listBatch(int idx, int num, boolean newestFirst) throws IOException {
+    Request get = clientRequest(String.format("/automation/v2/secrets?idx=%d&num=%d&newestFirst=%s", idx, num, newestFirst)).get().build();
+    Response httpResponse = mutualSslClient.newCall(get).execute();
+    assertThat(httpResponse.code()).isEqualTo(200);
+    return mapper.readValue(httpResponse.body().byteStream(), new TypeReference<List<String>>() {
+    });
+  }
+
+  List<SanitizedSecret> listingV2() throws IOException {
+    Request get = clientRequest("/automation/v2/secrets/v2").get().build();
+    Response httpResponse = mutualSslClient.newCall(get).execute();
+    assertThat(httpResponse.code()).isEqualTo(200);
+    return mapper.readValue(httpResponse.body().byteStream(), new TypeReference<List<SanitizedSecret>>() {
+    });
+  }
+
+  List<SanitizedSecret> listBatchV2(int idx, int num, boolean newestFirst) throws IOException {
+    Request get = clientRequest(String.format("/automation/v2/secrets/v2?idx=%d&num=%d&newestFirst=%s", idx, num, newestFirst)).get().build();
+    Response httpResponse = mutualSslClient.newCall(get).execute();
+    assertThat(httpResponse.code()).isEqualTo(200);
+    return mapper.readValue(httpResponse.body().byteStream(), new TypeReference<List<SanitizedSecret>>() {
     });
   }
 


### PR DESCRIPTION
This adds an endpoint to both the automation and admin APIs to list secrets in batches, specified by an index into a list of the secrets sorted by creation date from oldest to newest, and a number of secrets after that index to retrieve.  

The fact that an index of 0 retrieves the oldest secret is not necessarily the most convenient for a user querying secrets.  However, if the automation endpoint is used to iterate over secrets in batches, querying from newest to oldest would run into unexpected repeated secrets, and overlooked new secrets, if a secret was created between one batch and the next.  Querying from oldest to newest avoids this potential bug.