### PR TITLE
Log secrets' groups before deletion

### DIFF
--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -601,10 +601,17 @@ public class SecretResource {
   @Path("{name}")
   public Response deleteSecretSeries(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
-    secretDAO.getSecretByName(name)
-        .orElseThrow(NotFoundException::new);
+    Secret secret = secretController.getSecretByName(name).orElseThrow(() -> new NotFoundException("Secret series not found."));
+
+    // Get the groups for this secret so they can be restored manually if necessary
+    Set<String> groups = aclDAO.getGroupsFor(secret).stream().map(Group::getName).collect(toSet());
+
     secretDAO.deleteSecretsByName(name);
-    auditLog.recordEvent(new Event(Instant.now(), EventTag.SECRET_DELETE, automationClient.getName(), name));
+
+    // Record the deletion in the audit log
+    Map<String, String> extraInfo = new HashMap<>();
+    extraInfo.put("groups", groups.toString());
+    auditLog.recordEvent(new Event(Instant.now(), EventTag.SECRET_DELETE, automationClient.getName(), name, extraInfo));
     return Response.noContent().build();
   }
 

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import io.dropwizard.jersey.params.LongParam;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import javax.ws.rs.NotFoundException;
@@ -179,6 +180,10 @@ public class SecretsResourceTest {
 
   @Test public void canDelete() {
     when(secretController.getSecretById(0xdeadbeef)).thenReturn(Optional.of(secret));
+    HashSet<Group> groups = new HashSet<>();
+    groups.add(new Group(0, "group1", "", NOW, null, NOW, null, null));
+    groups.add(new Group(0, "group2", "", NOW, null, NOW, null, null));
+    when(aclDAO.getGroupsFor(secret)).thenReturn(groups);
 
     Response response = resource.deleteSecret(user, new LongParam(Long.toString(0xdeadbeef)));
     verify(secretDAO).deleteSecretsByName("name");

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -233,6 +233,12 @@ public class SecretResourceTest {
         .name("secret12")
         .content(encoder.encodeToString("supa secret12".getBytes(UTF_8)))
         .build());
+    
+    createGroup("testGroup");
+    ModifyGroupsRequestV2 request = ModifyGroupsRequestV2.builder()
+        .addGroups("testGroup", "secret12")
+        .build();
+    List<String> groups = modifyGroups("secret12", request);
 
     // Delete works
     assertThat(deleteSeries("secret12").code()).isEqualTo(204);


### PR DESCRIPTION
Deleted secrets can be manually restored by resetting the "current" field in the "secrets" table to the appropriate secrets content.  However, the access permissions for a deleted secret are permanently deleted.  This logs what groups have access to a secret at the moment of its deletion to allow users to manually restore a secret's complete information. 