### PR TITLE
Return current secret version's metadata and hmac in secret info

### DIFF
--- a/api/src/main/java/keywhiz/api/automation/v2/SecretDetailResponseV2.java
+++ b/api/src/main/java/keywhiz/api/automation/v2/SecretDetailResponseV2.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import keywhiz.api.model.Secret;
 import keywhiz.api.model.SecretSeries;
+import keywhiz.api.model.SecretSeriesAndContent;
 import keywhiz.api.model.SecretVersion;
 
 import static com.google.common.base.Strings.nullToEmpty;
@@ -59,6 +60,20 @@ import static keywhiz.api.model.Secret.decodedLength;
           .type(series.type().orElse(null));
     }
 
+    // Does not save secret contents, but saves HMAC
+    public Builder seriesAndContent(SecretSeriesAndContent seriesAndContent) {
+      return this
+          .name(seriesAndContent.series().name())
+          .version(seriesAndContent.series().currentVersion().orElse(null))
+          .checksum(seriesAndContent.content().hmac())
+          .description(seriesAndContent.series().description())
+          .metadata(seriesAndContent.content().metadata())
+          .createdAtSeconds(seriesAndContent.series().createdAt().toEpochSecond())
+          .createdBy(seriesAndContent.series().createdBy())
+          .expiry(seriesAndContent.content().expiry())
+          .type(seriesAndContent.series().type().orElse(null));
+    }
+
     public Builder secret(Secret secret) {
       return this
           .name(secret.getName())
@@ -72,6 +87,7 @@ import static keywhiz.api.model.Secret.decodedLength;
           .metadata(secret.getMetadata());
     }
 
+    // Does not save secret contents or checksum
     public Builder secretVersion(SecretVersion secretVersion) {
       return this
           .name(secretVersion.name())
@@ -82,7 +98,6 @@ import static keywhiz.api.model.Secret.decodedLength;
           .type(secretVersion.type())
           .expiry(secretVersion.expiry())
           .metadata(secretVersion.metadata());
-
     }
 
     public SecretDetailResponseV2 build() {

--- a/api/src/test/java/keywhiz/api/automation/v2/SecretDetailResponseV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/SecretDetailResponseV2Test.java
@@ -23,6 +23,7 @@ import keywhiz.api.ApiDate;
 import keywhiz.api.model.Secret;
 import keywhiz.api.model.SecretContent;
 import keywhiz.api.model.SecretSeries;
+import keywhiz.api.model.SecretSeriesAndContent;
 import keywhiz.api.model.SecretVersion;
 import org.junit.Test;
 
@@ -60,6 +61,25 @@ public class SecretDetailResponseV2Test {
         .checksum("checksum")
         .metadata(ImmutableMap.of("owner", "root"))
         .expiry(1136214245)
+        .build();
+
+    assertThat(asJson(secretDetailResponse))
+        .isEqualTo(jsonFixture("fixtures/v2/secretDetailResponse.json"));
+  }
+
+  @Test public void formsCorrectlyFromSecretSeriesAndContent() throws Exception {
+    SecretSeries series = SecretSeries.of(1, "secret-name", "secret-description",
+        ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
+        ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user", "text/plain", null,
+        1L);
+    SecretContent content = SecretContent.of(1, 1, "YXNkZGFz", "checksum",
+        ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
+        ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
+        ImmutableMap.of("owner", "root"), 1136214245);
+    SecretSeriesAndContent seriesAndContent = SecretSeriesAndContent.of(series, content);
+    SecretDetailResponseV2 secretDetailResponse = SecretDetailResponseV2.builder()
+        .seriesAndContent(seriesAndContent)
+        .content("YXNkZGFz")
         .build();
 
     assertThat(asJson(secretDetailResponse))

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -404,9 +404,7 @@ public class SecretResource {
     SecretSeriesAndContent secret = secretDAO.getSecretByName(name)
         .orElseThrow(NotFoundException::new);
     return SecretDetailResponseV2.builder()
-        .series(secret.series())
-        .checksum(secret.content().hmac())
-        .expiry(secret.content().expiry())
+        .seriesAndContent(secret)
         .build();
   }
 

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -152,11 +152,11 @@ public class SecretResourceTest {
     assertThat(response.createdBy()).isEqualTo("client");
     assertThat(response.description()).isEqualTo("desc");
     assertThat(response.type()).isEqualTo("password");
+    assertThat(response.metadata()).isEqualTo(ImmutableMap.of("owner", "root", "mode", "0440"));
 
     // These values are left out for a series lookup as they pertain to a specific secret.
     assertThat(response.content()).isEmpty();
     assertThat(response.size().longValue()).isZero();
-    assertThat(response.metadata()).isEmpty();
   }
 
   //---------------------------------------------------------------------------------------


### PR DESCRIPTION
The automation secret-info endpoint now returns the metadata and content HMAC of the current version of the input secret, since the metadata often includes useful information.  (The content is omitted, since it is seldom needed and should not be exposed unnecessarily)