### PR TITLE
Fixing units test for secret version

### DIFF
--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -76,7 +76,7 @@ public abstract class SanitizedSecret {
         series.type().orElse(null),
         series.generationOptions(),
         content.expiry(),
-        series.currentVersion().orElse(null));
+        content.id());
   }
 
   /**

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -33,6 +33,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -654,13 +655,13 @@ public class SecretResourceTest {
 
     // Get the current version (the last version created)
     initialCurrentVersion = lookup(name);
-    assertThat(initialCurrentVersion.name().equals(name));
+    assertThat(initialCurrentVersion.name()).isEqualTo(name);
     assertThat(
-        initialCurrentVersion.description().equals(format("%s, version %d", name, totalVersions)));
+        initialCurrentVersion.description()).isEqualTo(format("%s, version %d", name, totalVersions - 1));
 
     // Get the earliest version of this secret
-    versions = listVersions(name, totalVersions - 2, 1);
-    assertThat(!versions.get(0).equals(initialCurrentVersion));
+    versions = listVersions(name, totalVersions - 3, 1);
+    assertThat(versions.get(0)).isNotEqualTo(initialCurrentVersion);
 
     // Reset the current version to this version
     setCurrentVersion(
@@ -668,8 +669,8 @@ public class SecretResourceTest {
 
     // Get the current version
     finalCurrentVersion = lookup(name);
-    assertThat(finalCurrentVersion.equals(versions.get(0)));
-    assertThat(!finalCurrentVersion.equals(initialCurrentVersion));
+    assertThat(finalCurrentVersion).isEqualToIgnoringGivenFields(versions.get(0), "updatedAtSeconds");
+    assertThat(finalCurrentVersion).isNotEqualTo(initialCurrentVersion);
   }
 
   @Test public void secretChangeVersion_invalidVersion() throws Exception {


### PR DESCRIPTION
Hey,

I am not sure the unit test _secretChangeVersion_success_  is totally correct. It seems that some assertions are not testing the expressions but instead just create a BooleanAssert object without testing the expected value. I believe it may also hides a bug in the list secret versions automation endpoint.

The first assertion L659 needs to be update as the latest version is not _totalVersions_ (6) but _totalVersions - 1_ (5) as the version # starts at 0.

The two others (L671, L672) need to be updated because:
- List secrets versions endpoint returns the same versions for all secrets (the current version) as it uses _SanitizedSecrets.fromSecretSeriesAndContent_ to build its list of object and this method uses the current secrets version for all objects instead of the secret content id (being the version) (SanitizedSecret.java L79), therefor all the secret versions will have the same value (the current version).
- When you update the secret version, the _updatedAt_ value of the secret will be updated to use the secret's content _updatedAt_ value meaning that, when testing equality with the previously retrieved object, you need to take this update into account.

Thanks,