### PR TITLE
Add fields for secret content creation data

### DIFF
--- a/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecret.java
@@ -46,23 +46,28 @@ public abstract class SanitizedSecret {
       @JsonProperty("type") @Nullable String type,
       @JsonProperty("generationOptions") @Nullable Map<String, String> generationOptions,
       @JsonProperty("expiry") long expiry,
-      @JsonProperty("version") @Nullable Long version) {
+      @JsonProperty("version") @Nullable Long version,
+      @JsonProperty("contentCreatedAt") @Nullable ApiDate contentCreatedAt,
+      @JsonProperty("contentCreatedBy") @Nullable String contentCreatedBy) {
     ImmutableMap<String, String> meta =
         (metadata == null) ? ImmutableMap.of() : ImmutableMap.copyOf(metadata);
     ImmutableMap<String, String> genOptions =
         (generationOptions == null) ? ImmutableMap.of() : ImmutableMap.copyOf(generationOptions);
     return new AutoValue_SanitizedSecret(id, name, nullToEmpty(description), checksum, createdAt,
         nullToEmpty(createdBy), updatedAt, nullToEmpty(updatedBy), meta, Optional.ofNullable(type),
-        genOptions, expiry, Optional.ofNullable(version));
+        genOptions, expiry, Optional.ofNullable(version), Optional.ofNullable(contentCreatedAt),
+        nullToEmpty(contentCreatedBy));
   }
 
   public static SanitizedSecret of(long id, String name) {
-    return of(id, name, null, "", new ApiDate(0), null, new ApiDate(0), null, null, null, null, 0, null);
+    return of(id, name, null, "", new ApiDate(0), null, new ApiDate(0), null,
+        null, null, null, 0, null, null, null);
   }
 
   public static SanitizedSecret fromSecretSeriesAndContent(SecretSeriesAndContent seriesAndContent) {
     SecretSeries series = seriesAndContent.series();
     SecretContent content = seriesAndContent.content();
+    // Note that for all content records, createdAt = updatedAt and createdBy = updatedBy
     return SanitizedSecret.of(
         series.id(),
         series.name(),
@@ -76,7 +81,9 @@ public abstract class SanitizedSecret {
         series.type().orElse(null),
         series.generationOptions(),
         content.expiry(),
-        content.id());
+        content.id(),
+        content.createdAt(),
+        content.createdBy());
   }
 
   /**
@@ -100,7 +107,9 @@ public abstract class SanitizedSecret {
         secret.getType().orElse(null),
         secret.getGenerationOptions(),
         secret.getExpiry(),
-        secret.getVersion().orElse(null));
+        secret.getVersion().orElse(null),
+        secret.getContentCreatedAt().orElse(null),
+        secret.getContentCreatedBy());
   }
 
   @JsonProperty public abstract long id();
@@ -116,6 +125,8 @@ public abstract class SanitizedSecret {
   @JsonProperty public abstract ImmutableMap<String, String> generationOptions();
   @JsonProperty public abstract long expiry();
   @JsonProperty public abstract Optional<Long> version();
+  @JsonProperty public abstract Optional<ApiDate> contentCreatedAt();
+  @JsonProperty public abstract String contentCreatedBy();
 
   /** @return Name to serialize for clients. */
   public static String displayName(SanitizedSecret sanitizedSecret) {

--- a/api/src/main/java/keywhiz/api/model/SanitizedSecretWithGroups.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecretWithGroups.java
@@ -37,7 +37,8 @@ public abstract class SanitizedSecretWithGroups {
 
   public static SanitizedSecretWithGroups of(long id, String name, List<Group> groups) {
     SanitizedSecret sanitizedSecret = SanitizedSecret.of(id, name, null, "",
-        new ApiDate(0), null, new ApiDate(0), null, null, null, null, 0, null);
+        new ApiDate(0), null, new ApiDate(0), null, null, null, null, 0,
+        null, null, null);
     return SanitizedSecretWithGroups.of(sanitizedSecret, groups);
   }
 

--- a/api/src/main/java/keywhiz/api/model/Secret.java
+++ b/api/src/main/java/keywhiz/api/model/Secret.java
@@ -48,13 +48,8 @@ public class Secret {
   private String secret;
   private final LazyString encryptedSecret;
   private final String checksum;
-
-  /**
-   * Information about this secret's creation and update.  If the secret's content
-   * has been rolled back to an earlier version, these timestamps will still reflect
-   * the secret's creation and latest update, not the creation/update time for the
-   * secret's contents.
-   */
+  
+  /** Data on the creation and update of the secret _series_ */
   private final ApiDate createdAt;
   private final String createdBy;
   private final ApiDate updatedAt;
@@ -71,6 +66,10 @@ public class Secret {
   /** Current version of the secret (may be null) */
   private final Long version;
 
+  /** Data on the creation of the current secret _content_ (equivalent to its update data) */
+  private final ApiDate contentCreatedAt;
+  private final String contentCreatedBy;
+
   public Secret(long id,
                 String name,
                 @Nullable String description,
@@ -84,7 +83,9 @@ public class Secret {
                 @Nullable String type,
                 @Nullable Map<String, String> generationOptions,
                 long expiry,
-                @Nullable Long version) {
+                @Nullable Long version,
+                @Nullable ApiDate contentCreatedAt,
+                @Nullable String contentCreatedBy) {
 
     checkArgument(!name.isEmpty());
     this.id = id;
@@ -103,6 +104,8 @@ public class Secret {
         ImmutableMap.of() : ImmutableMap.copyOf(generationOptions);
     this.expiry = expiry;
     this.version = version;
+    this.contentCreatedAt = contentCreatedAt;
+    this.contentCreatedBy = nullToEmpty(contentCreatedBy);
   }
 
   public long getId() {
@@ -167,6 +170,14 @@ public class Secret {
 
   public Optional<Long> getVersion() {return Optional.ofNullable(version); }
 
+  public Optional<ApiDate> getContentCreatedAt() {
+    return Optional.ofNullable(contentCreatedAt);
+  }
+
+  public String getContentCreatedBy() {
+    return contentCreatedBy;
+  }
+
   /** Slightly hokey way of calculating the decoded-length without bothering to decode. */
   public static int decodedLength(String secret) {
     checkNotNull(secret);
@@ -192,7 +203,9 @@ public class Secret {
           Objects.equal(this.type, that.type) &&
           Objects.equal(this.generationOptions, that.generationOptions) &&
           this.expiry == that.expiry &&
-          Objects.equal(this.version, that.version)) {
+          Objects.equal(this.version, that.version) &&
+          Objects.equal(this.contentCreatedAt, that.contentCreatedAt) &&
+          Objects.equal(this.contentCreatedBy, that.contentCreatedBy)) {
         return true;
       }
     }
@@ -201,7 +214,7 @@ public class Secret {
 
   @Override public int hashCode() {
     return Objects.hashCode(id, name, description, getSecret(), checksum, createdAt, createdBy, updatedAt,
-        updatedBy, metadata, type, generationOptions, expiry);
+        updatedBy, metadata, type, generationOptions, expiry, version, contentCreatedAt, contentCreatedBy);
   }
 
   @Override
@@ -221,6 +234,8 @@ public class Secret {
         .add("generationOptions", generationOptions)
         .add("expiry", expiry)
         .add("version", version)
+        .add("contentCreationDate", contentCreatedAt)
+        .add("contentCreatedBy", contentCreatedBy)
         .toString();
   }
 

--- a/api/src/test/java/keywhiz/api/AutomationSecretResponseTest.java
+++ b/api/src/test/java/keywhiz/api/AutomationSecretResponseTest.java
@@ -34,7 +34,7 @@ public class AutomationSecretResponseTest {
       ImmutableMap.of("key1", "value1", "key2", "value2");
   private static final ApiDate NOW = ApiDate.now();
   private static final Secret secret = new Secret(0, "name", null, () -> "YWJj", "checksum", NOW, null, NOW, null, metadata,
-      "upload", null, 1136214245, null);
+      "upload", null, 1136214245, null, null, null);
 
   @Test
   public void setsLength() {

--- a/api/src/test/java/keywhiz/api/SecretDeliveryResponseTest.java
+++ b/api/src/test/java/keywhiz/api/SecretDeliveryResponseTest.java
@@ -33,10 +33,10 @@ public class SecretDeliveryResponseTest {
   private static final ApiDate NOW = ApiDate.now();
   private static final Secret secret = new Secret(0, "name", null,
       () -> "YWJj", "checksum", NOW, null, NOW, null, metadata,
-      "upload", null, 0, null);
+      "upload", null, 0, null, NOW, null);
 
   private static final SanitizedSecret sanitizedSecret = SanitizedSecret.of(0, "name", null, "checksum",
-      NOW, null, NOW, null, metadata, "upload", null, 0, null);
+      NOW, null, NOW, null, metadata, "upload", null, 0, null, NOW, null);
 
   @Test
   public void setsLength() {

--- a/api/src/test/java/keywhiz/api/SecretsResponseTest.java
+++ b/api/src/test/java/keywhiz/api/SecretsResponseTest.java
@@ -41,7 +41,9 @@ public class SecretsResponseTest {
             "password",
             ImmutableMap.of("param1", "value1"),
             1136214245,
-            1L),
+            1L,
+            ApiDate.parse("2013-03-28T21:42:42.573Z"),
+            "keywhizAdmin"),
         SanitizedSecret.of(
             768,
             "anotherSecret",
@@ -55,7 +57,9 @@ public class SecretsResponseTest {
             "upload",
             null,
             1136214245,
-            10L)
+            10L,
+            ApiDate.parse("2013-04-28T21:42:42.573Z"),
+            "keywhizAdmin")
     ));
 
     assertThat(asJson(secretsResponse))

--- a/api/src/test/java/keywhiz/api/automation/v2/SecretDetailResponseV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/SecretDetailResponseV2Test.java
@@ -73,7 +73,8 @@ public class SecretDetailResponseV2Test {
         ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
         ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user",
         ImmutableMap.of("owner", "root"), "text/plain", null,
-        1136214245, 1L);
+        1136214245, 1L,
+        ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user");
     SecretDetailResponseV2 secretDetailResponse = SecretDetailResponseV2.builder()
         .sanitizedSecret(sanitizedSecret)
         .build();

--- a/api/src/test/java/keywhiz/api/automation/v2/SecretDetailResponseV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/SecretDetailResponseV2Test.java
@@ -44,6 +44,8 @@ public class SecretDetailResponseV2Test {
         .type("text/plain")
         .metadata(ImmutableMap.of("owner", "root"))
         .expiry(1136214245)
+        .contentCreatedAtSeconds(OffsetDateTime.parse("2014-03-28T21:23:04.159Z").toEpochSecond())
+        .contentCreatedBy("updater-user")
         .build();
 
     assertThat(asJson(secretDetailResponse))
@@ -56,7 +58,7 @@ public class SecretDetailResponseV2Test {
         ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user", "text/plain", null,
         1L);
     SecretContent content = SecretContent.of(1, 1, "YXNkZGFz", "checksum",
-        ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
+        ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user",
         ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user",
         ImmutableMap.of("owner", "root"), 1136214245);
     SecretSeriesAndContent seriesAndContent = SecretSeriesAndContent.of(series, content);

--- a/api/src/test/java/keywhiz/api/model/SanitizedSecretTest.java
+++ b/api/src/test/java/keywhiz/api/model/SanitizedSecretTest.java
@@ -39,7 +39,9 @@ public class SanitizedSecretTest {
         "password",
         ImmutableMap.of("favoriteFood", "PB&J sandwich"),
         1136214245,
-        1L);
+        1L,
+        ApiDate.parse("2013-03-28T21:42:42.573Z"),
+        "keywhizAdmin");
 
     assertThat(asJson(sanitizedSecret))
         .isEqualTo(jsonFixture("fixtures/sanitizedSecret.json"));
@@ -61,7 +63,9 @@ public class SanitizedSecretTest {
             "password",
             ImmutableMap.of("favoriteFood", "PB&J sandwich"),
             1136214245,
-            1L));
+            1L,
+            ApiDate.parse("2013-03-28T21:42:42.573Z"),
+            "keywhizAdmin"));
 
     assertThat(asJson(sanitizedSecret))
         .isEqualTo(jsonFixture("fixtures/sanitizedSecret.json"));

--- a/api/src/test/java/keywhiz/api/model/SanitizedSecretWithGroupsTest.java
+++ b/api/src/test/java/keywhiz/api/model/SanitizedSecretWithGroupsTest.java
@@ -41,7 +41,9 @@ public class SanitizedSecretWithGroupsTest {
       "password",
       ImmutableMap.of("favoriteFood", "PB&J sandwich"),
       1136214245,
-      1L);
+      1L,
+      ApiDate.parse("2013-03-28T21:42:42.000Z"),
+      "keywhizAdmin");
 
   private List<Group> groups;
 
@@ -80,7 +82,9 @@ public class SanitizedSecretWithGroupsTest {
             "password",
             ImmutableMap.of("favoriteFood", "PB&J sandwich"),
             1136214245,
-            1L), groups);
+            1L,
+            ApiDate.parse("2013-03-28T21:42:42.000Z"),
+            "keywhizAdmin"), groups);
 
     assertThat(asJson(sanitizedSecretWithGroups))
         .isEqualTo(jsonFixture("fixtures/sanitizedSecretWithGroups.json"));

