### PR TITLE
Add keywhiz cli rollback

### DIFF
--- a/api/src/main/java/keywhiz/api/automation/v2/SecretDetailResponseV2.java
+++ b/api/src/main/java/keywhiz/api/automation/v2/SecretDetailResponseV2.java
@@ -96,7 +96,7 @@ import static keywhiz.api.model.Secret.decodedLength;
           .checksum(secretVersion.checksum())
           .createdAtSeconds(secretVersion.createdAt().toEpochSecond())
           .createdBy(secretVersion.createdBy())
-          .type(secretVersion.type())
+          .type(secretVersion.type().orElse(null))
           .expiry(secretVersion.expiry())
           .metadata(secretVersion.metadata());
     }

--- a/api/src/main/java/keywhiz/api/automation/v2/SecretDetailResponseV2.java
+++ b/api/src/main/java/keywhiz/api/automation/v2/SecretDetailResponseV2.java
@@ -93,6 +93,7 @@ import static keywhiz.api.model.Secret.decodedLength;
           .name(secretVersion.name())
           .version(secretVersion.versionId())
           .description(secretVersion.description())
+          .checksum(secretVersion.checksum())
           .createdAtSeconds(secretVersion.createdAt().toEpochSecond())
           .createdBy(secretVersion.createdBy())
           .type(secretVersion.type())

--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -121,7 +121,7 @@ public abstract class SanitizedSecret {
         secret.updatedAt(),
         secret.updatedBy(),
         secret.metadata(),
-        secret.type(),
+        secret.type().orElse(null),
         ImmutableMap.of(),
         secret.expiry(),
         secret.versionId());

