### PR TITLE
Add link to javadocs, remove Stack Overflow link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -263,8 +263,8 @@ limitations under the License.</pre>
               <ul class="nav nav-pills nav-stacked secondary">
                 <li><a href="https://github.com/square/keywhiz/wiki">Wiki</a></li>
                 <li><a href="apidocs">API</a></li>
+                <li><a href="javadocs">Javadocs</a></li>
                 <li><a href="https://groups.google.com/forum/#!forum/keywhiz-users">Google Group</a></li>
-                <li><a href="https://stackoverflow.com/questions/tagged/keywhiz?sort=active">StackOverflow</a></li>
               </ul>
             </div>
           </div>

--- a/docs/javadocs/index.html
+++ b/docs/javadocs/index.html
@@ -4,7 +4,6 @@
 <p><a href="cli">cli</a></p>
 <p><a href="client">client</a></p>
 <p><a href="hkdf">hkdf</a></p>
-<p><a href="index.html">index.html</a></p>
 <p><a href="log">log</a></p>
 <p><a href="model">model</a></p>
 <p><a href="server">server</a></p>


### PR DESCRIPTION
Make the javadocs at least a little discoverable.

Remove stackoverflow link, nobody uses it for keywhiz