### PR TITLE
Synchronize timestamps for secret creation and updates.

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
@@ -61,7 +61,7 @@ class SecretContentDAO {
   }
 
   public long createSecretContent(long secretId, String encryptedContent, String hmac,
-      String creator, Map<String, String> metadata, long expiry) {
+      String creator, Map<String, String> metadata, long expiry, long now) {
     SecretsContentRecord r = dslContext.newRecord(SECRETS_CONTENT);
 
     String jsonMetadata;
@@ -71,8 +71,6 @@ class SecretContentDAO {
       // Serialization of a Map<String, String> can never fail.
       throw Throwables.propagate(e);
     }
-
-    long now = OffsetDateTime.now().toEpochSecond();
 
     r.setSecretid(secretId);
     r.setEncryptedContent(encryptedContent);

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -100,7 +100,7 @@ public class SecretDAO {
 
       long secretContentId = secretContentDAO.createSecretContent(secretId, encryptedSecret, hmac,
           creator, metadata, expiry, now);
-      secretSeriesDAO.setCurrentVersion(secretId, secretContentId);
+      secretSeriesDAO.setCurrentVersion(secretId, secretContentId, creator, now);
 
       return secretId;
     });
@@ -130,7 +130,7 @@ public class SecretDAO {
 
       long secretContentId = secretContentDAO.createSecretContent(secretId, encryptedSecret, hmac,
           creator, metadata, expiry, now);
-      secretSeriesDAO.setCurrentVersion(secretId, secretContentId);
+      secretSeriesDAO.setCurrentVersion(secretId, secretContentId, creator, now);
 
       return secretId;
     });
@@ -173,7 +173,7 @@ public class SecretDAO {
 
       long secretContentId = secretContentDAO.createSecretContent(secretId, encryptedContent, hmac,
           creator, metadata, expiry, now);
-      secretSeriesDAO.setCurrentVersion(secretId, secretContentId);
+      secretSeriesDAO.setCurrentVersion(secretId, secretContentId, creator, now);
 
       return secretId;
     });