--- a/api/src/test/java/keywhiz/api/model/SecretTest.java
+++ b/api/src/test/java/keywhiz/api/model/SecretTest.java
@@ -46,7 +46,7 @@ public class SecretTest {
 
   @Test public void callsDecryptOnlyOnce() {
     Secret s = new Secret(42, "toto", null, () -> String.valueOf(++called), "checksum", ApiDate.now(), "", ApiDate.now(), "", null,
-        null, null, 0, 1L);
+        null, null, 0, 1L, ApiDate.now(), "");
     assertThat(s.getSecret()).isEqualTo("1");
     assertThat(s.getSecret()).isEqualTo("1");
   }

--- a/api/src/test/resources/fixtures/sanitizedSecret.json
+++ b/api/src/test/resources/fixtures/sanitizedSecret.json
@@ -15,5 +15,7 @@
     "favoriteFood" : "PB&J sandwich"
   },
   "expiry" : 1136214245,
-  "version" : 1
+  "version" : 1,
+  "contentCreatedAt" : "2013-03-28T21:42:42.000Z",
+  "contentCreatedBy" : "keywhizAdmin"
 }

--- a/api/src/test/resources/fixtures/sanitizedSecretWithGroups.json
+++ b/api/src/test/resources/fixtures/sanitizedSecretWithGroups.json
@@ -16,7 +16,9 @@
       "favoriteFood": "PB&J sandwich"
     },
     "expiry": 1136214245,
