### PR TITLE
Update SanitizedSecret to use content for update time

### DIFF
--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -63,6 +63,9 @@ public abstract class SanitizedSecret {
   public static SanitizedSecret fromSecretSeriesAndContent(SecretSeriesAndContent seriesAndContent) {
     SecretSeries series = seriesAndContent.series();
     SecretContent content = seriesAndContent.content();
+    // Use the series' creation information, but the content's update information; if this is
+    // the current content, series and content update information matches, and otherwise, this
+    // preserves the content's update data (which can also be used as its creation data).
     return SanitizedSecret.of(
         series.id(),
         series.name(),
@@ -70,8 +73,8 @@ public abstract class SanitizedSecret {
         content.hmac(),
         series.createdAt(),
         series.createdBy(),
-        series.updatedAt(),
-        series.updatedBy(),
+        content.updatedAt(),
+        content.updatedBy(),
         content.metadata(),
         series.type().orElse(null),
         series.generationOptions(),

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -738,9 +738,10 @@ public class SecretResourceTest {
     assertThat(versions.size()).isEqualTo(expectedVersions);
 
     for (SecretDetailResponseV2 version : versions) {
-      // Check creation ordering
-      assertThat(version.createdAtSeconds()).isLessThanOrEqualTo(creationTime);
-      creationTime = version.createdAtSeconds();
+      // Check creation ordering (createdAtSeconds is from the secret series; updatedAtSeconds
+      // is from the content and matches when this version was created)
+      assertThat(version.updatedAtSeconds()).isLessThan(creationTime);
+      creationTime = version.updatedAtSeconds();
 
       // Check version number
       assertThat(version.metadata()).isEqualTo(


### PR DESCRIPTION
When SanitizedSecret is used to represent a secret version, it is constructed from a secret series and a secret content record.  Originally, the SanitizedSecret's creation and update times were taken from the secret series; however, this loses information on when the version was created.  This commit keeps the SanitizedSecret's creation date set to the series' creation date, but changes its update time to match the current content record's update time.  If the content is the secret's current version, this does not change SanitizedSecret's behavior; however, if the content is a past version the SanitizedSecret's update time reflects when that version was last updated/created (since creation and update are always identical for a secret content record).