### PR TITLE
Fix --keystore flag in gen-aes command

### DIFF
--- a/server/src/main/java/keywhiz/commands/GenerateAesKeyCommand.java
+++ b/server/src/main/java/keywhiz/commands/GenerateAesKeyCommand.java
@@ -43,8 +43,8 @@ public class GenerateAesKeyCommand extends Command {
   @Override public void configure(Subparser parser) {
     parser.addArgument("--keystore")
         .dest("keystore")
-        .type(Path.class)
-        .setDefault(Paths.get("derivation.jceks"))
+        .type(String.class)
+        .setDefault("derivation.jceks")
         .help("keystore file name");
 
     parser.addArgument("--storepass")
@@ -68,7 +68,7 @@ public class GenerateAesKeyCommand extends Command {
 
   @Override public void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
     char[] password = namespace.getString("storepass").toCharArray();
-    Path destination = namespace.get("keystore");
+    Path destination = Paths.get(namespace.get("keystore"));
     int keySize = namespace.getInt("keysize");
     String alias = namespace.getString("alias");
 


### PR DESCRIPTION
Can't use `java.nio.file.Path` for arg type, it doesn't have a string constructor. 