-    "version": 1
+    "version": 1,
+    "contentCreatedAt": "2013-03-28T21:42:42.000Z",
+    "contentCreatedBy": "keywhizAdmin"
   },
   "groups": [
     {

--- a/api/src/test/resources/fixtures/secretsResponse.json
+++ b/api/src/test/resources/fixtures/secretsResponse.json
@@ -17,7 +17,9 @@
         "param1" : "value1"
       },
       "expiry" : 1136214245,
-      "version" : 1
+      "version" : 1,
+      "contentCreatedAt" : "2013-03-28T21:42:42.000Z",
+      "contentCreatedBy" : "keywhizAdmin"
     },
     {
       "id" : 768,
@@ -32,7 +34,9 @@
       "type" : "upload",
       "generationOptions" : {},
       "expiry" : 1136214245,
-      "version" : 10
+      "version" : 10,
+      "contentCreatedAt" : "2013-04-28T21:42:42.000Z",
+      "contentCreatedBy" : "keywhizAdmin"
     }
   ]
 }

--- a/api/src/test/resources/fixtures/v2/secretDetailResponse.json
+++ b/api/src/test/resources/fixtures/v2/secretDetailResponse.json
@@ -9,5 +9,7 @@
   "metadata": {"owner": "root"},
   "type": "text/plain",
   "expiry": 1136214245,
