### PR TITLE
Standardize the meaning of createdAt/updatedAt for secrets.

### DIFF
--- a/api/src/main/java/keywhiz/api/model/SanitizedSecretWithGroups.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecretWithGroups.java
@@ -64,7 +64,6 @@ public abstract class SanitizedSecretWithGroups {
 
   /** @return Name to serialize for clients. */
   public static String displayName(SanitizedSecretWithGroups sanitizedSecretWithGroups) {
-    String name = sanitizedSecretWithGroups.secret().name();
-    return name;
+    return sanitizedSecretWithGroups.secret().name();
   }
 }

--- a/api/src/main/java/keywhiz/api/model/Secret.java
+++ b/api/src/main/java/keywhiz/api/model/Secret.java
@@ -49,6 +49,12 @@ public class Secret {
   private final LazyString encryptedSecret;
   private final String checksum;
 
+  /**
+   * Information about this secret's creation and update.  If the secret's content
+   * has been rolled back to an earlier version, these timestamps will still reflect
+   * the secret's creation and latest update, not the creation/update time for the
+   * secret's contents.
+   */
   private final ApiDate createdAt;
   private final String createdBy;
   private final ApiDate updatedAt;

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -28,10 +27,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
-
-import keywhiz.api.ApiDate;
-import keywhiz.api.GroupDetailResponse;
-import keywhiz.api.SecretDetailResponse;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
@@ -60,7 +55,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 import static keywhiz.jooq.tables.Accessgrants.ACCESSGRANTS;
 import static keywhiz.jooq.tables.Clients.CLIENTS;
 import static keywhiz.jooq.tables.Groups.GROUPS;
@@ -272,10 +266,6 @@ public class AclDAO {
         .where(CLIENTS.NAME.eq(client.getName()).and(SECRETS.CURRENT.isNotNull()))
         .getQuery();
     query.addSelect(SECRETS_CONTENT.CONTENT_HMAC);
-    query.addSelect(SECRETS_CONTENT.CREATEDAT);
-    query.addSelect(SECRETS_CONTENT.CREATEDBY);
-    query.addSelect(SECRETS_CONTENT.UPDATEDAT);
-    query.addSelect(SECRETS_CONTENT.UPDATEDBY);
     query.addSelect(SECRETS_CONTENT.METADATA);
     query.addSelect(SECRETS_CONTENT.EXPIRY);
     query.fetch()
@@ -286,10 +276,10 @@ public class AclDAO {
               series.name(),
               series.description(),
               row.getValue(SECRETS_CONTENT.CONTENT_HMAC),
-              new ApiDate(row.getValue(SECRETS_CONTENT.CREATEDAT)),
-              row.getValue(SECRETS_CONTENT.CREATEDBY),
-              new ApiDate(row.getValue(SECRETS_CONTENT.UPDATEDAT)),
-              row.getValue(SECRETS_CONTENT.UPDATEDBY),
+              series.createdAt(),
+              series.createdBy(),
+              series.updatedAt(),
+              series.updatedBy(),
               secretContentMapper.tryToReadMapFromMetadata(row.getValue(SECRETS_CONTENT.METADATA)),
               series.type().orElse(null),
               series.generationOptions(),
@@ -330,10 +320,6 @@ public class AclDAO {
         .limit(1)
         .getQuery();
     query.addSelect(SECRETS_CONTENT.CONTENT_HMAC);
-    query.addSelect(SECRETS_CONTENT.CREATEDAT);
-    query.addSelect(SECRETS_CONTENT.CREATEDBY);
-    query.addSelect(SECRETS_CONTENT.UPDATEDAT);
-    query.addSelect(SECRETS_CONTENT.UPDATEDBY);
     query.addSelect(SECRETS_CONTENT.METADATA);
     query.addSelect(SECRETS_CONTENT.EXPIRY);
     return Optional.ofNullable(query.fetchOne())
@@ -344,10 +330,10 @@ public class AclDAO {
               series.name(),
               series.description(),
               row.getValue(SECRETS_CONTENT.CONTENT_HMAC),
-              new ApiDate(row.getValue(SECRETS_CONTENT.CREATEDAT)),
-              row.getValue(SECRETS_CONTENT.CREATEDBY),
-              new ApiDate(row.getValue(SECRETS_CONTENT.UPDATEDAT)),
-              row.getValue(SECRETS_CONTENT.UPDATEDBY),
+              series.createdAt(),
+              series.createdBy(),
+              series.updatedAt(),
+              series.updatedBy(),
               secretContentMapper.tryToReadMapFromMetadata(row.getValue(SECRETS_CONTENT.METADATA)),
               series.type().orElse(null),
               series.generationOptions(),


### PR DESCRIPTION
The createdAt/By and updatedAt/By for SanitizedSecret are now
standardized to reflect the creation and update information
for the "secret series"--the secret, including all of its versions--
rather than the latest version of the secret.  If the secret's
contents are rolled back to an older version, the SanitizedSecret's
creation and update data will not be altered.