### PR TITLE
Remove ambiguity in path for secret contents request

### DIFF
--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -496,7 +496,7 @@ public class SecretResource {
    */
   @Timed @ExceptionMetered
   @POST
-  @Path("contents")
+  @Path("request/contents")
   @Produces(APPLICATION_JSON)
   public SecretContentsResponseV2 secretContents(@Auth AutomationClient automationClient,
       @Valid SecretContentsRequestV2 request) {

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -895,7 +895,7 @@ public class SecretResourceTest {
 
   SecretContentsResponseV2 contents(SecretContentsRequestV2  request) throws IOException {
     RequestBody body = RequestBody.create(JSON, mapper.writeValueAsString(request));
-    Request get = clientRequest("/automation/v2/secrets/contents").post(body).build();
+    Request get = clientRequest("/automation/v2/secrets/request/contents").post(body).build();
     Response httpResponse = mutualSslClient.newCall(get).execute();
     assertThat(httpResponse.code()).isEqualTo(200);
     return mapper.readValue(httpResponse.body().byteStream(), SecretContentsResponseV2.class);


### PR DESCRIPTION
The secrets contents request path (POST /automation/v2/secrets/contents) was indistinguishable from a request to create a secret named "contents" (POST /automation/v2/secrets/contents).  This makes the path unique. 