-  "version" : 1
+  "version" : 1,
+  "contentCreatedAtSeconds": 1396041784,
+  "contentCreatedBy": "updater-user"
 }

--- a/cli/src/main/java/keywhiz/cli/Printing.java
+++ b/cli/src/main/java/keywhiz/cli/Printing.java
@@ -190,6 +190,17 @@ public class Printing {
     System.out.println("\tUpdated at:");
     d = new Date(secret.updatedAt().toEpochSecond() * 1000);
     System.out.println(INDENT + DateFormat.getDateTimeInstance().format(d));
+
+    if (!secret.contentCreatedBy().isEmpty()) {
+      System.out.println("\tContent created by:");
+      System.out.println(INDENT + secret.contentCreatedBy());
+    }
+
+    if (secret.contentCreatedAt().isPresent()) {
+      System.out.println("\tContent created at:");
+      d = new Date(secret.contentCreatedAt().get().toEpochSecond() * 1000);
+      System.out.println(INDENT + DateFormat.getDateTimeInstance().format(d));
+    }
   }
 
   public void printAllClients(List<Client> clients) {
@@ -232,24 +243,22 @@ public class Printing {
         System.out.println("Version id for rollback: Unknown!");
       }
 
-      if (secret.createdBy().isEmpty()) {
-        System.out.println(INDENT + String.format("Created on %s (creator unknown)",
-            DateFormat.getDateTimeInstance()
-                .format(new Date(secret.createdAt().toEpochSecond() * 1000))));
+      if (secret.contentCreatedAt().isPresent()) {
+        if (secret.contentCreatedBy().isEmpty()) {
+          System.out.println(INDENT + String.format("Created on %s (creator unknown)",
+              DateFormat.getDateTimeInstance()
+                  .format(new Date(secret.contentCreatedAt().get().toEpochSecond() * 1000))));
+        } else {
+          System.out.println(INDENT + String.format("Created by %s on %s", secret.createdBy(),
+              DateFormat.getDateTimeInstance()
+                  .format(new Date(secret.contentCreatedAt().get().toEpochSecond() * 1000))));
+        }
       } else {
-        System.out.println(INDENT + String.format("Created by %s on %s", secret.createdBy(),
-            DateFormat.getDateTimeInstance()
-                .format(new Date(secret.createdAt().toEpochSecond() * 1000))));
-      }
-
-      if (secret.updatedBy().isEmpty()) {
-        System.out.println(INDENT + String.format("Updated on %s (updater unknown)",
-            DateFormat.getDateTimeInstance()
-                .format(new Date(secret.updatedAt().toEpochSecond() * 1000))));
-      } else {
-        System.out.println(INDENT + String.format("Updated by %s on %s", secret.updatedBy(),
-            DateFormat.getDateTimeInstance()
-                .format(new Date(secret.updatedAt().toEpochSecond() * 1000))));
+        if (secret.contentCreatedBy().isEmpty()) {
+          System.out.println(INDENT + "Creator and creation date unknown");
+        } else {
+          System.out.println(INDENT + String.format("Created by %s (date unknown)", secret.contentCreatedBy()));
+        }
       }
 
       if (secret.expiry() == 0) {

--- a/cli/src/test/java/keywhiz/cli/commands/AddActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/AddActionTest.java
@@ -56,7 +56,7 @@ public class AddActionTest {
   Client client = new Client(4, "newClient", null, null, null, null, null, null, true, false);
   Group group = new Group(4, "newGroup", null, null, null, null, null, null);
   Secret secret = new Secret(15, "newSecret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0, 1L);
+      ImmutableMap.of(), 0, 1L, NOW, null);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
   SecretDetailResponse secretDetailResponse = SecretDetailResponse.fromSecret(secret, null, null);
 

--- a/cli/src/test/java/keywhiz/cli/commands/AssignActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/AssignActionTest.java
@@ -54,7 +54,7 @@ public class AssignActionTest {
   GroupDetailResponse groupDetailResponse = GroupDetailResponse.fromGroup(group,
       ImmutableList.<SanitizedSecret>of(), ImmutableList.<Client>of());
   Secret secret = new Secret(16, "secret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0, 1L);
+      ImmutableMap.of(), 0, 1L, NOW, null);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
 
   @Before

--- a/cli/src/test/java/keywhiz/cli/commands/DeleteActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/DeleteActionTest.java
@@ -51,7 +51,7 @@ public class DeleteActionTest {
   DeleteAction deleteAction;
 
   Secret secret = new Secret(0, "secret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0, 1L);
+      ImmutableMap.of(), 0, 1L, NOW, null);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
 
   ByteArrayInputStream yes;

--- a/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
@@ -49,7 +49,7 @@ public class DescribeActionTest {
   DescribeActionConfig describeActionConfig;
   DescribeAction describeAction;
   Secret secret = new Secret(0, "secret", null, () ->  "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0, 1L);
+      ImmutableMap.of(), 0, 1L, NOW, null);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
 
   @Before

--- a/cli/src/test/java/keywhiz/cli/commands/ListVersionsActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/ListVersionsActionTest.java
@@ -33,7 +33,7 @@ public class ListVersionsActionTest {
 
   private static final ApiDate NOW = ApiDate.now();
   Secret secret = new Secret(0, "secret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0, 1L);
+      ImmutableMap.of(), 0, 1L, NOW, null);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
 
   @Before

--- a/cli/src/test/java/keywhiz/cli/commands/RollbackActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/RollbackActionTest.java
@@ -50,7 +50,7 @@ public class RollbackActionTest {
   RollbackAction rollbackAction;
 
   Secret secret = new Secret(0, "secret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0, 1L);
+      ImmutableMap.of(), 0, 1L, NOW, null);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
 
   ByteArrayInputStream yes;

--- a/cli/src/test/java/keywhiz/cli/commands/UnassignActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/UnassignActionTest.java
@@ -50,7 +50,7 @@ public class UnassignActionTest {
   Client client = new Client(11, "client-name", null, null, null, null, null, null, false, false);
   Group group = new Group(22, "group-name", null, null, null, null, null, null);
   Secret secret = new Secret(33, "secret-name", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0, 1L);
+      ImmutableMap.of(), 0, 1L, NOW, null);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
   GroupDetailResponse groupDetailResponse = GroupDetailResponse.fromGroup(group,
       ImmutableList.of(sanitizedSecret), ImmutableList.of(client));

--- a/cli/src/test/java/keywhiz/cli/commands/UpdateActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/UpdateActionTest.java
@@ -56,7 +56,7 @@ public class UpdateActionTest {
   UpdateAction updateAction;
 
   Secret secret = new Secret(15, "newSecret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0, 1L);
+      ImmutableMap.of(), 0, 1L, NOW, null);
   SecretDetailResponse secretDetailResponse = SecretDetailResponse.fromSecret(secret, null, null);
 
   @Before

--- a/server/src/main/java/keywhiz/service/crypto/SecretTransformer.java
+++ b/server/src/main/java/keywhiz/service/crypto/SecretTransformer.java
@@ -56,6 +56,8 @@ public class SecretTransformer {
         series.type().orElse(null),
         series.generationOptions(),
         content.expiry(),
-        series.currentVersion().orElse(null));
+        series.currentVersion().orElse(null),
+        content.createdAt(),
+        content.createdBy());
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import keywhiz.api.ApiDate;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
@@ -266,6 +267,8 @@ public class AclDAO {
         .where(CLIENTS.NAME.eq(client.getName()).and(SECRETS.CURRENT.isNotNull()))
         .getQuery();
     query.addSelect(SECRETS_CONTENT.CONTENT_HMAC);
+    query.addSelect(SECRETS_CONTENT.CREATEDAT);
+    query.addSelect(SECRETS_CONTENT.CREATEDBY);
     query.addSelect(SECRETS_CONTENT.METADATA);
     query.addSelect(SECRETS_CONTENT.EXPIRY);
     query.fetch()
@@ -284,9 +287,11 @@ public class AclDAO {
               series.type().orElse(null),
               series.generationOptions(),
               row.getValue(SECRETS_CONTENT.EXPIRY),
-              series.currentVersion().orElse(null));
+              series.currentVersion().orElse(null),
+              new ApiDate(row.getValue(SECRETS_CONTENT.CREATEDAT)),
+              row.getValue(SECRETS_CONTENT.CREATEDBY));
         })
-        .forEach(row -> sanitizedSet.add(row));
+        .forEach(sanitizedSet::add);
 
     return sanitizedSet.build();
   }
@@ -320,6 +325,8 @@ public class AclDAO {
         .limit(1)
         .getQuery();
     query.addSelect(SECRETS_CONTENT.CONTENT_HMAC);
+    query.addSelect(SECRETS_CONTENT.CREATEDAT);
+    query.addSelect(SECRETS_CONTENT.CREATEDBY);
     query.addSelect(SECRETS_CONTENT.METADATA);
     query.addSelect(SECRETS_CONTENT.EXPIRY);
     return Optional.ofNullable(query.fetchOne())
@@ -338,7 +345,9 @@ public class AclDAO {
               series.type().orElse(null),
               series.generationOptions(),
               row.getValue(SECRETS_CONTENT.EXPIRY),
-              series.currentVersion().orElse(null));
+              series.currentVersion().orElse(null),
+              new ApiDate(row.getValue(SECRETS_CONTENT.CREATEDAT)),
+              row.getValue(SECRETS_CONTENT.CREATEDBY));
         });
   }
 

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceIntegrationTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceIntegrationTest.java
@@ -45,7 +45,8 @@ public class SecretDeliveryResourceIntegrationTest {
     client = TestClients.mutualSslClient();
     generalPassword = new Secret(0, "General_Password", null, () -> "YXNkZGFz", "",
         ApiDate.parse("2011-09-29T15:46:00Z"), null,
-        ApiDate.parse("2011-09-29T15:46:00Z"), null, null, "upload", null, 0, 1L);
+        ApiDate.parse("2011-09-29T15:46:00Z"), null, null, "upload",
+        null, 0, 1L, ApiDate.parse("2011-09-29T15:46:00Z"), null);
   }
 
   @Test public void returnsSecretWhenAllowed() throws Exception {

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
@@ -48,9 +48,9 @@ public class SecretDeliveryResourceTest {
 
   final Client client = new Client(0, "principal", null, null, null, null, null, null, false, false);
   final Secret secret = new Secret(0, "secret_name", null, () -> "secret_value", "checksum", NOW, null, NOW, null,
-      null, null, null, 0, 1L);
+      null, null, null, 0, 1L, NOW, null);
   final Secret secretBase64 = new Secret(1, "Base64With=", null, () -> "SGVsbG8=", "checksum", NOW, null, NOW,
-      null, null, null, null, 0, 1L);
+      null, null, null, null, 0, 1L, NOW, null);
 
   @Before public void setUp() {
     secretDeliveryResource = new SecretDeliveryResource(secretController, aclDAO, clientDAO);
@@ -58,7 +58,7 @@ public class SecretDeliveryResourceTest {
 
   @Test public void returnsSecretWhenAllowed() throws Exception {
     Secret secret = new Secret(0, "secret_name", null, () -> "unused_secret", "checksum", NOW, null, NOW, null, null, null,
-        null, 0, 1L);
+        null, 0, 1L, NOW, null);
     SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
     String name = sanitizedSecret.name();
 
@@ -74,7 +74,7 @@ public class SecretDeliveryResourceTest {
   @Test public void returnsVersionedSecretWhenAllowed() throws Exception {
     String name = "secret_name";
     Secret versionedSecret = new Secret(2, name, null, () -> "U3BpZGVybWFu", "checksum", NOW, null, NOW,
-        null, null, null, null, 0, 1L);
+        null, null, null, null, 0, 1L, NOW, null);
 
     when(aclDAO.getSanitizedSecretFor(client, name))
         .thenReturn(Optional.of(SanitizedSecret.fromSecret(versionedSecret)));

--- a/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceIntegrationTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceIntegrationTest.java
@@ -55,12 +55,16 @@ public class SecretsDeliveryResourceIntegrationTest {
         SanitizedSecret.fromSecret(
             new Secret(0, "General_Password", null, () -> "YXNkZGFz", "checksum",
                 ApiDate.parse("2011-09-29T15:46:00.312Z"), null,
-                ApiDate.parse("2011-09-29T15:46:00.312Z"), null, null, null, null, 0, 1L)));
+                ApiDate.parse("2011-09-29T15:46:00.312Z"), null,
+                null, null, null, 0, 1L,
+                ApiDate.parse("2011-09-29T15:46:00.312Z"), null)));
     databasePassword = SecretDeliveryResponse.fromSanitizedSecret(
         SanitizedSecret.fromSecret(
             new Secret(1, "Database_Password", null, () -> "MTIzNDU=","checksum",
                 ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
-                ApiDate.parse("2011-09-29T15:46:00.232Z"), null, null, null, null, 0, 2L)));
+                ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
+                null, null, null, 0, 2L,
+                ApiDate.parse("2011-09-29T15:46:00.312Z"), null)));
     nobodyPgPassPassword = SecretDeliveryResponse.fromSanitizedSecret(
         SanitizedSecret.fromSecret(
             new Secret(2, "Nobody_PgPass", null,
@@ -68,13 +72,15 @@ public class SecretsDeliveryResourceIntegrationTest {
                 "checksum",
                 ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
                 ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
-                ImmutableMap.of("owner", "nobody", "mode", "0400"), null, null, 0, 3L)));
+                ImmutableMap.of("owner", "nobody", "mode", "0400"), null, null, 0, 3L,
+                ApiDate.parse("2011-09-29T15:46:00.312Z"), null)));
     nonExistentOwnerPass = SecretDeliveryResponse.fromSanitizedSecret(
         SanitizedSecret.fromSecret(
             new Secret(3, "NonexistentOwner_Pass", null, () -> "MTIzNDU=", "checksum",
                 ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
                 ApiDate.parse("2011-09-29T15:46:00.232Z"), null,
-                ImmutableMap.of("owner", "NonExistent", "mode", "0400"), null, null, 0, 4L)));
+                ImmutableMap.of("owner", "NonExistent", "mode", "0400"), null, null, 0, 4L,
+                ApiDate.parse("2011-09-29T15:46:00.312Z"), null)));
   }
 
   @Test

