### PR TITLE
Revert "Update SanitizedSecret to use content for update time"

### DIFF
--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -63,9 +63,6 @@ public abstract class SanitizedSecret {
   public static SanitizedSecret fromSecretSeriesAndContent(SecretSeriesAndContent seriesAndContent) {
     SecretSeries series = seriesAndContent.series();
     SecretContent content = seriesAndContent.content();
-    // Use the series' creation information, but the content's update information; if this is
-    // the current content, series and content update information matches, and otherwise, this
-    // preserves the content's update data (which can also be used as its creation data).
     return SanitizedSecret.of(
         series.id(),
         series.name(),
@@ -73,8 +70,8 @@ public abstract class SanitizedSecret {
         content.hmac(),
         series.createdAt(),
         series.createdBy(),
-        content.updatedAt(),
-        content.updatedBy(),
+        series.updatedAt(),
+        series.updatedBy(),
         content.metadata(),
         series.type().orElse(null),
         series.generationOptions(),

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -738,10 +738,9 @@ public class SecretResourceTest {
     assertThat(versions.size()).isEqualTo(expectedVersions);
 
     for (SecretDetailResponseV2 version : versions) {
-      // Check creation ordering (createdAtSeconds is from the secret series; updatedAtSeconds
-      // is from the content and matches when this version was created)
-      assertThat(version.updatedAtSeconds()).isLessThan(creationTime);
-      creationTime = version.updatedAtSeconds();
+      // Check creation ordering
+      assertThat(version.createdAtSeconds()).isLessThanOrEqualTo(creationTime);
+      creationTime = version.createdAtSeconds();
 
       // Check version number
       assertThat(version.metadata()).isEqualTo(


### PR DESCRIPTION
This reverts commit 57bd122a22f703d65ebbc418cf97460ce13a827c.
The change in that commit meant that SanitizedSecrets created
directly from SecretSeriesAndContent objects would have different
update information than SanitizedSecrets created from Secrets
created from those SecretSeriesAndContent objects by way of a
SecretTransformer.  This caused errors in the Keywhiz admin
client when unassigning secrets; the client retrieves a
SanitizedSecret from Keywhiz, retrieves a list of SanitizedSecrets
associated with a group, and compares them before completing
the unassignment.  Because of the mismatched update information,
secrets being unassigned from a group would "not appear" in the
list of secrets associated with it, causing an error.  When a
secret has been rolled back to a previous version of its contents,
or if the update times for the secret table and secret_contents
table disagree for other reasons, this problem would occur.

A later commit will add a "contentCreatedAt" and "contentCreatedBy"
field to SanitizedSecret so that SanitizedSecret can still be used
to represent versions of secrets.  However, createdAt/createdBy and
updatedAt/updatedBy will always refer to the secret as a whole,
not its contents.