### PR TITLE
Fix behavior when secret is created, deleted, and recreated

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -86,9 +86,10 @@ public class SecretDAO {
         SecretSeries secretSeries1 = secretSeries.get();
         if (secretSeries1.currentVersion().isPresent()) {
           throw new DataAccessException(format("secret already present: %s", name));
+        } else {
+          // Unreachable unless the implementation of getSecretSeriesByName is changed
+          throw new IllegalStateException(format("secret %s retrieved without current version set", name));
         }
-        secretId = secretSeries1.id();
-        secretSeriesDAO.updateSecretSeries(secretId, name, creator, description, type, generationOptions);
       } else {
         secretId = secretSeriesDAO.createSecretSeries(name, creator, description, type,
             generationOptions);

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -163,12 +163,12 @@ public class SecretSeriesDAO {
   }
 
   public Optional<SecretSeries> getSecretSeriesById(long id) {
-    SecretsRecord r = dslContext.fetchOne(SECRETS, SECRETS.ID.eq(id));
+    SecretsRecord r = dslContext.fetchOne(SECRETS, SECRETS.ID.eq(id).and(SECRETS.CURRENT.isNotNull()));
     return Optional.ofNullable(r).map(secretSeriesMapper::map);
   }
 
   public Optional<SecretSeries> getSecretSeriesByName(String name) {
-    SecretsRecord r = dslContext.fetchOne(SECRETS, SECRETS.NAME.eq(name));
+    SecretsRecord r = dslContext.fetchOne(SECRETS, SECRETS.NAME.eq(name).and(SECRETS.CURRENT.isNotNull()));
     return Optional.ofNullable(r).map(secretSeriesMapper::map);
   }
 
@@ -215,7 +215,7 @@ public class SecretSeriesDAO {
   public void deleteSecretSeriesByName(String name) {
     long now = OffsetDateTime.now().toEpochSecond();
     dslContext.transaction(configuration -> {
-      SecretsRecord r = DSL.using(configuration).fetchOne(SECRETS, SECRETS.NAME.eq(name));
+      SecretsRecord r = DSL.using(configuration).fetchOne(SECRETS, SECRETS.NAME.eq(name).and(SECRETS.CURRENT.isNotNull()));
       if (r != null) {
         DSL.using(configuration)
             .update(SECRETS)

--- a/server/src/main/resources/db/h2/migration/V6__drop_unique_constraint_on_secret_name.sql
+++ b/server/src/main/resources/db/h2/migration/V6__drop_unique_constraint_on_secret_name.sql
@@ -1,0 +1,3 @@
+ALTER TABLE secrets DROP INDEX secrets_name_idx;  /* from V2.2 */
+CREATE INDEX secrets_name_idx ON secrets (name);
+CREATE UNIQUE INDEX name_id_idx ON secrets (id, name);

--- a/server/src/main/resources/db/mysql/migration/V6__drop_unique_constraint_on_secret_name.sql
+++ b/server/src/main/resources/db/mysql/migration/V6__drop_unique_constraint_on_secret_name.sql
@@ -1,0 +1,3 @@
+DROP INDEX name ON secrets;
+CREATE INDEX name ON secrets (name);
+CREATE UNIQUE INDEX name_id_idx ON secrets (id, name);

--- a/server/src/main/resources/db/postgres/migration/V6__drop_unique_constraint_on_secret_name.sql
+++ b/server/src/main/resources/db/postgres/migration/V6__drop_unique_constraint_on_secret_name.sql
@@ -1,0 +1,3 @@
+DROP INDEX name ON secrets;
+CREATE INDEX name ON secrets (name);
+CREATE UNIQUE INDEX name_id_idx ON secrets (id, name);

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -207,10 +207,10 @@ public class SecretDAOTest {
 
     long secondId = secretDAO.createSecret(name, "content2", cryptographer.computeHmac("content2".getBytes(UTF_8)), "creator2",
         ImmutableMap.of("foo2", "bar2"), 2000, "description2", "type2", ImmutableMap.of());
-    assertThat(secondId).isEqualTo(firstId);
+    assertThat(secondId).isGreaterThan(firstId);
 
-    SecretSeriesAndContent newSecret = secretDAO.getSecretById(firstId).get();
-    assertThat(newSecret.series().createdBy()).isEqualTo("creator1");
+    SecretSeriesAndContent newSecret = secretDAO.getSecretById(secondId).get();
+    assertThat(newSecret.series().createdBy()).isEqualTo("creator2");
     assertThat(newSecret.series().updatedBy()).isEqualTo("creator2");
     assertThat(newSecret.series().description()).isEqualTo("description2");
     assertThat(newSecret.series().type().get()).isEqualTo("type2");


### PR DESCRIPTION
See https://github.com/square/keywhiz/issues/317.  The current implementation of secret creation reuses database IDs for secrets which have the same name as a deleted secret.  This saves space in the database if secrets with the same name are deliberately deleted and recreated; however, it makes it impossible to distinguish which versions of a secret belong to the current secret and which versions belong to the deleted secret.  This PR removes the constraint that secret names in the database must be unique, replacing it with a code-enforced constraint that only one secret series with a given name can have currentVersion set.  The list of secret versions now displays only the versions associated with the current created secret. 