--- a/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceTest.java
@@ -42,16 +42,15 @@ public class SecretsDeliveryResourceTest {
   @Rule public MockitoRule mockito = MockitoJUnit.rule();
 
   @Mock AclDAO aclDAO;
-  @Mock ClientDAO clientDAO;
   SecretsDeliveryResource secretsDeliveryResource;
 
   Secret firstSecret = new Secret(0, "first_secret_name", null,
       () -> Base64.getEncoder().encodeToString("first_secret_contents".getBytes(UTF_8)), "checksum", NOW, null, NOW, null, null,
-      null, null, 0, 1L);
+      null, null, 0, 1L, NOW, null);
   SanitizedSecret sanitizedFirstSecret = SanitizedSecret.fromSecret(firstSecret);
   Secret secondSecret = new Secret(1, "second_secret_name", null,
       () -> Base64.getEncoder().encodeToString("second_secret_contents".getBytes(UTF_8)), "checksum", NOW, null, NOW, null, null,
-      null, null, 0, 1L);
+      null, null, 0, 1L, NOW, null);
   SanitizedSecret sanitizedSecondSecret = SanitizedSecret.fromSecret(secondSecret);
   Client client;
 

--- a/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
@@ -114,7 +114,7 @@ public class ClientsResourceTest {
     Group group1 = new Group(0, "group1", null, null, null, null, null, null);
     Group group2 = new Group(0, "group2", null, null, null, null, null, null);
     Secret secret = new Secret(15, "secret", null, () -> "supersecretdata", "checksum", now, "creator", now,
-        "updater", null, null, null, 0, 1L);
+        "updater", null, null, null, 0, 1L, now, "updater");
 
     when(clientDAO.getClientById(1)).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(client)).thenReturn(Sets.newHashSet(group1, group2));

