### PR TITLE
Fix existing expiry construction in expiration backfiller code

### DIFF
--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -358,7 +358,7 @@ public class SecretResource {
     Secret secret = secretOptional.get();
     Optional<Instant> existingExpiry = Optional.empty();
     if (secret.getExpiry() > 0) {
-      existingExpiry = Optional.of(Instant.ofEpochMilli(secret.getExpiry()));
+      existingExpiry = Optional.of(Instant.ofEpochMilli(secret.getExpiry()*1000));
     }
 
     String secretName = secret.getName();


### PR DESCRIPTION
Fix existing expiry construction in expiration backfiller code. Value from database is in seconds, not milliseconds. 