### PR TITLE
Track expiration of client certificates in database

### DIFF
--- a/api/src/main/java/keywhiz/api/ApiDate.java
+++ b/api/src/main/java/keywhiz/api/ApiDate.java
@@ -44,6 +44,10 @@ public class ApiDate {
     return epochSecond;
   }
 
+  public Instant toInstant() {
+    return Instant.ofEpochSecond(epochSecond);
+  }
+
   public ApiDate(long epochSecond) {
     this.epochSecond = epochSecond;
   }

--- a/api/src/main/java/keywhiz/api/model/AutomationClient.java
+++ b/api/src/main/java/keywhiz/api/model/AutomationClient.java
@@ -22,8 +22,8 @@ import javax.annotation.Nullable;
 public class AutomationClient extends Client {
   private AutomationClient(Client client) {
     super(client.getId(), client.getName(), client.getDescription(), client.getCreatedAt(),
-        client.getCreatedBy(), client.getUpdatedAt(), client.getUpdatedBy(), client.getLastSeen(), client.isEnabled(), true
-    );
+        client.getCreatedBy(), client.getUpdatedAt(), client.getUpdatedBy(), client.getLastSeen(),
+        client.getExpiration(), client.isEnabled(), true);
   }
 
   @Nullable public static AutomationClient of(Client client) {

--- a/api/src/main/java/keywhiz/api/model/Client.java
+++ b/api/src/main/java/keywhiz/api/model/Client.java
@@ -19,6 +19,7 @@ package keywhiz.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import java.time.Instant;
 import javax.annotation.Nullable;
 import keywhiz.api.ApiDate;
 
@@ -51,6 +52,9 @@ public class Client {
   @JsonProperty
   private final ApiDate lastSeen;
 
+  @JsonProperty
+  private final ApiDate expiration;
+
   /** True if client is enabled to retrieve secrets. */
   @JsonProperty
   private final boolean enabled;
@@ -67,6 +71,7 @@ public class Client {
       @JsonProperty("updatedAt") ApiDate updatedAt,
       @JsonProperty("updatedBy") @Nullable String updatedBy,
       @JsonProperty("lastSeen") @Nullable ApiDate lastSeen,
+      @JsonProperty("expiration") @Nullable ApiDate expiration,
       @JsonProperty("enabled") boolean enabled,
       @JsonProperty("automationAllowed") boolean automationAllowed) {
     this.id = id;
@@ -76,13 +81,18 @@ public class Client {
     this.createdBy = nullToEmpty(createdBy);
     this.updatedAt = updatedAt;
     this.updatedBy = nullToEmpty(updatedBy);
-    if (lastSeen != null && lastSeen.toEpochSecond() == 0L) {
-      lastSeen = null;
-    }
-    this.lastSeen = lastSeen;
+    this.lastSeen = cleanTimestamp(lastSeen);
+    this.expiration = cleanTimestamp(expiration);
 
     this.enabled = enabled;
     this.automationAllowed = automationAllowed;
+  }
+
+  private static ApiDate cleanTimestamp(ApiDate instant) {
+    if (instant != null && instant.toEpochSecond() == 0L) {
+      return null;
+    }
+    return instant;
   }
 
   public long getId() {
@@ -117,6 +127,10 @@ public class Client {
     return lastSeen;
   }
 
+  public ApiDate getExpiration() {
+    return expiration;
+  }
+
   public boolean isEnabled() {
     return enabled;
   }
@@ -137,6 +151,7 @@ public class Client {
           Objects.equal(this.updatedAt, that.updatedAt) &&
           Objects.equal(this.updatedBy, that.updatedBy) &&
           Objects.equal(this.lastSeen, that.lastSeen) &&
+          Objects.equal(this.expiration, that.expiration) &&
           this.enabled == that.enabled &&
           this.automationAllowed == that.automationAllowed) {
         return true;
@@ -148,8 +163,8 @@ public class Client {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(id, name, description, createdAt, createdBy, updatedAt, updatedBy, lastSeen,
-        enabled, automationAllowed);
+    return Objects.hashCode(id, name, description, createdAt, createdBy, updatedAt, updatedBy,
+        lastSeen, expiration, enabled, automationAllowed);
   }
 
   @Override
@@ -163,6 +178,7 @@ public class Client {
         .add("updatedAt", updatedAt)
         .add("updatedBy", updatedBy)
         .add("lastSeen", lastSeen)
+        .add("expiration", expiration)
         .add("enabled", enabled)
         .add("automationAllowed", automationAllowed)
         .toString();

--- a/api/src/test/java/keywhiz/api/automation/v2/ClientDetailResponseV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/ClientDetailResponseV2Test.java
@@ -50,7 +50,7 @@ public class ClientDetailResponseV2Test {
     ApiDate updatedAt = new ApiDate(1347246930);
 
     Client client = new Client(0, "Client Name", "Client Description", createdAt, "creator-user",
-        updatedAt, "updater-user", null, true, false);
+        updatedAt, "updater-user", null, null, true, false);
     ClientDetailResponseV2 clientDetailResponse = ClientDetailResponseV2.fromClient(client);
 
     assertThat(asJson(clientDetailResponse))

--- a/api/src/test/java/keywhiz/api/model/ClientTest.java
+++ b/api/src/test/java/keywhiz/api/model/ClientTest.java
@@ -33,6 +33,7 @@ public class ClientTest {
                                ApiDate.parse("2013-03-28T21:29:27.465Z"),
                                "keywhizAdmin",
                                 null,
+                                null,
                                 true,
                                 false
     );

--- a/cli/src/test/java/keywhiz/cli/commands/AddActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/AddActionTest.java
@@ -53,7 +53,7 @@ public class AddActionTest {
   AddActionConfig addActionConfig;
   AddAction addAction;
 
-  Client client = new Client(4, "newClient", null, null, null, null, null, null, true, false);
+  Client client = new Client(4, "newClient", null, null, null, null, null, null, null, true, false);
   Group group = new Group(4, "newGroup", null, null, null, null, null, null);
   Secret secret = new Secret(15, "newSecret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
       ImmutableMap.of(), 0, 1L, NOW, null);

--- a/cli/src/test/java/keywhiz/cli/commands/AssignActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/AssignActionTest.java
@@ -68,7 +68,7 @@ public class AssignActionTest {
     assignActionConfig.assignType = Arrays.asList("client");
     assignActionConfig.name = "non-existent-client-name";
     assignActionConfig.group = group.getName();
-    Client client = new Client(543, assignActionConfig.name, null, null, null, null, null, null, false, false);
+    Client client = new Client(543, assignActionConfig.name, null, null, null, null, null, null, null, false, false);
 
     // Group exists
     when(keywhizClient.getGroupByName(group.getName())).thenReturn(group);
@@ -89,7 +89,7 @@ public class AssignActionTest {
     assignActionConfig.assignType = Arrays.asList("client");
     assignActionConfig.name = "existing-client-name";
     assignActionConfig.group = group.getName();
-    Client client = new Client(5673, assignActionConfig.name, null, null, null, null, null, null, false, true);
+    Client client = new Client(5673, assignActionConfig.name, null, null, null, null, null, null, null, false, true);
 
     // Group exists
     when(keywhizClient.getGroupByName(group.getName())).thenReturn(group);

--- a/cli/src/test/java/keywhiz/cli/commands/DeleteActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/DeleteActionTest.java
@@ -85,7 +85,7 @@ public class DeleteActionTest {
     deleteActionConfig.deleteType = Arrays.asList("client");
     deleteActionConfig.name = "newClient";
 
-    Client client = new Client(657, "newClient", null, NOW, null, NOW, null, null, true, false);
+    Client client = new Client(657, "newClient", null, NOW, null, NOW, null, null, null, true, false);
     when(keywhizClient.getClientByName(deleteActionConfig.name)).thenReturn(client);
 
     deleteAction.run();

--- a/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
@@ -75,7 +75,7 @@ public class DescribeActionTest {
     describeActionConfig.describeType = Arrays.asList("client");
     describeActionConfig.name = "client-name";
 
-    Client client = new Client(0, describeActionConfig.name, null, null, null, null, null, null, false, false);
+    Client client = new Client(0, describeActionConfig.name, null, null, null, null, null, null, null, false, false);
     when(keywhizClient.getClientByName(describeActionConfig.name)).thenReturn(client);
 
     describeAction.run();

--- a/cli/src/test/java/keywhiz/cli/commands/UnassignActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/UnassignActionTest.java
@@ -47,7 +47,7 @@ public class UnassignActionTest {
   UnassignActionConfig unassignActionConfig;
   UnassignAction unassignAction;
 
-  Client client = new Client(11, "client-name", null, null, null, null, null, null, false, false);
+  Client client = new Client(11, "client-name", null, null, null, null, null, null, null, false, false);
   Group group = new Group(22, "group-name", null, null, null, null, null, null);
   Secret secret = new Secret(33, "secret-name", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
       ImmutableMap.of(), 0, 1L, NOW, null);

--- a/docs/apidocs/automation_v2-group-management.json
+++ b/docs/apidocs/automation_v2-group-management.json
@@ -217,6 +217,9 @@
         "lastSeen" : {
           "type" : "ApiDate"
         },
+        "expiration" : {
+          "type" : "ApiDate"
+        },
         "enabled" : {
           "type" : "boolean"
         },

--- a/docs/apidocs/automation_v2-secret-management.json
+++ b/docs/apidocs/automation_v2-secret-management.json
@@ -674,6 +674,9 @@
         "lastSeen" : {
           "type" : "ApiDate"
         },
+        "expiration" : {
+          "type" : "ApiDate"
+        },
         "enabled" : {
           "type" : "boolean"
         },

--- a/docs/apidocs/groups-admin.json
+++ b/docs/apidocs/groups-admin.json
@@ -191,6 +191,9 @@
         "lastSeen" : {
           "type" : "ApiDate"
         },
+        "expiration" : {
+          "type" : "ApiDate"
+        },
         "enabled" : {
           "type" : "boolean"
         },

--- a/docs/apidocs/secrets-admin.json
+++ b/docs/apidocs/secrets-admin.json
@@ -444,6 +444,9 @@
         "lastSeen" : {
           "type" : "ApiDate"
         },
+        "expiration" : {
+          "type" : "ApiDate"
+        },
         "enabled" : {
           "type" : "boolean"
         },

--- a/server/src/main/java/keywhiz/auth/mutualssl/CertificatePrincipal.java
+++ b/server/src/main/java/keywhiz/auth/mutualssl/CertificatePrincipal.java
@@ -19,6 +19,9 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
+import java.time.Instant;
+
+import static java.time.Instant.EPOCH;
 
 public class CertificatePrincipal implements Principal {
   private final String subjectDn;
@@ -31,6 +34,13 @@ public class CertificatePrincipal implements Principal {
 
   public ImmutableList<X509Certificate> getCertificateChain() {
     return certificateChain;
+  }
+
+  public Instant getCertificateExpiration() {
+    return certificateChain.stream()
+        .map(c -> c.getNotAfter().toInstant())
+        .min(Instant::compareTo)
+        .orElse(EPOCH);
   }
 
   /**

--- a/server/src/main/java/keywhiz/service/daos/ClientDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/ClientDAO.java
@@ -115,9 +115,7 @@ public class ClientDAO {
             .set(CLIENTS.LASTSEEN,
                 when(CLIENTS.LASTSEEN.isNull(), lastSeenValue)
                     .otherwise(greatest(CLIENTS.LASTSEEN, lastSeenValue)))
-            .set(CLIENTS.EXPIRATION,
-                when(CLIENTS.EXPIRATION.isNull(), expirationValue)
-                    .otherwise(greatest(CLIENTS.EXPIRATION, expirationValue)))
+            .set(CLIENTS.EXPIRATION, expirationValue)
             .where(CLIENTS.ID.eq(client.getId()))
             .execute();
       });

--- a/server/src/main/java/keywhiz/service/daos/ClientMapper.java
+++ b/server/src/main/java/keywhiz/service/daos/ClientMapper.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 class ClientMapper implements RecordMapper<ClientsRecord, Client> {
   public Client map(ClientsRecord r) {
     ApiDate lastSeen = Optional.ofNullable(r.getLastseen()).map(ApiDate::new).orElse(null);
+    ApiDate expiration = Optional.ofNullable(r.getExpiration()).map(ApiDate::new).orElse(null);
 
     return new Client(
         r.getId(),
@@ -41,6 +42,7 @@ class ClientMapper implements RecordMapper<ClientsRecord, Client> {
         new ApiDate(r.getUpdatedat()),
         r.getUpdatedby(),
         lastSeen,
+        expiration,
         r.getEnabled(),
         r.getAutomationallowed()
     );

--- a/server/src/main/resources/db/h2/migration/V7__add_client_expiration_column.sql
+++ b/server/src/main/resources/db/h2/migration/V7__add_client_expiration_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE clients ADD COLUMN expiration timestamp;

--- a/server/src/main/resources/db/mysql/migration/V7__add_client_expiration_column.sql
+++ b/server/src/main/resources/db/mysql/migration/V7__add_client_expiration_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE clients ADD expiration BIGINT;

--- a/server/src/test/java/keywhiz/service/providers/AutomationClientAuthFactoryTest.java
+++ b/server/src/test/java/keywhiz/service/providers/AutomationClientAuthFactoryTest.java
@@ -41,7 +41,7 @@ public class AutomationClientAuthFactoryTest {
 
   private static final Principal principal = SimplePrincipal.of("CN=principal,OU=blah");
   private static final Client client =
-      new Client(0, "principal", null, null, null, null, null, null, true, true);
+      new Client(0, "principal", null, null, null, null, null, null, null, true, true);
   private static final AutomationClient automationClient = AutomationClient.of(client);
 
   @Mock ContainerRequest request;
@@ -66,7 +66,7 @@ public class AutomationClientAuthFactoryTest {
   @Test(expected = ForbiddenException.class)
   public void automationClientRejectsClientsWithoutAutomation() {
     Client clientWithoutAutomation =
-        new Client(3423, "clientWithoutAutomation", null, null, null, null, null, null, true, false);
+        new Client(3423, "clientWithoutAutomation", null, null, null, null, null, null, null, true, false);
 
     when(securityContext.getUserPrincipal()).thenReturn(SimplePrincipal.of("CN=clientWithoutAutomation"));
     when(clientDAO.getClient("clientWithoutAutomation"))

--- a/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
+++ b/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
@@ -44,7 +44,7 @@ public class ClientAuthFactoryTest {
 
   private static final Principal principal = SimplePrincipal.of("CN=principal,OU=organizational-unit");
   private static final Client client =
-      new Client(0, "principal", null, null, null, null, null, null, true, false);
+      new Client(0, "principal", null, null, null, null, null, null, null, true, false);
 
   @Mock ContainerRequest request;
   @Mock SecurityContext securityContext;
@@ -74,7 +74,7 @@ public class ClientAuthFactoryTest {
 
   @Test(expected = NotAuthorizedException.class)
   public void rejectsDisabledClients() {
-    Client disabledClient =new Client(1, "disabled", null, null, null, null, null, null,
+    Client disabledClient =new Client(1, "disabled", null, null, null, null, null, null, null,
         false /* disabled */, false);
 
     when(securityContext.getUserPrincipal()).thenReturn(SimplePrincipal.of("CN=disabled"));
@@ -85,8 +85,8 @@ public class ClientAuthFactoryTest {
 
   @Test public void createsDbRecordForNewClient() throws Exception {
     ApiDate now = ApiDate.now();
-    Client newClient = new Client(2345L, "new-client", "desc", now, "automatic", now, "automatic", null,
-        true, false);
+    Client newClient = new Client(2345L, "new-client", "desc", now, "automatic", now, "automatic",
+        null, null, true, false);
 
     // lookup doesn't find client
     when(securityContext.getUserPrincipal()).thenReturn(SimplePrincipal.of("CN=new-client"));
@@ -102,7 +102,7 @@ public class ClientAuthFactoryTest {
   @Test public void updatesClientLastSeen() {
     when(securityContext.getUserPrincipal()).thenReturn(principal);
     factory.provide(request);
-    verify(clientDAO, times(1)).sawClient(any());
+    verify(clientDAO, times(1)).sawClient(any(), eq(principal));
   }
 
 }

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceIntegrationTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceIntegrationTest.java
@@ -17,6 +17,7 @@ package keywhiz.service.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
+import java.time.Instant;
 import keywhiz.IntegrationTestRule;
 import keywhiz.KeywhizService;
 import keywhiz.TestClients;
@@ -34,6 +35,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+import static java.time.Instant.EPOCH;
 import static keywhiz.testing.HttpClients.testUrl;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -80,6 +82,7 @@ public class SecretDeliveryResourceIntegrationTest {
     keywhizClient.login(DbSeedCommand.defaultUser, DbSeedCommand.defaultPassword.toCharArray());
     Client client = keywhizClient.getClientByName("client");
     assertThat(client.getExpiration()).isNotNull();
+    assertThat(client.getExpiration().toInstant().isAfter(EPOCH)).isTrue();
   }
 
   @Test public void returnsNotFoundWhenSecretUnspecified() throws Exception {

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
@@ -46,7 +46,7 @@ public class SecretDeliveryResourceTest {
   @Mock ClientDAO clientDAO;
   SecretDeliveryResource secretDeliveryResource;
 
-  final Client client = new Client(0, "principal", null, null, null, null, null, null, false, false);
+  final Client client = new Client(0, "principal", null, null, null, null, null, null, null, false, false);
   final Secret secret = new Secret(0, "secret_name", null, () -> "secret_value", "checksum", NOW, null, NOW, null,
       null, null, null, 0, 1L, NOW, null);
   final Secret secretBase64 = new Secret(1, "Base64With=", null, () -> "SGVsbG8=", "checksum", NOW, null, NOW,

--- a/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretsDeliveryResourceTest.java
@@ -56,7 +56,7 @@ public class SecretsDeliveryResourceTest {
 
   @Before public void setUp() {
     secretsDeliveryResource = new SecretsDeliveryResource(aclDAO);
-    client = new Client(0, "client_name", null, null, null, null, null, null, false, false);
+    client = new Client(0, "client_name", null, null, null, null, null, null, null, false, false);
   }
 
   @Test public void returnsEmptyJsonArrayWhenUserHasNoSecrets() throws Exception {

--- a/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
@@ -55,7 +55,7 @@ public class ClientsResourceTest {
 
   User user = User.named("user");
   ApiDate now = ApiDate.now();
-  Client client = new Client(1, "client", "1st client", now, "test", now, "test", null, true, false);
+  Client client = new Client(1, "client", "1st client", now, "test", now, "test", null, null, true, false);
   AuditLog auditLog = new SimpleLogger();
 
   ClientsResource resource;
@@ -65,8 +65,8 @@ public class ClientsResourceTest {
   }
 
   @Test public void listClients() {
-    Client client1 = new Client(1, "client", "1st client", now, "test", now, "test", null, true, false);
-    Client client2 = new Client(2, "client2", "2nd client", now, "test", now, "test", null, true, false);
+    Client client1 = new Client(1, "client", "1st client", now, "test", now, "test", null, null, true, false);
+    Client client2 = new Client(2, "client2", "2nd client", now, "test", now, "test", null, null, true, false);
 
     when(clientDAO.getClients()).thenReturn(ImmutableSet.of(client1, client2));
 

--- a/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
@@ -105,7 +105,7 @@ public class GroupsResourceTest {
         1136214245, 125L, now, "creator");
     when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of(secret));
 
-    Client client = new Client(1, "client", "desc", now, "creator", now, "creator", null, true, false);
+    Client client = new Client(1, "client", "desc", now, "creator", now, "creator", null, null, true, false);
     when(aclDAO.getClientsFor(group)).thenReturn(ImmutableSet.of(client));
 
     GroupDetailResponse response = resource.getGroup(user, new LongParam("4444"));

--- a/server/src/test/java/keywhiz/service/resources/admin/MembershipResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/MembershipResourceTest.java
@@ -46,7 +46,7 @@ public class MembershipResourceTest {
   @Mock AclDAO aclDAO;
 
   User user = User.named("user");
-  Client client = new Client(44, "client", "desc", NOW, "creator", NOW, "updater", null, true, false);
+  Client client = new Client(44, "client", "desc", NOW, "creator", NOW, "updater", null, null, true, false);
   Group group = new Group(55, "group", null, null, null, null, null, null);
   Secret secret = new Secret(66, "secret", null, () -> "shush", "checksum", NOW, null, NOW, null, null, null, null, 0, 1L, NOW, null);
   AuditLog auditLog = new SimpleLogger();

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -299,7 +299,7 @@ public class SecretsResourceTest {
 
   @Test
   public void includesAssociations() {
-    Client client = new Client(0, "client", null, null, null, null, null, null, false, false);
+    Client client = new Client(0, "client", null, null, null, null, null, null, null, false, false);
     Group group1 = new Group(0, "group1", null, null, null, null, null, null);
     Group group2 = new Group(0, "group2", null, null, null, null, null, null);
 

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationClientResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationClientResourceTest.java
@@ -49,7 +49,7 @@ public class AutomationClientResourceTest {
   @Mock AclDAO aclDAO;
   ApiDate now = ApiDate.now();
   AutomationClient automation = AutomationClient.of(
-      new Client(1, "automation", "Automation client", now, "test", now, "test", null, true, true));
+      new Client(1, "automation", "Automation client", now, "test", now, "test", null, null, true, true));
   AuditLog auditLog = new SimpleLogger();
 
   AutomationClientResource resource;
@@ -59,7 +59,7 @@ public class AutomationClientResourceTest {
   }
 
   @Test public void findClientByName() {
-    Client client = new Client(2, "client", "2nd client", now, "test", now, "test", null, true, false);
+    Client client = new Client(2, "client", "2nd client", now, "test", now, "test", null, null, true, false);
     Group firstGroup = new Group(1, "first Group", "testing group", now, "client", now, "client",
         ImmutableMap.of("app", "keywhiz"));
     Group secondGroup = new Group(2, "second Group", "testing group", now, "client", now, "client",
@@ -83,7 +83,7 @@ public class AutomationClientResourceTest {
   }
 
   @Test public void createNewClient() {
-    Client client = new Client(543L, "client", "2nd client", now, "test", now, "test", null, true, false);
+    Client client = new Client(543L, "client", "2nd client", now, "test", now, "test", null, null, true, false);
 
     CreateClientRequest request = new CreateClientRequest("client");
 
@@ -100,7 +100,7 @@ public class AutomationClientResourceTest {
   }
 
   @Test public void createNewClientAlreadyExists() {
-    Client client = new Client(543L, "client", "2nd client", now, "test", now, "test", null, true, false);
+    Client client = new Client(543L, "client", "2nd client", now, "test", now, "test", null, null, true, false);
 
     CreateClientRequest request = new CreateClientRequest("client");
 

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationGroupResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationGroupResourceTest.java
@@ -41,6 +41,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.isNotNull;
 import static org.mockito.Mockito.when;
 
 public class AutomationGroupResourceTest {
@@ -50,7 +51,7 @@ public class AutomationGroupResourceTest {
   @Mock AclDAO aclDAO;
   ApiDate now = ApiDate.now();
   AutomationClient automation = AutomationClient.of(
-      new Client(1, "automation", "Automation client", now, "test", now, "test", null, true, true));
+      new Client(1, "automation", "Automation client", now, "test", now, "test", null, null, true, true));
   AuditLog auditLog = new SimpleLogger();
 
   AutomationGroupResource resource;
@@ -89,7 +90,7 @@ public class AutomationGroupResourceTest {
     Group group = new Group(50, "testGroup", "testing group", now, "automation client", now,
         "automation client", ImmutableMap.of("app", "keywhiz"));
     Client groupClient =
-        new Client(1, "firstClient", "Group client", now, "test", now, "test", null, true, true);
+        new Client(1, "firstClient", "Group client", now, "test", now, "test", null, null, true, true);
     SanitizedSecret firstGroupSecret =
         SanitizedSecret.of(1, "name1", "desc", "checksum", now, "test", now, "test", null, "", null, 1136214245, 125L, now, "test");
     SanitizedSecret secondGroupSecret =

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationSecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationSecretResourceTest.java
@@ -62,7 +62,7 @@ public class AutomationSecretResourceTest {
   @Mock SecretDAO secretDAO;
 
   AutomationClient automation = AutomationClient.of(
-      new Client(1, "automation", "Automation client", NOW, "test", NOW, "test", null, true, true));
+      new Client(1, "automation", "Automation client", NOW, "test", NOW, "test", null, null, true, true));
   AuditLog auditLog = new SimpleLogger();
 
   @Before


### PR DESCRIPTION
Track expiration of client certificates in database, alongside the last seen value we already track. Updates at most once per 24 hour period. 