--- a/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
@@ -102,7 +102,7 @@ public class GroupsResourceTest {
     when(groupDAO.getGroupById(4444)).thenReturn(Optional.of(group));
 
     SanitizedSecret secret = SanitizedSecret.of(1, "name", null, "checksum", now, "creator", now, "creator", null, null, null,
-        1136214245, 125L);
+        1136214245, 125L, now, "creator");
     when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of(secret));
 
     Client client = new Client(1, "client", "desc", now, "creator", now, "creator", null, true, false);

--- a/server/src/test/java/keywhiz/service/resources/admin/MembershipResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/MembershipResourceTest.java
@@ -48,7 +48,7 @@ public class MembershipResourceTest {
   User user = User.named("user");
   Client client = new Client(44, "client", "desc", NOW, "creator", NOW, "updater", null, true, false);
   Group group = new Group(55, "group", null, null, null, null, null, null);
-  Secret secret = new Secret(66, "secret", null, () -> "shush", "checksum", NOW, null, NOW, null, null, null, null, 0, 1L);
+  Secret secret = new Secret(66, "secret", null, () -> "shush", "checksum", NOW, null, NOW, null, null, null, null, 0, 1L, NOW, null);
   AuditLog auditLog = new SimpleLogger();
 
   MembershipResource resource;

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -77,7 +77,7 @@ public class SecretsResourceTest {
   ImmutableMap<String, String> emptyMap = ImmutableMap.of();
 
   Secret secret = new Secret(22, "name", "desc", () -> "secret", "checksum", NOW, "creator", NOW,
-      "updater", emptyMap, null, null, 1136214245, 1L);
+      "updater", emptyMap, null, null, 1136214245, 1L, NOW, "user");
 
   AuditLog auditLog = new SimpleLogger();
 
@@ -91,9 +91,9 @@ public class SecretsResourceTest {
   @Test
   public void listSecrets() {
     SanitizedSecret secret1 = SanitizedSecret.of(1, "name1", "desc","checksum", NOW, "user", NOW, "user",
-        emptyMap, null, null, 1136214245, 125L);
+        emptyMap, null, null, 1136214245, 125L, NOW, "user");
     SanitizedSecret secret2 = SanitizedSecret.of(2, "name2", "desc","checksum", NOW, "user", NOW, "user",
-        emptyMap, null, null, 1136214245, 250L);
+        emptyMap, null, null, 1136214245, 250L, NOW, "user");
     when(secretController.getSanitizedSecrets(null, null)).thenReturn(ImmutableList.of(secret1, secret2));
 
     List<SanitizedSecret> response = resource.listSecrets(user);
@@ -103,9 +103,9 @@ public class SecretsResourceTest {
   @Test
   public void listSecretsBatched() {
     SanitizedSecret secret1 = SanitizedSecret.of(1, "name1", "desc", "checksum", NOW, "user", NOW, "user",
-        emptyMap, null, null, 1136214245, 125L);
+        emptyMap, null, null, 1136214245, 125L, NOW, "user");
     SanitizedSecret secret2 = SanitizedSecret.of(2, "name2", "desc", "checksum", NOWPLUS, "user", NOWPLUS, "user",
-        emptyMap, null, null, 1136214245, 250L);
+        emptyMap, null, null, 1136214245, 250L, NOW, "user");
     when(secretController.getSecretsBatched(0, 1, false)).thenReturn(ImmutableList.of(secret1));
     when(secretController.getSecretsBatched(0, 1, true)).thenReturn(ImmutableList.of(secret2));
     when(secretController.getSecretsBatched(1, 1, false)).thenReturn(ImmutableList.of(secret2));
@@ -192,9 +192,9 @@ public class SecretsResourceTest {
   @Test
   public void listSecretVersions() {
     SanitizedSecret secret1 = SanitizedSecret.of(1, "name1", "desc", "checksum", NOW, "user",
-        NOW, "user", emptyMap, null, null, 1136214245, 125L);
+        NOW, "user", emptyMap, null, null, 1136214245, 125L, NOW, "user");
     SanitizedSecret secret2 = SanitizedSecret.of(1, "name1", "desc", "checksum2", NOWPLUS, "user",
-        NOWPLUS, "user", emptyMap, null, null, 1136214245, 250L);
+        NOWPLUS, "user", emptyMap, null, null, 1136214245, 250L, NOW, "user");
 
     when(secretDAO.getSecretVersionsByName("name1", 0, 10)).thenReturn(
         Optional.of(ImmutableList.of(secret2, secret1)));
@@ -224,7 +224,7 @@ public class SecretsResourceTest {
   public void rollbackSuccess() {
     Secret secret1 = new Secret(1, "name1", "desc", () -> "secret",
         "checksum", NOW, "user", NOW, "user", emptyMap, null,
-        null, 1136214245, 125L);
+        null, 1136214245, 125L, NOW, "user");
 
     when(secretController.getSecretByName("name1")).thenReturn(Optional.of(secret1));
 

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationGroupResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationGroupResourceTest.java
@@ -91,9 +91,9 @@ public class AutomationGroupResourceTest {
     Client groupClient =
         new Client(1, "firstClient", "Group client", now, "test", now, "test", null, true, true);
     SanitizedSecret firstGroupSecret =
-        SanitizedSecret.of(1, "name1", "desc", "checksum", now, "test", now, "test", null, "", null, 1136214245, 125L);
+        SanitizedSecret.of(1, "name1", "desc", "checksum", now, "test", now, "test", null, "", null, 1136214245, 125L, now, "test");
     SanitizedSecret secondGroupSecret =
-        SanitizedSecret.of(2, "name2", "desc", "checksum", now, "test", now, "test", null, "", null, 1136214245, 250L);
+        SanitizedSecret.of(2, "name2", "desc", "checksum", now, "test", now, "test", null, "", null, 1136214245, 250L, now, "test");
 
     when(groupDAO.getGroup("testGroup")).thenReturn(Optional.of(group));
     when(aclDAO.getClientsFor(group)).thenReturn(ImmutableSet.of(groupClient));

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationSecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationSecretResourceTest.java
@@ -95,7 +95,9 @@ public class AutomationSecretResourceTest {
         null,
         null,
         0,
-        1L);
+        1L,
+        NOW,
+        automation.getName());
 
     when(secretBuilder.create()).thenReturn(secret);
 
@@ -112,7 +114,7 @@ public class AutomationSecretResourceTest {
   @Test
   public void deleteSecret() throws Exception {
     Secret secret = new Secret(0, "mySecret", null, (Secret.LazyString) () -> "meh",
-        "checksum", NOW, null, NOW, null, ImmutableMap.of(), null, null, 0, 1L);
+        "checksum", NOW, null, NOW, null, ImmutableMap.of(), null, null, 0, 1L, NOW, null);
 
     HashSet<Group> groups = new HashSet<>();
     groups.add(new Group(0, "group1", "", NOW, null, NOW, null, null));


### PR DESCRIPTION
The primary changes are to Secret, SanitizedSecret, SecretDetailResponseV2, and Printing in keywhiz.cli; most of the other alterations just update tests to add parameters. 

If secrets have had their contents reset to an earlier version, or when SanitizedSecret/SecretDetailResponseV2 is used to represent an older version of a secret, the content creation information will differ from the secret's creation and update data.  This adds a field to explicitly track content creation data (which is equivalent to content update data since Keywhiz never updates content records).