### PR TITLE
Downgrade logback version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <slf4j.version>1.7.25</slf4j.version>
     <findbugs.version>3.0.1</findbugs.version>
     <mysql.version>5.1.45</mysql.version>
-    <logback.version>1.2.3</logback.version>
+    <logback.version>1.1.3</logback.version>
 
     <custom.build.directory>target</custom.build.directory>
   </properties>


### PR DESCRIPTION
Dropwizard before version 1.0.0 is incompatible with logback
after 1.1.3, because logback 1.1.5 and 1.1.6 added checks to
RollingFileAppender which cause errors in Dropwizard's
FileAppenderFactory (see Dropwizard issue 1478 on Github).  The
result is that Dropwizard before 1.0.0 will log to the console but
not to files if logback is after 1.1.3.  Keywhiz currently uses
Dropwizard 0.8.0, so logback must be kept to an early version
until it can be upgraded together with Dropwizard.