### PR TITLE
Adds an endpoint for retrieving a SanitizedSecret by name

### DIFF
--- a/docs/apidocs/automation_v2-secret-management.json
+++ b/docs/apidocs/automation_v2-secret-management.json
@@ -403,6 +403,29 @@
       "consumes" : [ "application/json" ]
     } ]
   }, {
+    "path" : "/automation/v2/secrets/{name}/sanitized",
+    "operations" : [ {
+      "method" : "GET",
+      "nickname" : "getSanitizedSecret",
+      "type" : "SanitizedSecret",
+      "parameters" : [ {
+        "type" : "string",
+        "description" : "Secret series name",
+        "paramType" : "path",
+        "name" : "name",
+        "required" : true
+      } ],
+      "summary" : "Retrieve information on a secret series",
+      "responseMessages" : [ {
+        "code" : 200,
+        "message" : "Secret series information retrieved"
+      }, {
+        "code" : 404,
+        "message" : "Secret series not found"
+      } ],
+      "produces" : [ "application/json" ]
+    } ]
+  }, {
     "path" : "/automation/v2/secrets/{name}/setversion",
     "operations" : [ {
       "method" : "POST",
@@ -476,6 +499,10 @@
           "format" : "int64"
         }
       }
+    },
+    "SanitizedSecret" : {
+      "id" : "SanitizedSecret",
+      "properties" : { }
     },
     "ApiDate" : {
       "id" : "ApiDate",

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -485,6 +485,25 @@ public class SecretResource {
   }
 
   /**
+   * Retrieve information on a secret series
+   *
+   * @excludeParams automationClient
+   * @param name Secret series name
+   *
+   * @responseMessage 200 Secret series information retrieved
+   * @responseMessage 404 Secret series not found
+   */
+  @Timed @ExceptionMetered
+  @GET
+  @Path("{name}/sanitized")
+  @Produces(APPLICATION_JSON)
+  public SanitizedSecret getSanitizedSecret(@Auth AutomationClient automationClient,
+      @PathParam("name") String name) {
+    return SanitizedSecret.fromSecretSeriesAndContent(
+        secretDAO.getSecretByName(name).orElseThrow(NotFoundException::new));
+  }
+
+  /**
    * Retrieve contents for a set of secret series.  Throws an exception
    * for unexpected errors (i. e. empty secret names or errors connecting to
    * the database); returns a response containing the contents of found

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -222,7 +222,7 @@ public class SecretResourceTest {
   //---------------------------------------------------------------------------------------
 
   @Test public void getSanitizedSecret_notFound() throws Exception {
-    Request get = clientRequest("/automation/v2/secrets/non-existent").get().build();
+    Request get = clientRequest("/automation/v2/secrets/non-existent/sanitized").get().build();
     Response httpResponse = mutualSslClient.newCall(get).execute();
     assertThat(httpResponse.code()).isEqualTo(404);
   }
@@ -237,7 +237,7 @@ public class SecretResourceTest {
         .type("password")
         .build());
 
-    SanitizedSecret response = lookupSantizedSecret("secret12455");
+    SanitizedSecret response = lookupSanitizedSecret("secret12455");
     assertThat(response.name()).isEqualTo("secret12455");
     assertThat(response.createdBy()).isEqualTo("client");
     assertThat(response.updatedBy()).isEqualTo("client");
@@ -975,7 +975,7 @@ public class SecretResourceTest {
     return mapper.readValue(httpResponse.body().byteStream(), SecretDetailResponseV2.class);
   }
 
-  SanitizedSecret lookupSantizedSecret(String name) throws IOException {
+  SanitizedSecret lookupSanitizedSecret(String name) throws IOException {
     Request get = clientRequest(format("/automation/v2/secrets/%s/sanitized", name)).get().build();
     Response httpResponse = mutualSslClient.newCall(get).execute();
     assertThat(httpResponse.code()).isEqualTo(200);


### PR DESCRIPTION
This should probably eventually replace secretInfo, which returns a SecretDetailResponseV2. This is the only place SecretDetailResponseV2 is used, and it would be nice to get rid of it.