### PR TITLE
Fix audit logging on ACL changes

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -119,7 +119,7 @@ public class AclDAO {
 
       extraInfo.put("group", group.get().getName());
       extraInfo.put("secret added", secret.get().name());
-      auditLog.recordEvent(new Event(Instant.now(), EventTag.CHANGEACL_GROUP_SECRET, group.get().getName(), user, extraInfo));
+      auditLog.recordEvent(new Event(Instant.now(), EventTag.CHANGEACL_GROUP_SECRET, user, group.get().getName(), extraInfo));
     });
   }
 
@@ -146,7 +146,7 @@ public class AclDAO {
 
       extraInfo.put("group", group.get().getName());
       extraInfo.put("secret removed", secret.get().name());
-      auditLog.recordEvent(new Event(Instant.now(), EventTag.CHANGEACL_GROUP_SECRET, group.get().getName(), user, extraInfo));
+      auditLog.recordEvent(new Event(Instant.now(), EventTag.CHANGEACL_GROUP_SECRET, user, group.get().getName(), extraInfo));
     });
   }
 
@@ -173,7 +173,7 @@ public class AclDAO {
 
       extraInfo.put("group", group.get().getName());
       extraInfo.put("client added", client.get().getName());
-      auditLog.recordEvent(new Event(Instant.now(), EventTag.CHANGEACL_GROUP_CLIENT, group.get().getName(), user, extraInfo));
+      auditLog.recordEvent(new Event(Instant.now(), EventTag.CHANGEACL_GROUP_CLIENT, user, group.get().getName(), extraInfo));
     });
   }
 
@@ -200,7 +200,7 @@ public class AclDAO {
 
       extraInfo.put("group", group.get().getName());
       extraInfo.put("client removed", client.get().getName());
-      auditLog.recordEvent(new Event(Instant.now(), EventTag.CHANGEACL_GROUP_CLIENT, group.get().getName(), user, extraInfo));
+      auditLog.recordEvent(new Event(Instant.now(), EventTag.CHANGEACL_GROUP_CLIENT, user, group.get().getName(), extraInfo));
     });
   }
 


### PR DESCRIPTION
Events record the user (an automation client or an admin user) who triggered a change, the object (secret/group/client) affected, and optionally additional information.  The user and object-affected arguments were reversed for ACL changes (although the affected group was correctly recorded in the additional-information map).