@@ -310,8 +310,7 @@ public class SecretDAO {
    * @return Versions of a secret matching input parameters or Optional.absent().
    */
   public Optional<ImmutableList<SanitizedSecret>> getSecretVersionsByName(String name,
-      int versionIdx,
-      int numVersions) {
+      int versionIdx, int numVersions) {
     checkArgument(!name.isEmpty());
     checkArgument(versionIdx >= 0);
     checkArgument(numVersions >= 0);
@@ -344,14 +343,15 @@ public class SecretDAO {
    * @param versionId The identifier for the desired current version
    * @throws NotFoundException if secret not found
    */
-  public void setCurrentSecretVersionByName(String name, long versionId) {
+  public void setCurrentSecretVersionByName(String name, long versionId, String updater) {
     checkArgument(!name.isEmpty());
     checkArgument(versionId >= 0);
 
     SecretSeriesDAO secretSeriesDAO = secretSeriesDAOFactory.using(dslContext.configuration());
     SecretSeries series = secretSeriesDAO.getSecretSeriesByName(name).orElseThrow(
         NotFoundException::new);
-    secretSeriesDAO.setCurrentVersion(series.id(), versionId);
+    secretSeriesDAO.setCurrentVersion(series.id(), versionId, updater,
+        OffsetDateTime.now().toEpochSecond());
   }
 
 

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -131,9 +131,8 @@ public class SecretSeriesDAO {
         .execute();
   }
 
-  public int setCurrentVersion(long secretId, long secretContentId) {
+  public int setCurrentVersion(long secretId, long secretContentId, String updater, long now) {
     long checkId;
-    long now = OffsetDateTime.now().toEpochSecond();
     Record1<Long> r = dslContext.select(SECRETS_CONTENT.SECRETID)
         .from(SECRETS_CONTENT)
         .where(SECRETS_CONTENT.ID.eq(secretContentId))
@@ -153,6 +152,7 @@ public class SecretSeriesDAO {
 
     return dslContext.update(SECRETS)
         .set(SECRETS.CURRENT, secretContentId)
+        .set(SECRETS.UPDATEDBY, updater)
         .set(SECRETS.UPDATEDAT, now)
         .where(SECRETS.ID.eq(secretId))
         .execute();

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -66,10 +66,8 @@ public class SecretSeriesDAO {
   }
 
   long createSecretSeries(String name, String creator, String description, @Nullable String type,
-      @Nullable Map<String, String> generationOptions) {
+      @Nullable Map<String, String> generationOptions, long now) {
     SecretsRecord r = dslContext.newRecord(SECRETS);
-
-    long now = OffsetDateTime.now().toEpochSecond();
 
     r.setName(name);
     r.setDescription(description);
@@ -94,9 +92,7 @@ public class SecretSeriesDAO {
   }
 
   void updateSecretSeries(long secretId, String name, String creator, String description,
-      @Nullable String type,
-      @Nullable Map<String, String> generationOptions) {
-    long now = OffsetDateTime.now().toEpochSecond();
+      @Nullable String type, @Nullable Map<String, String> generationOptions, long now) {
     if (generationOptions == null) {
       generationOptions = ImmutableMap.of();
     }

--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -400,7 +400,7 @@ public class SecretsResource {
     logger.info("User '{}' rolling back secret '{}' to version with ID '{}'.", user, secretName,
         versionId);
 
-    secretDAOReadWrite.setCurrentSecretVersionByName(secretName, versionId.get());
+    secretDAOReadWrite.setCurrentSecretVersionByName(secretName, versionId.get(), user.getName());
 
     // If the secret wasn't found or the request was misformed, setCurrentSecretVersionByName
     // already threw an exception

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -575,13 +575,15 @@ public class SecretResource {
   @POST
   public Response resetSecretVersion(@Auth AutomationClient automationClient,
       @Valid SetSecretVersionRequestV2 request) {
-    secretDAO.setCurrentSecretVersionByName(request.name(), request.version());
+    secretDAO.setCurrentSecretVersionByName(request.name(), request.version(),
+        automationClient.getName());
 
     // If the secret wasn't found or the request was misformed, setCurrentSecretVersionByName
     // already threw an exception
     Map<String, String> extraInfo = new HashMap<>();
     extraInfo.put("new version", Long.toString(request.version()));
-    auditLog.recordEvent(new Event(Instant.now(), EventTag.SECRET_CHANGEVERSION, automationClient.getName(), request.name(), extraInfo));
+    auditLog.recordEvent(new Event(Instant.now(), EventTag.SECRET_CHANGEVERSION,
+        automationClient.getName(), request.name(), extraInfo));
 
     return Response.status(Response.Status.CREATED).build();
   }

--- a/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
@@ -73,7 +73,7 @@ public class SecretContentDAOTest {
   @Test public void createSecretContent() {
     int before = tableSize();
     secretContentDAO.createSecretContent(secretContent1.secretSeriesId()+1, "encrypted", "checksum", "creator",
-        metadata, 1136214245);
+        metadata, 1136214245, OffsetDateTime.now().toEpochSecond());
     assertThat(tableSize()).isEqualTo(before + 1);
   }
 
@@ -90,8 +90,8 @@ public class SecretContentDAOTest {
     // Create contents
     long[] ids = new long[15];
     for (int i = 0; i < ids.length; i++) {
-      long id = secretContentDAO.createSecretContent(
-          secretSeriesId, "encrypted", "checksum", "creator", metadata, 1136214245);
+      long id = secretContentDAO.createSecretContent(secretSeriesId, "encrypted", "checksum",
+          "creator", metadata, 1136214245, now);
       ids[i] = id;
     }
 
@@ -137,8 +137,8 @@ public class SecretContentDAOTest {
     // Create contents
     long[] ids = new long[15];
     for (int i = 0; i < ids.length; i++) {
-      long id = secretContentDAO.createSecretContent(
-          secretSeriesId, "encrypted", "checksum", "creator", metadata, 1136214245);
+      long id = secretContentDAO.createSecretContent(secretSeriesId, "encrypted",
+          "checksum", "creator", metadata, 1136214245, now);
       ids[i] = id;
     }
 

--- a/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
@@ -55,7 +55,7 @@ public class SecretSeriesDAOTest {
         ImmutableMap.of("foo", "bar"), now);
     long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
-    secretSeriesDAO.setCurrentVersion(id, contentId);
+    secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
 
     SecretSeries expected = SecretSeries.of(id, "newSecretSeries", "desc", nowDate, "creator", nowDate,
         "creator", null, ImmutableMap.of("foo", "bar"), contentId);
@@ -83,10 +83,12 @@ public class SecretSeriesDAOTest {
 
     long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
-    secretSeriesDAO.setCurrentVersion(id, contentId);
+    secretSeriesDAO.setCurrentVersion(id, contentId, "updater", now + 3600);
 
     secretSeriesById = secretSeriesDAO.getSecretSeriesById(id);
     assertThat(secretSeriesById.get().currentVersion().get()).isEqualTo(contentId);
+    assertThat(secretSeriesById.get().updatedBy()).isEqualTo("updater");
+    assertThat(secretSeriesById.get().updatedAt().toEpochSecond()).isEqualTo(now + 3600);
   }
 
   @Test(expected = IllegalStateException.class)
@@ -99,7 +101,7 @@ public class SecretSeriesDAOTest {
     long contentId = secretContentDAOFactory.readwrite().createSecretContent(other, "blah",
         "checksum", "creator", null, 0, now);
 
-    secretSeriesDAO.setCurrentVersion(id, contentId);
+    secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
   }
 
   @Test public void deleteSecretSeriesByName() {
@@ -108,7 +110,7 @@ public class SecretSeriesDAOTest {
         "", null, null, now);
     long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
-    secretSeriesDAO.setCurrentVersion(id, contentId);
+    secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
     assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName").get().currentVersion().isPresent()).isTrue();
 
     secretSeriesDAO.deleteSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName");
@@ -122,7 +124,7 @@ public class SecretSeriesDAOTest {
         "creator", "", null, null, now);
     long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
-    secretSeriesDAO.setCurrentVersion(id, contentId);
+    secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
     assertThat(secretSeriesDAO.getSecretSeriesById(id).get().currentVersion().isPresent()).isTrue();
 
     secretSeriesDAO.deleteSecretSeriesById(id);

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -235,7 +235,7 @@ public class SecretsResourceTest {
   @Test (expected = NotFoundException.class)
   public void rollbackThrowsException() {
     doThrow(new NotFoundException()).when(secretDAO)
-        .setCurrentSecretVersionByName(eq("name2"), anyLong());
+        .setCurrentSecretVersionByName(eq("name2"), anyLong(), eq("user"));
     resource.resetSecretVersion(user, "name2", new LongParam("125"));
   }
 


### PR DESCRIPTION
Secrets are represented in two tables, one for the "secret series"
and one for each set of contents that the secret has.  Both the
secret and its contents have update and creation timestamps.
This commit ensures that these timestamps will always match
(i. e. the first content for a secret will have a createdAt value
matching the createdAt value in the secret table, and immediately
after a secret update which creates new content the secret's
updatedAt value will match the updatedAt/createdAt value for its
current content, which was just created).

This should fix an intermittent failure in the AclDAO test, which
compares a SanitizedSecret whose timestamps use the values from the
"secrets" table against a SanitizedSecret (for the same secret) whose
timestamps use the values from the "secrets_content" table for the
secret's current contents.  Occasionally, the timestamp from the
"secrets" table (which is updated first) was a second behind the
timestamp from the "secrets_content" table.