--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -114,7 +114,7 @@ public abstract class SanitizedSecret {
     return SanitizedSecret.of(
         secret.secretId(),
         secret.name(),
-        "", // No checksum
+        secret.checksum(),
         secret.description(),
         secret.createdAt(),
         secret.createdBy(),

--- a/api/src/main/java/keywhiz/api/model/SanitizedSecretWithGroups.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecretWithGroups.java
@@ -37,7 +37,7 @@ public abstract class SanitizedSecretWithGroups {
 
   public static SanitizedSecretWithGroups of(long id, String name, List<Group> groups) {
     SanitizedSecret sanitizedSecret = SanitizedSecret.of(id, name, "", null,
-        new ApiDate(0), null, new ApiDate(0), null, null, null, null, 0);
+        new ApiDate(0), null, new ApiDate(0), null, null, null, null, 0, null);
     return SanitizedSecretWithGroups.of(sanitizedSecret, groups);
   }
 

--- a/api/src/main/java/keywhiz/api/model/Secret.java
+++ b/api/src/main/java/keywhiz/api/model/Secret.java
@@ -62,6 +62,9 @@ public class Secret {
 
   private final long expiry;
 
+  /** Current version of the secret (may be null) */
+  private final Long version;
+
   public Secret(long id,
                 String name,
                 @Nullable String description,
@@ -74,7 +77,8 @@ public class Secret {
                 @Nullable Map<String, String> metadata,
                 @Nullable String type,
                 @Nullable Map<String, String> generationOptions,
-                long expiry) {
+                long expiry,
+                @Nullable Long version) {
 
     checkArgument(!name.isEmpty());
     this.id = id;
@@ -92,6 +96,7 @@ public class Secret {
     this.generationOptions = (generationOptions == null) ?
         ImmutableMap.of() : ImmutableMap.copyOf(generationOptions);
     this.expiry = expiry;
+    this.version = version;
   }
 
   public long getId() {
@@ -154,6 +159,8 @@ public class Secret {
     return expiry;
   }
 
+  public Optional<Long> getVersion() {return Optional.ofNullable(version); }
+
   /** Slightly hokey way of calculating the decoded-length without bothering to decode. */
   public static int decodedLength(String secret) {
     checkNotNull(secret);
@@ -178,7 +185,8 @@ public class Secret {
           Objects.equal(this.metadata, that.metadata) &&
           Objects.equal(this.type, that.type) &&
           Objects.equal(this.generationOptions, that.generationOptions) &&
-          this.expiry == that.expiry) {
+          this.expiry == that.expiry &&
+          Objects.equal(this.version, that.version)) {
         return true;
       }
     }
@@ -206,6 +214,7 @@ public class Secret {
         .add("type", type)
         .add("generationOptions", generationOptions)
         .add("expiry", expiry)
+        .add("version", version)
         .toString();
   }
 

--- a/api/src/main/java/keywhiz/api/model/SecretVersion.java
+++ b/api/src/main/java/keywhiz/api/model/SecretVersion.java
@@ -15,11 +15,12 @@ import static com.google.common.base.Strings.nullToEmpty;
  */
 @AutoValue
 public abstract class SecretVersion {
-  public static SecretVersion of(long secretId, long versionId, String name, @Nullable String description, ApiDate createdAt,
+  public static SecretVersion of(long secretId, long versionId, String name,
+      @Nullable String description, String checksum, ApiDate createdAt,
       @Nullable String createdBy, ApiDate updatedAt, @Nullable String updatedBy,
       ImmutableMap<String, String> metadata, @Nullable String type, long expiry) {
     return new AutoValue_SecretVersion(secretId, versionId, name, nullToEmpty(description),
-        createdAt, nullToEmpty(createdBy), updatedAt,
+        checksum, createdAt, nullToEmpty(createdBy), updatedAt,
         nullToEmpty(updatedBy), metadata, type, expiry);
   }
 
@@ -27,6 +28,7 @@ public abstract class SecretVersion {
   public abstract long versionId();
   public abstract String name();
   public abstract String description();
+  public abstract String checksum();
   public abstract ApiDate createdAt();
   public abstract String createdBy();
   public abstract ApiDate updatedAt();
@@ -40,6 +42,7 @@ public abstract class SecretVersion {
         .add("secretId", secretId())
         .add("name", name())
         .add("description", description())
+        .add("checksum", checksum())
         .add("createdAt", createdAt())
         .add("createdBy", createdBy())
         .add("updatedAt", updatedAt())

--- a/api/src/main/java/keywhiz/api/model/SecretVersion.java
+++ b/api/src/main/java/keywhiz/api/model/SecretVersion.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import keywhiz.api.ApiDate;
 
@@ -21,7 +22,7 @@ public abstract class SecretVersion {
       ImmutableMap<String, String> metadata, @Nullable String type, long expiry) {
     return new AutoValue_SecretVersion(secretId, versionId, name, nullToEmpty(description),
         checksum, createdAt, nullToEmpty(createdBy), updatedAt,
-        nullToEmpty(updatedBy), metadata, type, expiry);
+        nullToEmpty(updatedBy), metadata, Optional.ofNullable(type), expiry);
   }
 
   public abstract long secretId();
@@ -34,7 +35,7 @@ public abstract class SecretVersion {
   public abstract ApiDate updatedAt();
   public abstract String updatedBy();
   @JsonAnyGetter public abstract  ImmutableMap<String, String> metadata();
-  public abstract String type();
+  public abstract Optional<String> type();
   public abstract long expiry();
 
   @Override public String toString() {
@@ -48,7 +49,7 @@ public abstract class SecretVersion {
         .add("updatedAt", updatedAt())
         .add("updatedBy", updatedBy())
         .add("metadata", metadata())
-        .add("type", type())
+        .add("type", type().orElse(""))
         .add("expiry", expiry())
         .omitNullValues().toString();
   }

--- a/api/src/test/java/keywhiz/api/AutomationSecretResponseTest.java
+++ b/api/src/test/java/keywhiz/api/AutomationSecretResponseTest.java
@@ -34,7 +34,7 @@ public class AutomationSecretResponseTest {
       ImmutableMap.of("key1", "value1", "key2", "value2");
   private static final ApiDate NOW = ApiDate.now();
   private static final Secret secret = new Secret(0, "name", null, () -> "YWJj", "checksum", NOW, null, NOW, null, metadata,
-      "upload", null, 1136214245);
+      "upload", null, 1136214245, null);
 
   @Test
   public void setsLength() {

--- a/api/src/test/java/keywhiz/api/SecretDeliveryResponseTest.java
+++ b/api/src/test/java/keywhiz/api/SecretDeliveryResponseTest.java
@@ -34,10 +34,10 @@ public class SecretDeliveryResponseTest {
   private static final ApiDate NOW = ApiDate.now();
   private static final Secret secret = new Secret(0, "name", null,
       () -> "YWJj", "checksum", NOW, null, NOW, null, metadata,
-      "upload", null, 0);
+      "upload", null, 0, null);
 
   private static final SanitizedSecret sanitizedSecret = SanitizedSecret.of(0, "name", "checksum",
-      null, NOW, null, NOW, null, metadata, "upload", null, 0);
+      null, NOW, null, NOW, null, metadata, "upload", null, 0, null);
 
   @Test
   public void setsLength() {

--- a/api/src/test/java/keywhiz/api/SecretsResponseTest.java
+++ b/api/src/test/java/keywhiz/api/SecretsResponseTest.java
@@ -40,7 +40,8 @@ public class SecretsResponseTest {
             ImmutableMap.of("owner", "the king"),
             "password",
             ImmutableMap.of("param1", "value1"),
-            1136214245),
+            1136214245,
+            1L),
         SanitizedSecret.of(
             768,
             "anotherSecret",
@@ -53,7 +54,8 @@ public class SecretsResponseTest {
             null,
             "upload",
             null,
-            1136214245)
+            1136214245,
+            10L)
     ));
 
     assertThat(asJson(secretsResponse))

--- a/api/src/test/java/keywhiz/api/automation/v2/SecretDetailResponseV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/SecretDetailResponseV2Test.java
@@ -91,7 +91,7 @@ public class SecretDetailResponseV2Test {
         ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
         ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
         ImmutableMap.of("owner", "root"), "text/plain", null,
-        1136214245);
+        1136214245, null);
     SecretDetailResponseV2 secretDetailResponse = SecretDetailResponseV2.builder()
         .secret(secret)
         .content("YXNkZGFz")
@@ -104,13 +104,12 @@ public class SecretDetailResponseV2Test {
 
   @Test public void formsCorrectlyFromSecretVersion() throws Exception {
     SecretVersion version = SecretVersion.of(10, 1, "secret-name", "secret-description",
-        ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
+        "checksum", ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
         ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
         ImmutableMap.of("owner", "root"), "text/plain", 1136214245);
     SecretDetailResponseV2 secretDetailResponse = SecretDetailResponseV2.builder()
         .secretVersion(version)
         .content("YXNkZGFz")
-        .checksum("checksum")
         .build();
 
     assertThat(asJson(secretDetailResponse))

--- a/api/src/test/java/keywhiz/api/model/SanitizedSecretTest.java
+++ b/api/src/test/java/keywhiz/api/model/SanitizedSecretTest.java
@@ -97,4 +97,38 @@ public class SanitizedSecretTest {
     assertThat(asJson(sanitizedSecret))
         .isEqualTo(jsonFixture("fixtures/sanitizedSecret.json"));
   }
+
+  @Test public void buildsCorrectlyFromSecretVersion() throws Exception {
+    SanitizedSecret secret = SanitizedSecret.fromSecretVersion(
+        SecretVersion.of(
+            767,
+            1L,
+            "trapdoor",
+            "v1",
+            "checksum",
+            ApiDate.parse("2013-03-28T21:42:42.573Z"),
+            "keywhizAdmin",
+            ApiDate.parse("2013-03-28T21:42:42.573Z"),
+            "keywhizAdmin",
+            ImmutableMap.of("owner", "the king"),
+            "password",
+            1136214245));
+    SanitizedSecret withGenerationOptions = SanitizedSecret.of(
+        secret.id(),
+        secret.name(),
+        secret.checksum(),
+        secret.description(),
+        secret.createdAt(),
+        secret.createdBy(),
+        secret.updatedAt(),
+        secret.updatedBy(),
+        secret.metadata(),
+        secret.type().orElse(null),
+        ImmutableMap.of("favoriteFood", "PB&J sandwich"),
+        secret.expiry(),
+        secret.version().orElse(null));
+
+    assertThat(asJson(withGenerationOptions))
+        .isEqualTo(jsonFixture("fixtures/sanitizedSecret.json"));
+  }
 }

--- a/api/src/test/java/keywhiz/api/model/SanitizedSecretTest.java
+++ b/api/src/test/java/keywhiz/api/model/SanitizedSecretTest.java
@@ -38,7 +38,8 @@ public class SanitizedSecretTest {
         ImmutableMap.of("owner", "the king"),
         "password",
         ImmutableMap.of("favoriteFood", "PB&J sandwich"),
-        1136214245);
+        1136214245,
+        1L);
 
     assertThat(asJson(sanitizedSecret))
         .isEqualTo(jsonFixture("fixtures/sanitizedSecret.json"));
@@ -59,7 +60,8 @@ public class SanitizedSecretTest {
             ImmutableMap.of("owner", "the king"),
             "password",
             ImmutableMap.of("favoriteFood", "PB&J sandwich"),
-            1136214245));
+            1136214245,
+            1L));
 
     assertThat(asJson(sanitizedSecret))
         .isEqualTo(jsonFixture("fixtures/sanitizedSecret.json"));
@@ -78,7 +80,7 @@ public class SanitizedSecretTest {
                 "keywhizAdmin",
                 "password",
                 ImmutableMap.of("favoriteFood", "PB&J sandwich"),
-                1136214245L
+                1L
             ), SecretContent.of(
                 1L,
                 767,

--- a/api/src/test/java/keywhiz/api/model/SanitizedSecretWithGroupsTest.java
+++ b/api/src/test/java/keywhiz/api/model/SanitizedSecretWithGroupsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keywhiz.api.model;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.List;
+import keywhiz.api.ApiDate;
+import org.junit.Before;
+import org.junit.Test;
+
+import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.jsonFixture;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SanitizedSecretWithGroupsTest {
+  SanitizedSecret sanitizedSecret = SanitizedSecret.of(
+      767,
+      "trapdoor",
+      "checksum",
+      "v1",
+      ApiDate.parse("2013-03-28T21:42:42.000Z"),
+      "keywhizAdmin",
+      ApiDate.parse("2013-03-28T21:42:42.000Z"),
+      "keywhizAdmin",
+      ImmutableMap.of("owner", "the king"),
+      "password",
+      ImmutableMap.of("favoriteFood", "PB&J sandwich"),
+      1136214245,
+      1L);
+
+  List<Group> groups;
+
+  @Before
+  public void setUp() {
+    groups = new ArrayList<>();
+    groups.add(new Group(100, "group1", "test-group-1", ApiDate.parse("2013-03-28T21:42:42.000Z"),
+        "keywhizAdmin",
+        ApiDate.parse("2013-03-28T21:42:42.000Z"),
+        "keywhizAdmin",
+        ImmutableMap.of("owner", "the king")));
+    groups.add(new Group(100, "group2", "test-group-1", ApiDate.parse("2013-03-28T21:42:42.000Z"),
+        null,
+        ApiDate.parse("2013-03-28T21:42:42.000Z"), null, null));
+  }
+
+  @Test public void serializesCorrectly() throws Exception {
+    SanitizedSecretWithGroups sanitizedSecretWithGroups = SanitizedSecretWithGroups.of(sanitizedSecret, groups);
+    assertThat(asJson(sanitizedSecretWithGroups))
+        .isEqualTo(jsonFixture("fixtures/sanitizedSecretWithGroups.json"));
+  }
+
+  @Test public void buildsCorrectlyFromSecretAndGroups() throws Exception {
+    SanitizedSecretWithGroups sanitizedSecretWithGroups = SanitizedSecretWithGroups.fromSecret(
+        new Secret(
+            767,
+            "trapdoor",
+            "v1",
+            () -> "foo",
+            "checksum",
+            ApiDate.parse("2013-03-28T21:42:42.000Z"),
+            "keywhizAdmin",
+            ApiDate.parse("2013-03-28T21:42:42.000Z"),
+            "keywhizAdmin",
+            ImmutableMap.of("owner", "the king"),
+            "password",
+            ImmutableMap.of("favoriteFood", "PB&J sandwich"),
+            1136214245,
+            1L), groups);
+
+    assertThat(asJson(sanitizedSecretWithGroups))
+        .isEqualTo(jsonFixture("fixtures/sanitizedSecretWithGroups.json"));
+  }
+
+  @Test public void buildsCorrectlyFromSecretSeriesAndContent() throws Exception {
+    SanitizedSecretWithGroups sanitizedSecretWithGroups = SanitizedSecretWithGroups.fromSecretSeriesAndContentAndGroups(
+        SecretSeriesAndContent.of(
+            SecretSeries.of(
+                767,
+                "trapdoor",
+                "v1",
+                ApiDate.parse("2013-03-28T21:42:42.000Z"),
+                "keywhizAdmin",
+                ApiDate.parse("2013-03-28T21:42:42.000Z"),
+                "keywhizAdmin",
+                "password",
+                ImmutableMap.of("favoriteFood", "PB&J sandwich"),
+                1L
+            ), SecretContent.of(
+                1L,
+                767,
+                "foo",
+                "checksum",
+                ApiDate.parse("2013-03-28T21:42:42.000Z"),
+                "keywhizAdmin",
+                ApiDate.parse("2013-03-28T21:42:42.000Z"),
+                "keywhizAdmin",
+                ImmutableMap.of("owner", "the king"),
+                1136214245L
+            )), groups);
+
+    assertThat(asJson(sanitizedSecretWithGroups))
+        .isEqualTo(jsonFixture("fixtures/sanitizedSecretWithGroups.json"));
+  }
+}

--- a/api/src/test/java/keywhiz/api/model/SecretTest.java
+++ b/api/src/test/java/keywhiz/api/model/SecretTest.java
@@ -46,7 +46,7 @@ public class SecretTest {
 
   @Test public void callsDecryptOnlyOnce() {
     Secret s = new Secret(42, "toto", null, () -> String.valueOf(++called), "checksum", ApiDate.now(), "", ApiDate.now(), "", null,
-        null, null, 0);
+        null, null, 0, 1L);
     assertThat(s.getSecret()).isEqualTo("1");
     assertThat(s.getSecret()).isEqualTo("1");
   }

--- a/api/src/test/resources/fixtures/sanitizedSecret.json
+++ b/api/src/test/resources/fixtures/sanitizedSecret.json
@@ -14,5 +14,6 @@
   "generationOptions" : {
     "favoriteFood" : "PB&J sandwich"
   },
-  "expiry": 1136214245
+  "expiry" : 1136214245,
+  "version" : 1
 }

--- a/api/src/test/resources/fixtures/sanitizedSecretWithGroups.json
+++ b/api/src/test/resources/fixtures/sanitizedSecretWithGroups.json
@@ -1,0 +1,45 @@
+{
+  "secret": {
+    "id": 767,
+    "name": "trapdoor",
+    "checksum": "checksum",
+    "description": "v1",
+    "createdAt": "2013-03-28T21:42:42.000Z",
+    "createdBy": "keywhizAdmin",
+    "updatedAt": "2013-03-28T21:42:42.000Z",
+    "updatedBy": "keywhizAdmin",
+    "metadata": {
+      "owner": "the king"
+    },
+    "type": "password",
+    "generationOptions": {
+      "favoriteFood": "PB&J sandwich"
+    },
+    "expiry": 1136214245,
+    "version": 1
+  },
+  "groups": [
+    {
+      "id": 100,
+      "name": "group1",
+      "description": "test-group-1",
+      "createdAt": "2013-03-28T21:42:42.000Z",
+      "createdBy": "keywhizAdmin",
+      "updatedAt": "2013-03-28T21:42:42.000Z",
+      "updatedBy": "keywhizAdmin",
+      "metadata": {
+        "owner": "the king"
+      }
+    },
+    {
+      "id": 100,
+      "name": "group2",
+      "description": "test-group-1",
+      "createdAt": "2013-03-28T21:42:42.000Z",
+      "createdBy": "",
+      "updatedAt": "2013-03-28T21:42:42.000Z",
+      "updatedBy": "",
+      "metadata": {}
+    }
+  ]
+}

--- a/api/src/test/resources/fixtures/secretsResponse.json
+++ b/api/src/test/resources/fixtures/secretsResponse.json
@@ -16,7 +16,8 @@
       "generationOptions" : {
         "param1" : "value1"
       },
-      "expiry" : 1136214245
+      "expiry" : 1136214245,
+      "version" : 1
     },
     {
       "id" : 768,
@@ -30,7 +31,8 @@
       "metadata" : {},
       "type" : "upload",
       "generationOptions" : {},
-      "expiry" : 1136214245
+      "expiry" : 1136214245,
+      "version" : 10
     }
   ]
 }

--- a/cli/src/main/java/keywhiz/cli/CliMain.java
+++ b/cli/src/main/java/keywhiz/cli/CliMain.java
@@ -39,6 +39,8 @@ public class CliMain {
         .put("delete", new DeleteActionConfig())
         .put("assign", new AssignActionConfig())
         .put("unassign", new UnassignActionConfig())
+        .put("versions", new ListVersionsActionConfig())
+        .put("rollback", new RollbackActionConfig())
         .build();
     commander.setProgramName("KeyWhiz Configuration Utility");
     commander.addObject(config);

--- a/cli/src/main/java/keywhiz/cli/CommandExecutor.java
+++ b/cli/src/main/java/keywhiz/cli/CommandExecutor.java
@@ -44,7 +44,7 @@ import static java.lang.String.format;
 public class CommandExecutor {
   public static final String APP_VERSION = "2.1";
 
-  public enum Command { LOGIN, LIST, DESCRIBE, ADD, UPDATE, DELETE, ASSIGN, UNASSIGN }
+  public enum Command { LOGIN, LIST, DESCRIBE, ADD, UPDATE, DELETE, ASSIGN, UNASSIGN, VERSIONS, ROLLBACK }
 
   private final Path cookieDir = Paths.get(USER_HOME.value());
 
@@ -148,6 +148,14 @@ public class CommandExecutor {
 
       case UNASSIGN:
         new UnassignAction((UnassignActionConfig) commands.get(command), client).run();
+        break;
+
+      case VERSIONS:
+        new ListVersionsAction((ListVersionsActionConfig) commands.get(command), client, printing).run();
+        break;
+
+      case ROLLBACK:
+        new RollbackAction((RollbackActionConfig) commands.get(command), client).run();
         break;
 
       case LOGIN:

--- a/cli/src/main/java/keywhiz/cli/commands/ListVersionsAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/ListVersionsAction.java
@@ -1,0 +1,48 @@
+package keywhiz.cli.commands;
+
+import com.google.common.base.Throwables;
+import java.io.IOException;
+import java.util.List;
+import keywhiz.api.model.SanitizedSecret;
+import keywhiz.cli.Printing;
+import keywhiz.cli.configs.ListVersionsActionConfig;
+import keywhiz.client.KeywhizClient;
+import keywhiz.client.KeywhizClient.NotFoundException;
+
+import static java.lang.String.format;
+import static keywhiz.cli.Utilities.VALID_NAME_PATTERN;
+import static keywhiz.cli.Utilities.validName;
+
+public class ListVersionsAction implements Runnable {
+
+  private final ListVersionsActionConfig listVersionsActionConfig;
+  private final KeywhizClient keywhizClient;
+  private final Printing printing;
+
+  public ListVersionsAction(ListVersionsActionConfig listVersionsActionConfig, KeywhizClient client, Printing printing) {
+    this.listVersionsActionConfig = listVersionsActionConfig;
+    this.keywhizClient = client;
+    this.printing = printing;
+  }
+
+  @Override public void run() {
+    if (listVersionsActionConfig.name == null || !validName(listVersionsActionConfig.name)) {
+      throw new IllegalArgumentException(format("Invalid name, must match %s", VALID_NAME_PATTERN));
+    }
+
+    try {
+      SanitizedSecret sanitizedSecret =
+          keywhizClient.getSanitizedSecretByName(listVersionsActionConfig.name);
+
+      List<SanitizedSecret> versions =
+          keywhizClient.listSecretVersions(sanitizedSecret.name(),
+              listVersionsActionConfig.idx, listVersionsActionConfig.number);
+      // The current version can never be negative
+      printing.printSecretVersions(versions, sanitizedSecret.version().orElse(-1L));
+    } catch (NotFoundException e) {
+      throw new AssertionError("Secret does not exist: " + listVersionsActionConfig.name);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/cli/src/main/java/keywhiz/cli/commands/RollbackAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/RollbackAction.java
@@ -1,0 +1,77 @@
+package keywhiz.cli.commands;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import keywhiz.api.model.SanitizedSecret;
+import keywhiz.cli.configs.RollbackActionConfig;
+import keywhiz.client.KeywhizClient;
+import keywhiz.client.KeywhizClient.NotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static keywhiz.cli.Utilities.VALID_NAME_PATTERN;
+import static keywhiz.cli.Utilities.validName;
+
+public class RollbackAction implements Runnable {
+  private static final Logger logger = LoggerFactory.getLogger(RollbackAction.class);
+
+  private final RollbackActionConfig rollbackActionConfig;
+  private final KeywhizClient keywhizClient;
+  
+  @VisibleForTesting
+  InputStream inputStream = System.in;
+
+  public RollbackAction(RollbackActionConfig rollbackActionConfig, KeywhizClient client) {
+    this.rollbackActionConfig = rollbackActionConfig;
+    this.keywhizClient = client;
+  }
+
+  @Override public void run() {
+    try {
+      if (rollbackActionConfig.name == null || !validName(rollbackActionConfig.name)) {
+        throw new IllegalArgumentException(
+            format("Invalid name, must match %s", VALID_NAME_PATTERN));
+      }
+
+      if (rollbackActionConfig.id == null || rollbackActionConfig.id < 0) {
+        throw new IllegalArgumentException(
+            "Version ID must be specified and non-negative for rollback.  List the secret's versions to view IDs.");
+      }
+
+      SanitizedSecret sanitizedSecret =
+          keywhizClient.getSanitizedSecretByName(rollbackActionConfig.name);
+
+      // Get user confirmation for the rollback
+      BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8));
+      while (true) {
+        System.out.println(
+            format("Please confirm rollback of secret '%s' to version with ID %d: Y/N",
+                sanitizedSecret.name(), rollbackActionConfig.id));
+        String line = reader.readLine();
+
+        if (line == null /* EOF */ || line.toUpperCase().startsWith("N")) {
+          return;
+        } else if (line.toUpperCase().startsWith("Y")) {
+          logger.info("Rolling back secret '{}' to version {}", sanitizedSecret.name(),
+              rollbackActionConfig.id);
+          keywhizClient.rollbackSecret(sanitizedSecret.name(), rollbackActionConfig.id);
+          return;
+        } // else loop again
+      }
+    } catch (NotFoundException e) {
+      throw new AssertionError("Secret does not exist: " + rollbackActionConfig.name);
+    } catch (IOException e) {
+      throw new AssertionError(String.format(
+          "Error executing rollback; check whether ID %d is a valid version ID for secret %s by listing the secret's versions\nError: %s",
+          rollbackActionConfig.id, rollbackActionConfig.name, e.getMessage()));
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/cli/src/main/java/keywhiz/cli/commands/RollbackAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/RollbackAction.java
@@ -68,7 +68,7 @@ public class RollbackAction implements Runnable {
       throw new AssertionError("Secret does not exist: " + rollbackActionConfig.name);
     } catch (IOException e) {
       throw new AssertionError(String.format(
-          "Error executing rollback; check whether ID %d is a valid version ID for secret %s by listing the secret's versions\nError: %s",
+          "Error executing rollback; check whether ID %d is a valid version ID for secret %s by listing the secret's versions%nError: %s",
           rollbackActionConfig.id, rollbackActionConfig.name, e.getMessage()));
     } catch (Exception e) {
       throw Throwables.propagate(e);

--- a/cli/src/main/java/keywhiz/cli/configs/ListVersionsActionConfig.java
+++ b/cli/src/main/java/keywhiz/cli/configs/ListVersionsActionConfig.java
@@ -1,0 +1,17 @@
+package keywhiz.cli.configs;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+@Parameters(commandDescription = "List the previous versions of a secret")
+public class ListVersionsActionConfig {
+
+  @Parameter(names = "--name", description = "Name of the secret whose versions should be listed", required = true)
+  public String name;
+
+  @Parameter(names = "--idx", description = "Index of the first version to return in a list of versions sorted from newest to oldest update time")
+  public int idx = 0;
+
+  @Parameter(names = "--number", description = "Maximum number of versions to return in a list of versions sorted from newest to oldest update time")
+  public int number = 10;
+}

--- a/cli/src/main/java/keywhiz/cli/configs/RollbackActionConfig.java
+++ b/cli/src/main/java/keywhiz/cli/configs/RollbackActionConfig.java
@@ -9,6 +9,6 @@ public class RollbackActionConfig {
   @Parameter(names = "--name", description = "Name of the secret to roll back", required = true)
   public String name;
 
-  @Parameter(names = "--id", description = "Version ID to roll back to (list versions to view IDs)", required = true)
+  @Parameter(names = "--version", description = "Version ID to roll back to (list versions to view IDs)", required = true)
   public Long id;
 }

--- a/cli/src/main/java/keywhiz/cli/configs/RollbackActionConfig.java
+++ b/cli/src/main/java/keywhiz/cli/configs/RollbackActionConfig.java
@@ -1,0 +1,14 @@
+package keywhiz.cli.configs;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+@Parameters(commandDescription = "Rollback to a previous version of a secret")
+public class RollbackActionConfig {
+
+  @Parameter(names = "--name", description = "Name of the secret to roll back", required = true)
+  public String name;
+
+  @Parameter(names = "--id", description = "Version ID to roll back to (list versions to view IDs)", required = true)
+  public Long id;
+}

--- a/cli/src/test/java/keywhiz/cli/commands/AddActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/AddActionTest.java
@@ -56,7 +56,7 @@ public class AddActionTest {
   Client client = new Client(4, "newClient", null, null, null, null, null, null, true, false);
   Group group = new Group(4, "newGroup", null, null, null, null, null, null);
   Secret secret = new Secret(15, "newSecret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0);
+      ImmutableMap.of(), 0, 1L);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
   SecretDetailResponse secretDetailResponse = SecretDetailResponse.fromSecret(secret, null, null);
 

--- a/cli/src/test/java/keywhiz/cli/commands/AssignActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/AssignActionTest.java
@@ -54,7 +54,7 @@ public class AssignActionTest {
   GroupDetailResponse groupDetailResponse = GroupDetailResponse.fromGroup(group,
       ImmutableList.<SanitizedSecret>of(), ImmutableList.<Client>of());
   Secret secret = new Secret(16, "secret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0);
+      ImmutableMap.of(), 0, 1L);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
 
   @Before

--- a/cli/src/test/java/keywhiz/cli/commands/DeleteActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/DeleteActionTest.java
@@ -51,7 +51,7 @@ public class DeleteActionTest {
   DeleteAction deleteAction;
 
   Secret secret = new Secret(0, "secret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0);
+      ImmutableMap.of(), 0, 1L);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
 
   ByteArrayInputStream yes;

--- a/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
@@ -49,7 +49,7 @@ public class DescribeActionTest {
   DescribeActionConfig describeActionConfig;
   DescribeAction describeAction;
   Secret secret = new Secret(0, "secret", null, () ->  "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0);
+      ImmutableMap.of(), 0, 1L);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
 
   @Before

--- a/cli/src/test/java/keywhiz/cli/commands/ListVersionsActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/ListVersionsActionTest.java
@@ -1,0 +1,90 @@
+package keywhiz.cli.commands;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import keywhiz.api.ApiDate;
+import keywhiz.api.model.SanitizedSecret;
+import keywhiz.api.model.Secret;
+import keywhiz.cli.Printing;
+import keywhiz.cli.configs.ListVersionsActionConfig;
+import keywhiz.client.KeywhizClient;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ListVersionsActionTest {
+  @Rule public MockitoRule mockito = MockitoJUnit.rule();
+
+  @Mock KeywhizClient keywhizClient;
+  @Mock Printing printing;
+
+  ListVersionsActionConfig listVersionsActionConfig;
+  ListVersionsAction listVersionsAction;
+
+  private static final ApiDate NOW = ApiDate.now();
+  Secret secret = new Secret(0, "secret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
+      ImmutableMap.of(), 0, 1L);
+  SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
+
+  @Before
+  public void setUp() {
+    listVersionsActionConfig = new ListVersionsActionConfig();
+    listVersionsAction = new ListVersionsAction(listVersionsActionConfig, keywhizClient, printing);
+  }
+
+  @Test
+  public void listVersionsCallsPrint() throws Exception {
+    listVersionsActionConfig.name = secret.getDisplayName();
+    listVersionsActionConfig.idx = 5;
+    listVersionsActionConfig.number = 15;
+
+    when(keywhizClient.getSanitizedSecretByName(secret.getDisplayName())).thenReturn(sanitizedSecret);
+
+    listVersionsAction.run();
+
+    verify(printing).printSecretVersions(keywhizClient.listSecretVersions("test-secret", 5, 15),
+        1L);
+  }
+
+  @Test
+  public void listVersionsUsesDefaults() throws Exception {
+    listVersionsActionConfig.name = secret.getDisplayName();
+
+    when(keywhizClient.getSanitizedSecretByName(secret.getDisplayName())).thenReturn(sanitizedSecret);
+    listVersionsAction.run();
+
+    verify(printing).printSecretVersions(keywhizClient.listSecretVersions("test-secret", 0, 10),
+        1L);
+  }
+
+  @Test(expected = AssertionError.class)
+  public void listVersionsThrowsIfSecretDoesNotExist() throws Exception {
+    listVersionsActionConfig.name = secret.getDisplayName();
+
+    when(keywhizClient.getSanitizedSecretByName(secret.getDisplayName())).thenThrow(new KeywhizClient.NotFoundException());
+
+    listVersionsAction.run();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void listVersionsThrowsIfNoSecretSpecified() throws Exception {
+    listVersionsActionConfig.name = null;
+    listVersionsAction.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void listVersionsValidatesSecretName() throws Exception {
+    listVersionsActionConfig.name = "Invalid Name";
+    listVersionsAction.run();
+  }
+}

--- a/cli/src/test/java/keywhiz/cli/commands/RollbackActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/RollbackActionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keywhiz.cli.commands;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayInputStream;
+import javax.ws.rs.BadRequestException;
+import keywhiz.api.ApiDate;
+import keywhiz.api.model.SanitizedSecret;
+import keywhiz.api.model.Secret;
+import keywhiz.cli.configs.RollbackActionConfig;
+import keywhiz.client.KeywhizClient;
+import keywhiz.client.KeywhizClient.NotFoundException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RollbackActionTest {
+  private static final ApiDate NOW = ApiDate.now();
+
+  @Rule public MockitoRule mockito = MockitoJUnit.rule();
+
+  @Mock KeywhizClient keywhizClient;
+
+  RollbackActionConfig rollbackActionConfig;
+  RollbackAction rollbackAction;
+
+  Secret secret = new Secret(0, "secret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
+      ImmutableMap.of(), 0, 1L);
+  SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
+
+  ByteArrayInputStream yes;
+  ByteArrayInputStream no;
+
+  @Before
+  public void setUp() {
+    rollbackActionConfig = new RollbackActionConfig();
+    rollbackAction = new RollbackAction(rollbackActionConfig, keywhizClient);
+
+    yes = new ByteArrayInputStream("Y".getBytes(UTF_8));
+    no = new ByteArrayInputStream("\nOther\nN".getBytes(UTF_8)); // empty line, not yes or no, then no
+  }
+
+  @Test
+  public void rollbackCallsRollback() throws Exception {
+    rollbackAction.inputStream = yes;
+    rollbackActionConfig.name = secret.getDisplayName();
+    rollbackActionConfig.id = 1L;
+
+    when(keywhizClient.getSanitizedSecretByName(secret.getName())).thenReturn(sanitizedSecret);
+
+    rollbackAction.run();
+    verify(keywhizClient).rollbackSecret(sanitizedSecret.name(), rollbackActionConfig.id);
+  }
+
+  @Test
+  public void rollbackSkipsWithoutConfirmation() throws Exception {
+    rollbackAction.inputStream = no;
+    rollbackActionConfig.name = secret.getDisplayName();
+    rollbackActionConfig.id = 1L;
+
+    when(keywhizClient.getSanitizedSecretByName(secret.getName())).thenReturn(sanitizedSecret);
+
+    rollbackAction.run();
+    verify(keywhizClient, never()).rollbackSecret(anyString(), anyLong());
+  }
+
+  @Test(expected = AssertionError.class)
+  public void rollbackThrowsIfFindSecretFails() throws Exception {
+    rollbackAction.inputStream = yes;
+    rollbackActionConfig.name = secret.getDisplayName();
+    rollbackActionConfig.id = 1L;
+
+    when(keywhizClient.getSanitizedSecretByName(secret.getName())).thenThrow(new NotFoundException());
+
+    rollbackAction.run();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void rollbackThrowsIfIllegalIdInput() throws Exception {
+    rollbackAction.inputStream = yes;
+    rollbackActionConfig.name = secret.getDisplayName();
+    rollbackActionConfig.id = 1L;
+
+    when(keywhizClient.getSanitizedSecretByName(secret.getName())).thenReturn(sanitizedSecret);
+    when(keywhizClient.rollbackSecret(secret.getDisplayName(), 1L)).thenThrow(new IllegalStateException());
+
+    rollbackAction.run();
+  }
+
+  @Test(expected = BadRequestException.class)
+  public void rollbackThrowsIfInvalidIdInput() throws Exception {
+    rollbackAction.inputStream = yes;
+    rollbackActionConfig.name = secret.getDisplayName();
+    rollbackActionConfig.id = 1L;
+
+    when(keywhizClient.getSanitizedSecretByName(secret.getName())).thenReturn(sanitizedSecret);
+    when(keywhizClient.rollbackSecret(secret.getDisplayName(), 1L)).thenThrow(new BadRequestException());
+
+    rollbackAction.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rollbackThrowsIfNoSecretSpecified() throws Exception {
+    rollbackActionConfig.name = null;
+    rollbackActionConfig.id = 1L;
+
+    rollbackAction.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rollbackThrowsIfNoIdSpecified() throws Exception {
+    rollbackActionConfig.name = "test-name";
+    rollbackActionConfig.id = null;
+
+    rollbackAction.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rollbackValidatesSecretName() throws Exception {
+    rollbackActionConfig.name = "Invalid Name";
+    rollbackAction.run();
+  }
+}

--- a/cli/src/test/java/keywhiz/cli/commands/UnassignActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/UnassignActionTest.java
@@ -50,7 +50,7 @@ public class UnassignActionTest {
   Client client = new Client(11, "client-name", null, null, null, null, null, null, false, false);
   Group group = new Group(22, "group-name", null, null, null, null, null, null);
   Secret secret = new Secret(33, "secret-name", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0);
+      ImmutableMap.of(), 0, 1L);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
   GroupDetailResponse groupDetailResponse = GroupDetailResponse.fromGroup(group,
       ImmutableList.of(sanitizedSecret), ImmutableList.of(client));

--- a/cli/src/test/java/keywhiz/cli/commands/UpdateActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/UpdateActionTest.java
@@ -56,7 +56,7 @@ public class UpdateActionTest {
   UpdateAction updateAction;
 
   Secret secret = new Secret(15, "newSecret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0);
+      ImmutableMap.of(), 0, 1L);
   SecretDetailResponse secretDetailResponse = SecretDetailResponse.fromSecret(secret, null, null);
 
   @Before

--- a/client/src/main/java/keywhiz/client/KeywhizClient.java
+++ b/client/src/main/java/keywhiz/client/KeywhizClient.java
@@ -32,6 +32,7 @@ import keywhiz.api.LoginRequest;
 import keywhiz.api.SecretDetailResponse;
 import keywhiz.api.automation.v2.CreateOrUpdateSecretRequestV2;
 import keywhiz.api.automation.v2.PartialUpdateSecretRequestV2;
+import keywhiz.api.automation.v2.SecretDetailResponseV2;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
@@ -186,6 +187,16 @@ public class KeywhizClient {
 
   public SecretDetailResponse secretDetailsForId(long secretId) throws IOException {
     String response = httpGet(baseUrl.resolve(format("/admin/secrets/%d", secretId)));
+    return mapper.readValue(response, SecretDetailResponse.class);
+  }
+
+  public List<SanitizedSecret> listSecretVersions(String name, int idx, int numVersions) throws IOException {
+    String response = httpGet(baseUrl.resolve(format("/admin/secrets/versions/%s?versionIdx=%d&numVersions=%d", name, idx, numVersions)));
+    return mapper.readValue(response, new TypeReference<List<SanitizedSecret>>() {});
+  }
+
+  public SecretDetailResponse rollbackSecret (String name, long version) throws IOException {
+    String response = httpPost(baseUrl.resolve(format("/admin/secrets/rollback/%s/%d", name, version)), null);
     return mapper.readValue(response, SecretDetailResponse.class);
   }
 

--- a/server/src/main/java/keywhiz/service/crypto/SecretTransformer.java
+++ b/server/src/main/java/keywhiz/service/crypto/SecretTransformer.java
@@ -55,6 +55,7 @@ public class SecretTransformer {
         content.metadata(),
         series.type().orElse(null),
         series.generationOptions(),
-        content.expiry());
+        content.expiry(),
+        series.currentVersion().orElse(null));
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -293,7 +293,8 @@ public class AclDAO {
               secretContentMapper.tryToReadMapFromMetadata(row.getValue(SECRETS_CONTENT.METADATA)),
               series.type().orElse(null),
               series.generationOptions(),
-              row.getValue(SECRETS_CONTENT.EXPIRY));
+              row.getValue(SECRETS_CONTENT.EXPIRY),
+              series.currentVersion().orElse(null));
         })
         .forEach(row -> sanitizedSet.add(row));
 
@@ -350,7 +351,8 @@ public class AclDAO {
               secretContentMapper.tryToReadMapFromMetadata(row.getValue(SECRETS_CONTENT.METADATA)),
               series.type().orElse(null),
               series.generationOptions(),
-              row.getValue(SECRETS_CONTENT.EXPIRY));
+              row.getValue(SECRETS_CONTENT.EXPIRY),
+              series.currentVersion().orElse(null));
         });
   }
 

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -315,9 +315,9 @@ public class SecretDAO {
         ImmutableList.Builder<SecretVersion> b = new ImmutableList.Builder<>();
         b.addAll(contents.get()
             .stream()
-            .map(c -> SecretVersion.of(s.id(), c.id(), s.name(), s.description(), c.createdAt(),
-                c.createdBy(), c.updatedAt(), c.updatedBy(), c.metadata(), s.type().orElse(""),
-                c.expiry()))
+            .map(c -> SecretVersion.of(s.id(), c.id(), s.name(), s.description(), c.hmac(),
+                c.createdAt(), c.createdBy(), c.updatedAt(), c.updatedBy(), c.metadata(),
+                s.type().orElse(""), c.expiry()))
             .collect(toList()));
 
         return Optional.of(b.build());

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -150,7 +150,9 @@ public class SecretSeriesDAO {
 
     checkId = r.value1();
     if (checkId != secretId) {
-      throw new IllegalStateException("inconsistent secrets_content");
+      throw new IllegalStateException(String.format(
+          "tried to reset secret with id %d to version %d, but this version is not associated with this secret",
+          secretId, secretContentId));
     }
 
     return dslContext.update(SECRETS)

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
+import io.dropwizard.jersey.params.IntParam;
 import io.dropwizard.jersey.params.LongParam;
 import java.net.URI;
 import java.time.Instant;
@@ -48,10 +49,12 @@ import keywhiz.api.CreateSecretRequest;
 import keywhiz.api.SecretDetailResponse;
 import keywhiz.api.automation.v2.CreateOrUpdateSecretRequestV2;
 import keywhiz.api.automation.v2.PartialUpdateSecretRequestV2;
+import keywhiz.api.automation.v2.SecretDetailResponseV2;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.api.model.Secret;
+import keywhiz.api.model.SecretVersion;
 import keywhiz.auth.User;
 import keywhiz.log.AuditLog;
 import keywhiz.log.Event;
@@ -69,6 +72,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -342,6 +346,76 @@ public class SecretsResource {
   }
 
   /**
+   * Retrieve the given range of versions of this secret, sorted from newest to
+   * oldest update time.  If versionIdx is nonzero, then numVersions versions,
+   * starting from versionIdx in the list and increasing in index, will be
+   * returned (set numVersions to a very large number to retrieve all versions).
+   * For instance, versionIdx = 5 and numVersions = 10 will retrieve entries
+   * at indices 5 through 14.
+   *
+   * @excludeParams user
+   * @param name Secret series name
+   * @param versionIdx The index in the list of versions of the first version to retrieve
+   * @param numVersions The number of versions to retrieve
+   * @excludeParams automationClient
+   * @responseMessage 200 Secret series information retrieved
+   * @responseMessage 404 Secret series not found
+   */
+  @Timed @ExceptionMetered
+  @GET
+  @Path("versions/{name}")
+  @Produces(APPLICATION_JSON)
+  public List<SanitizedSecret> secretVersions(@Auth User user,
+      @PathParam("name") String name, @QueryParam("versionIdx") int versionIdx,
+      @QueryParam("numVersions") int numVersions) {
+
+    logger.info("User '{}' listing {} versions starting at index {} for secret '{}'.", user,
+        numVersions, versionIdx, name);
+    
+    ImmutableList<SecretVersion> versions =
+        secretDAO.getSecretVersionsByName(name, versionIdx, numVersions)
+            .orElseThrow(NotFoundException::new);
+
+    return versions.stream()
+        .map(SanitizedSecret::fromSecretVersion)
+        .collect(toList());
+  }
+
+  /**
+   * Rollback to a previous secret version
+   *
+   * @param secretName the name of the secret to rollback
+   * @param versionId the ID of the version to return to
+   * @excludeParams user
+   * @description Returns the previous versions of the secret if found Used by Keywhiz CLI.
+   * @responseMessage 200 Found and reset the secret to this version
+   * @responseMessage 404 Secret with given name not found or invalid version provided
+   */
+  @Path("rollback/{secretName}/{versionId}")
+  @Timed @ExceptionMetered
+  @POST
+  public Response resetSecretVersion(@Auth User user, @PathParam("secretName") String secretName,
+      @PathParam("versionId") LongParam versionId) {
+
+    logger.info("User '{}' rolling back secret '{}' to version with ID '{}'.", user, secretName,
+        versionId);
+
+    secretDAO.setCurrentSecretVersionByName(secretName, versionId.get());
+
+    // If the secret wasn't found or the request was misformed, setCurrentSecretVersionByName
+    // already threw an exception
+    Map<String, String> extraInfo = new HashMap<>();
+    extraInfo.put("new version", versionId.toString());
+    auditLog.recordEvent(
+        new Event(Instant.now(), EventTag.SECRET_CHANGEVERSION, user.getName(), secretName,
+            extraInfo));
+
+    // Send the new secret in response
+    URI uri = UriBuilder.fromResource(SecretsResource.class).path("rollback/{secretName}/{versionID}").build(secretName, versionId);
+    return Response.created(uri).entity(secretDetailResponseFromName(secretName)).build();
+  }
+
+  /**
    * Delete Secret by ID
    *
    * @excludeParams user
@@ -378,6 +452,17 @@ public class SecretsResource {
 
   private SecretDetailResponse secretDetailResponseFromId(long secretId) {
     Optional<Secret> secrets = secretController.getSecretById(secretId);
+    if (!secrets.isPresent()) {
+      throw new NotFoundException("Secret not found.");
+    }
+
+    ImmutableList<Group> groups = ImmutableList.copyOf(aclDAO.getGroupsFor(secrets.get()));
+    ImmutableList<Client> clients = ImmutableList.copyOf(aclDAO.getClientsFor(secrets.get()));
+    return SecretDetailResponse.fromSecret(secrets.get(), groups, clients);
+  }
+
+  private SecretDetailResponse secretDetailResponseFromName(String secretName) {
+    Optional<Secret> secrets = secretController.getSecretByName(secretName);
     if (!secrets.isPresent()) {
       throw new NotFoundException("Secret not found.");
     }

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -446,6 +446,7 @@ public class SecretsResource {
     // Record the deletion
     Map<String, String> extraInfo = new HashMap<>();
     extraInfo.put("groups", groups.toString());
+    extraInfo.put("current version", secret.get().getVersion().toString());
     auditLog.recordEvent(new Event(Instant.now(), EventTag.SECRET_DELETE, user.getName(), secret.get().getName(), extraInfo));
     return Response.noContent().build();
   }

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationSecretResource.java
@@ -241,6 +241,7 @@ public class AutomationSecretResource {
     Map<String, String> extraInfo = new HashMap<>();
     extraInfo.put("deprecated", "true");
     extraInfo.put("groups", groups.toString());
+    extraInfo.put("current version", secret.getVersion().toString());
     auditLog.recordEvent(new Event(Instant.now(), EventTag.SECRET_DELETE, automationClient.getName(), secretName, extraInfo));
 
     return Response.ok().build();

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -611,6 +611,7 @@ public class SecretResource {
     // Record the deletion in the audit log
     Map<String, String> extraInfo = new HashMap<>();
     extraInfo.put("groups", groups.toString());
+    extraInfo.put("current version", secret.getVersion().toString());
     auditLog.recordEvent(new Event(Instant.now(), EventTag.SECRET_DELETE, automationClient.getName(), name, extraInfo));
     return Response.noContent().build();
   }

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -165,7 +165,7 @@ public class AclDAOTest {
 
     aclDAO.allowAccess(jooqContext.configuration(), secret2.getId(), group1.getId());
     Set<SanitizedSecret> secrets = aclDAO.getSanitizedSecretsFor(group1);
-    assertThat(Iterables.getOnlyElement(secrets)).isEqualToIgnoringGivenFields(sanitizedSecret2, "id");
+    assertThat(Iterables.getOnlyElement(secrets)).isEqualToIgnoringGivenFields(sanitizedSecret2, "id", "version");
 
     aclDAO.allowAccess(jooqContext.configuration(), secret1.getId(), group1.getId());
     secrets = aclDAO.getSanitizedSecretsFor(group1);
@@ -173,9 +173,9 @@ public class AclDAOTest {
 
     for (SanitizedSecret secret : secrets) {
       if (secret.name().equals(secret1.getName())) {
-        assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret1, "id");
+        assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret1, "id", "version");
       } else {
-        assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret2, "id");
+        assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret2, "id", "version");
       }
     }
   }
@@ -224,7 +224,7 @@ public class AclDAOTest {
     aclDAO.allowAccess(jooqContext.configuration(), secret2.getId(), group2.getId());
     Set<SanitizedSecret> secrets = aclDAO.getSanitizedSecretsFor(client2);
     assertThat(Iterables.getOnlyElement(secrets))
-        .isEqualToIgnoringGivenFields(SanitizedSecret.fromSecret(secret2), "id");
+        .isEqualToIgnoringGivenFields(SanitizedSecret.fromSecret(secret2), "id", "version");
 
     aclDAO.allowAccess(jooqContext.configuration(), secret1.getId(), group2.getId());
     secrets = aclDAO.getSanitizedSecretsFor(client2);
@@ -232,9 +232,9 @@ public class AclDAOTest {
 
     for (SanitizedSecret secret : secrets) {
       if (secret.name().equals(secret1.getName())) {
-        assertThat(secret).isEqualToIgnoringGivenFields(SanitizedSecret.fromSecret(secret1), "id");
+        assertThat(secret).isEqualToIgnoringGivenFields(SanitizedSecret.fromSecret(secret1), "id", "version");
       } else {
-        assertThat(secret).isEqualToIgnoringGivenFields(SanitizedSecret.fromSecret(secret2), "id");
+        assertThat(secret).isEqualToIgnoringGivenFields(SanitizedSecret.fromSecret(secret2), "id", "version");
       }
     }
 
@@ -310,7 +310,7 @@ public class AclDAOTest {
 
     SanitizedSecret secret = aclDAO.getSanitizedSecretFor(client2, sanitizedSecret1.name())
         .orElseThrow(RuntimeException::new);
-    assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret1, "id");
+    assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret1, "id", "version");
 
     aclDAO.evictClient(jooqContext.configuration(), client2.getId(), group1.getId());
     Optional<SanitizedSecret> missingSecret =
@@ -321,7 +321,7 @@ public class AclDAOTest {
 
     secret = aclDAO.getSanitizedSecretFor(client2, sanitizedSecret1.name())
         .orElseThrow(RuntimeException::new);
-    assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret1, "id");
+    assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret1, "id", "version");
   }
 
   @Test public void getSecretsReturnsDistinct() {

--- a/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import javax.inject.Inject;
 import keywhiz.KeywhizTestRunner;
 import keywhiz.api.ApiDate;
+import keywhiz.api.model.SecretContent;
 import keywhiz.api.model.SecretSeries;
 import keywhiz.service.daos.SecretSeriesDAO.SecretSeriesDAOFactory;
 import org.jooq.DSLContext;

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceIntegrationTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceIntegrationTest.java
@@ -45,7 +45,7 @@ public class SecretDeliveryResourceIntegrationTest {
     client = TestClients.mutualSslClient();
     generalPassword = new Secret(0, "General_Password", null, () -> "YXNkZGFz", "",
         ApiDate.parse("2011-09-29T15:46:00Z"), null,
-        ApiDate.parse("2011-09-29T15:46:00Z"), null, null, "upload", null, 0);
+        ApiDate.parse("2011-09-29T15:46:00Z"), null, null, "upload", null, 0, 1L);
   }
 
   @Test public void returnsSecretWhenAllowed() throws Exception {

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
@@ -48,9 +48,9 @@ public class SecretDeliveryResourceTest {
 
   final Client client = new Client(0, "principal", null, null, null, null, null, null, false, false);
   final Secret secret = new Secret(0, "secret_name", null, () -> "secret_value", "checksum", NOW, null, NOW, null,
-      null, null, null, 0);
+      null, null, null, 0, 1L);
   final Secret secretBase64 = new Secret(1, "Base64With=", null, () -> "SGVsbG8=", "checksum", NOW, null, NOW,
-      null, null, null, null, 0);
+      null, null, null, null, 0, 1L);
 
   @Before public void setUp() {
     secretDeliveryResource = new SecretDeliveryResource(secretController, aclDAO, clientDAO);
@@ -58,7 +58,7 @@ public class SecretDeliveryResourceTest {
 
   @Test public void returnsSecretWhenAllowed() throws Exception {
     Secret secret = new Secret(0, "secret_name", null, () -> "unused_secret", "checksum", NOW, null, NOW, null, null, null,
-        null, 0);
+        null, 0, 1L);
     SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
     String name = sanitizedSecret.name();
 
@@ -74,7 +74,7 @@ public class SecretDeliveryResourceTest {
   @Test public void returnsVersionedSecretWhenAllowed() throws Exception {
     String name = "secret_name";
     Secret versionedSecret = new Secret(2, name, null, () -> "U3BpZGVybWFu", "checksum", NOW, null, NOW,
-        null, null, null, null, 0);
+        null, null, null, null, 0, 1L);
 
     when(aclDAO.getSanitizedSecretFor(client, name))
         .thenReturn(Optional.of(SanitizedSecret.fromSecret(versionedSecret)));

--- a/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceIntegrationTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceIntegrationTest.java
@@ -55,12 +55,12 @@ public class SecretsDeliveryResourceIntegrationTest {
         SanitizedSecret.fromSecret(
             new Secret(0, "General_Password", null, () -> "YXNkZGFz", "checksum",
                 ApiDate.parse("2011-09-29T15:46:00.312Z"), null,
-                ApiDate.parse("2011-09-29T15:46:00.312Z"), null, null, null, null, 0)));
+                ApiDate.parse("2011-09-29T15:46:00.312Z"), null, null, null, null, 0, 1L)));
     databasePassword = SecretDeliveryResponse.fromSanitizedSecret(
         SanitizedSecret.fromSecret(
             new Secret(1, "Database_Password", null, () -> "MTIzNDU=","checksum",
                 ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
-                ApiDate.parse("2011-09-29T15:46:00.232Z"), null, null, null, null, 0)));
+                ApiDate.parse("2011-09-29T15:46:00.232Z"), null, null, null, null, 0, 2L)));
     nobodyPgPassPassword = SecretDeliveryResponse.fromSanitizedSecret(
         SanitizedSecret.fromSecret(
             new Secret(2, "Nobody_PgPass", null,
@@ -68,13 +68,13 @@ public class SecretsDeliveryResourceIntegrationTest {
                 "checksum",
                 ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
                 ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
-                ImmutableMap.of("owner", "nobody", "mode", "0400"), null, null, 0)));
+                ImmutableMap.of("owner", "nobody", "mode", "0400"), null, null, 0, 3L)));
     nonExistentOwnerPass = SecretDeliveryResponse.fromSanitizedSecret(
         SanitizedSecret.fromSecret(
             new Secret(3, "NonexistentOwner_Pass", null, () -> "MTIzNDU=", "checksum",
                 ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
                 ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
-                ImmutableMap.of("owner", "NonExistent", "mode", "0400"), null, null, 0)));
+                ImmutableMap.of("owner", "NonExistent", "mode", "0400"), null, null, 0, 4L)));
   }
 
   @Test

--- a/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceTest.java
@@ -47,11 +47,11 @@ public class SecretsDeliveryResourceTest {
 
   Secret firstSecret = new Secret(0, "first_secret_name", null,
       () -> Base64.getEncoder().encodeToString("first_secret_contents".getBytes(UTF_8)), "checksum", NOW, null, NOW, null, null,
-      null, null, 0);
+      null, null, 0, 1L);
   SanitizedSecret sanitizedFirstSecret = SanitizedSecret.fromSecret(firstSecret);
   Secret secondSecret = new Secret(1, "second_secret_name", null,
       () -> Base64.getEncoder().encodeToString("second_secret_contents".getBytes(UTF_8)), "checksum", NOW, null, NOW, null, null,
-      null, null, 0);
+      null, null, 0, 1L);
   SanitizedSecret sanitizedSecondSecret = SanitizedSecret.fromSecret(secondSecret);
   Client client;
 

--- a/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
@@ -114,7 +114,7 @@ public class ClientsResourceTest {
     Group group1 = new Group(0, "group1", null, null, null, null, null, null);
     Group group2 = new Group(0, "group2", null, null, null, null, null, null);
     Secret secret = new Secret(15, "secret", null, () -> "supersecretdata", "checksum", now, "creator", now,
-        "updater", null, null, null, 0);
+        "updater", null, null, null, 0, 1L);
 
     when(clientDAO.getClientById(1)).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(client)).thenReturn(Sets.newHashSet(group1, group2));

--- a/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
@@ -102,7 +102,7 @@ public class GroupsResourceTest {
     when(groupDAO.getGroupById(4444)).thenReturn(Optional.of(group));
 
     SanitizedSecret secret = SanitizedSecret.of(1, "name", "checksum", null, now, "creator", now, "creator", null, null, null,
-        1136214245);
+        1136214245, 125L);
     when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of(secret));
 
     Client client = new Client(1, "client", "desc", now, "creator", now, "creator", null, true, false);

--- a/server/src/test/java/keywhiz/service/resources/admin/MembershipResourceIntegrationTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/MembershipResourceIntegrationTest.java
@@ -58,7 +58,13 @@ public class MembershipResourceIntegrationTest {
   @Test(expected = KeywhizClient.NotFoundException.class)
   public void allowingMissingSecretInGroup() throws IOException {
     keywhizClient.login(DbSeedCommand.defaultUser, DbSeedCommand.defaultPassword.toCharArray());
-    keywhizClient.grantSecretToGroupByIds(4539475, 237694);
+    keywhizClient.grantSecretToGroupByIds(4539475, 919);
+  }
+
+  @Test(expected = KeywhizClient.NotFoundException.class)
+  public void allowingSecretInMissingGroup() throws IOException {
+    keywhizClient.login(DbSeedCommand.defaultUser, DbSeedCommand.defaultPassword.toCharArray());
+    keywhizClient.grantSecretToGroupByIds(741, 237694);
   }
 
   @Test(expected = KeywhizClient.UnauthorizedException.class)
@@ -83,7 +89,13 @@ public class MembershipResourceIntegrationTest {
   @Test(expected = KeywhizClient.NotFoundException.class)
   public void revokingMissingSecretFromGroup() throws IOException {
     keywhizClient.login(DbSeedCommand.defaultUser, DbSeedCommand.defaultPassword.toCharArray());
-    keywhizClient.revokeSecretFromGroupByIds(4539475, 237694);
+    keywhizClient.revokeSecretFromGroupByIds(4539475, 919);
+  }
+
+  @Test(expected = KeywhizClient.NotFoundException.class)
+  public void revokingSecretInMissingGroup() throws IOException {
+    keywhizClient.login(DbSeedCommand.defaultUser, DbSeedCommand.defaultPassword.toCharArray());
+    keywhizClient.grantSecretToGroupByIds(741, 237694);
   }
 
   @Test public void enrollsClientInGroup() throws IOException {
@@ -97,7 +109,13 @@ public class MembershipResourceIntegrationTest {
   @Test(expected = KeywhizClient.NotFoundException.class)
   public void enrollingMissingClientInGroup() throws IOException {
     keywhizClient.login(DbSeedCommand.defaultUser, DbSeedCommand.defaultPassword.toCharArray());
-    keywhizClient.enrollClientInGroupByIds(4539575, 237694);
+    keywhizClient.enrollClientInGroupByIds(4539575, 919);
+  }
+
+  @Test(expected = KeywhizClient.NotFoundException.class)
+  public void enrollingClientInMissingGroup() throws IOException {
+    keywhizClient.login(DbSeedCommand.defaultUser, DbSeedCommand.defaultPassword.toCharArray());
+    keywhizClient.enrollClientInGroupByIds(770, 237694);
   }
 
   @Test public void evictsClientFromGroup() throws IOException {
@@ -111,7 +129,12 @@ public class MembershipResourceIntegrationTest {
   @Test(expected = KeywhizClient.NotFoundException.class)
   public void evictingMissingClientFromGroup() throws IOException {
     keywhizClient.login(DbSeedCommand.defaultUser, DbSeedCommand.defaultPassword.toCharArray());
+    keywhizClient.evictClientFromGroupByIds(4539475, 919);
+  }
 
-    keywhizClient.evictClientFromGroupByIds(4539475, 237694);
+  @Test(expected = KeywhizClient.NotFoundException.class)
+  public void evictingClientFromMissingGroup() throws IOException {
+    keywhizClient.login(DbSeedCommand.defaultUser, DbSeedCommand.defaultPassword.toCharArray());
+    keywhizClient.enrollClientInGroupByIds(770, 237694);
   }
 }

--- a/server/src/test/java/keywhiz/service/resources/admin/MembershipResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/MembershipResourceTest.java
@@ -48,7 +48,7 @@ public class MembershipResourceTest {
   User user = User.named("user");
   Client client = new Client(44, "client", "desc", NOW, "creator", NOW, "updater", null, true, false);
   Group group = new Group(55, "group", null, null, null, null, null, null);
-  Secret secret = new Secret(66, "secret", null, () -> "shush", "checksum", NOW, null, NOW, null, null, null, null, 0);
+  Secret secret = new Secret(66, "secret", null, () -> "shush", "checksum", NOW, null, NOW, null, null, null, null, 0, 1L);
   AuditLog auditLog = new SimpleLogger();
 
   MembershipResource resource;

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -74,7 +74,7 @@ public class SecretsResourceTest {
   ImmutableMap<String, String> emptyMap = ImmutableMap.of();
 
   Secret secret = new Secret(22, "name", "desc", () -> "secret", "checksum", NOW, "creator", NOW,
-      "updater", emptyMap, null, null, 1136214245);
+      "updater", emptyMap, null, null, 1136214245, 1L);
 
   AuditLog auditLog = new SimpleLogger();
 
@@ -88,9 +88,9 @@ public class SecretsResourceTest {
   @Test
   public void listSecrets() {
     SanitizedSecret secret1 = SanitizedSecret.of(1, "name1", "checksum", "desc", NOW, "user", NOW, "user",
-        emptyMap, null, null, 1136214245);
+        emptyMap, null, null, 1136214245, 125L);
     SanitizedSecret secret2 = SanitizedSecret.of(2, "name2", "checksum", "desc", NOW, "user", NOW, "user",
-        emptyMap, null, null, 1136214245);
+        emptyMap, null, null, 1136214245, 250L);
     when(secretController.getSanitizedSecrets(null, null)).thenReturn(ImmutableList.of(secret1, secret2));
 
     List<SanitizedSecret> response = resource.listSecrets(user);
@@ -100,9 +100,9 @@ public class SecretsResourceTest {
   @Test
   public void listSecretsBatched() {
     SanitizedSecret secret1 = SanitizedSecret.of(1, "name1", "desc", "checksum", NOW, "user", NOW, "user",
-        emptyMap, null, null, 1136214245);
+        emptyMap, null, null, 1136214245, 125L);
     SanitizedSecret secret2 = SanitizedSecret.of(2, "name2", "desc", "checksum", NOWPLUS, "user", NOWPLUS, "user",
-        emptyMap, null, null, 1136214245);
+        emptyMap, null, null, 1136214245, 250L);
     when(secretController.getSecretsBatched(0, 1, false)).thenReturn(ImmutableList.of(secret1));
     when(secretController.getSecretsBatched(0, 1, true)).thenReturn(ImmutableList.of(secret2));
     when(secretController.getSecretsBatched(1, 1, false)).thenReturn(ImmutableList.of(secret2));

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -37,13 +37,16 @@ import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.api.model.Secret;
+import keywhiz.api.model.SecretVersion;
 import keywhiz.auth.User;
+import keywhiz.client.KeywhizClient;
 import keywhiz.log.AuditLog;
 import keywhiz.log.SimpleLogger;
 import keywhiz.service.daos.AclDAO;
 import keywhiz.service.daos.SecretController;
 import keywhiz.service.daos.SecretDAO;
 import keywhiz.service.exceptions.ConflictException;
+import org.apache.http.HttpStatus;
 import org.jooq.exception.DataAccessException;
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,6 +57,8 @@ import org.mockito.junit.MockitoRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -165,7 +170,15 @@ public class SecretsResourceTest {
 
     PartialUpdateSecretRequestV2 req = PartialUpdateSecretRequestV2.builder()
         .description(secret.getDescription())
+        .descriptionPresent(true)
+        .metadata(ImmutableMap.of("owner", "keywhizAdmin"))
+        .metadataPresent(true)
+        .expiry(1487268151L)
+        .expiryPresent(true)
+        .type("test")
+        .typePresent(true)
         .content(secret.getSecret())
+        .contentPresent(true)
         .build();
 
     when(secretDAO.partialUpdateSecret(eq(secret.getName()), any(), eq(req))).thenReturn(
@@ -178,6 +191,61 @@ public class SecretsResourceTest {
         .containsExactly(new URI("/admin/secrets/" + secret.getName() + "/partialupdate"));
   }
 
+  @Test
+  public void listSecretVersions() {
+    SanitizedSecret secret1 = SanitizedSecret.of(1, "name1", "checksum", "desc", NOW, "user",
+        NOW, "user", emptyMap, null, null, 1136214245, 125L);
+    SanitizedSecret secret2 = SanitizedSecret.of(1, "name1", "checksum2", "desc", NOWPLUS, "user",
+        NOWPLUS, "user", emptyMap, null, null, 1136214245, 250L);
+
+    SecretVersion version1 = SecretVersion.of(1, 125L, "name1", "desc", "checksum", NOW, "user",
+        NOW, "user", emptyMap, null, 1136214245);
+    SecretVersion version2 = SecretVersion.of(1, 250L, "name1", "desc", "checksum2", NOWPLUS,
+        "user", NOWPLUS, "user", emptyMap, null, 1136214245);
+
+    when(secretDAO.getSecretVersionsByName("name1", 0, 10)).thenReturn(
+        Optional.of(ImmutableList.of(version2, version1)));
+    when(secretDAO.getSecretVersionsByName("name1", 1, 5)).thenReturn(
+        Optional.of(ImmutableList.of(version1)));
+    when(secretDAO.getSecretVersionsByName("name1", 2, 10)).thenReturn(
+        Optional.of(ImmutableList.of()));
+
+    List<SanitizedSecret> response = resource.secretVersions(user, "name1", 0, 10);
+    assertThat(response).containsExactly(secret2, secret1);
+
+    response = resource.secretVersions(user, "name1", 1, 5);
+    assertThat(response).containsExactly(secret1);
+
+    response = resource.secretVersions(user, "name1", 2, 10);
+    assertThat(response).isEmpty();
+  }
+
+  @Test (expected = NotFoundException.class)
+  public void listSecretVersionsThrowsException() {
+    when(secretDAO.getSecretVersionsByName(eq("name2"), anyInt(), anyInt())).thenReturn(
+        Optional.empty());
+    resource.secretVersions(user, "name2", 0, 10);
+  }
+
+  @Test
+  public void rollbackSuccess() {
+    Secret secret1 = new Secret(1, "name1", "desc", () -> "secret",
+        "checksum", NOW, "user", NOW, "user", emptyMap, null,
+        null, 1136214245, 125L);
+
+    when(secretController.getSecretByName("name1")).thenReturn(Optional.of(secret1));
+
+    Response response = resource.resetSecretVersion(user, "name1", new LongParam("125"));
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CREATED);
+  }
+
+  @Test (expected = NotFoundException.class)
+  public void rollbackThrowsException() {
+    doThrow(new NotFoundException()).when(secretDAO)
+        .setCurrentSecretVersionByName(eq("name2"), anyLong());
+    resource.resetSecretVersion(user, "name2", new LongParam("125"));
+  }
+
   @Test public void canDelete() {
     when(secretController.getSecretById(0xdeadbeef)).thenReturn(Optional.of(secret));
     HashSet<Group> groups = new HashSet<>();
@@ -188,6 +256,12 @@ public class SecretsResourceTest {
     Response response = resource.deleteSecret(user, new LongParam(Long.toString(0xdeadbeef)));
     verify(secretDAO).deleteSecretsByName("name");
     assertThat(response.getStatus()).isEqualTo(204);
+  }
+
+  @Test (expected = NotFoundException.class)
+  public void deleteErrorsOnNotFound() {
+    when(secretController.getSecretById(0xdeadbeef)).thenReturn(Optional.empty());
+    resource.deleteSecret(user, new LongParam(Long.toString(0xdeadbeef)));
   }
 
   @Test(expected = ConflictException.class)

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationGroupResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationGroupResourceTest.java
@@ -91,9 +91,9 @@ public class AutomationGroupResourceTest {
     Client groupClient =
         new Client(1, "firstClient", "Group client", now, "test", now, "test", null, true, true);
     SanitizedSecret firstGroupSecret =
-        SanitizedSecret.of(1, "name1", "checksum", "desc", now, "test", now, "test", null, "", null, 1136214245);
+        SanitizedSecret.of(1, "name1", "checksum", "desc", now, "test", now, "test", null, "", null, 1136214245, 125L);
     SanitizedSecret secondGroupSecret =
-        SanitizedSecret.of(2, "name2", "checksum", "desc", now, "test", now, "test", null, "", null, 1136214245);
+        SanitizedSecret.of(2, "name2", "checksum", "desc", now, "test", now, "test", null, "", null, 1136214245, 250L);
 
     when(groupDAO.getGroup("testGroup")).thenReturn(Optional.of(group));
     when(aclDAO.getClientsFor(group)).thenReturn(ImmutableSet.of(groupClient));

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationSecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationSecretResourceTest.java
@@ -94,7 +94,8 @@ public class AutomationSecretResourceTest {
         request.metadata,
         null,
         null,
-        0);
+        0,
+        1L);
 
     when(secretBuilder.create()).thenReturn(secret);
 
@@ -111,7 +112,7 @@ public class AutomationSecretResourceTest {
   @Test
   public void deleteSecret() throws Exception {
     Secret secret = new Secret(0, "mySecret", null, (Secret.LazyString) () -> "meh",
-        "checksum", NOW, null, NOW, null, ImmutableMap.of(), null, null, 0);
+        "checksum", NOW, null, NOW, null, ImmutableMap.of(), null, null, 0, 1L);
 
     HashSet<Group> groups = new HashSet<>();
     groups.add(new Group(0, "group1", "", NOW, null, NOW, null, null));


### PR DESCRIPTION
This PR adds the ability to list versions of a secret and to reset a secret to an older version through keywhiz-cli.  It also updates some of the secret models to contain more information (so that the version listing can display more information) and logs the current version when a secret is deleted, so that one can manually un-delete a secret by modifying the database and restore the correct version.

<img width="693" alt="screen shot 2017-02-15 at 6 02 48 pm" src="https://cloud.githubusercontent.com/assets/13395970/23004110/b10516e4-f3a9-11e6-880c-d14c5cfbd72c.png">
