### PR TITLE
Print the content HMAC when describing a secret through the cli

### DIFF
--- a/cli/src/main/java/keywhiz/cli/Printing.java
+++ b/cli/src/main/java/keywhiz/cli/Printing.java
@@ -144,6 +144,13 @@ public class Printing {
         .sorted(Comparator.comparing(Client::getName))
         .forEach(c -> System.out.println(INDENT + c.getName()));
 
+    System.out.println("\tContent HMAC:");
+    if (secret.checksum().isEmpty()) {
+      System.out.println(INDENT + "WARNING: Content HMAC not calculated!");
+    } else {
+      System.out.println(INDENT + secret.checksum());
+    }
+
     System.out.println("\tMetadata:");
     if (!secret.metadata().isEmpty()) {
       String metadata;


### PR DESCRIPTION
This may be useful for debugging, such as checking whether two secrets have the same contents or verifying that an update altered secret contents.