### PR TITLE
Use dropwizard-sentry rather than dropwizard-raven for alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
         <version>${logback.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.tradier</groupId>
-        <artifactId>dropwizard-raven</artifactId>
-        <version>0.7.1</version>
+        <groupId>org.dhatim</groupId>
+        <artifactId>dropwizard-sentry</artifactId>
+        <version>1.3.5-1</version>
       </dependency>
       <dependency>
         <groupId>com.beust</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -133,8 +133,9 @@
       <artifactId>dropwizard-java8-auth</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.tradier</groupId>
-      <artifactId>dropwizard-raven</artifactId>
+      <groupId>org.dhatim</groupId>
+      <artifactId>dropwizard-sentry</artifactId>
+      <version>1.3.5-1</version>
     </dependency>
 
     <!-- Necessary for object type detection. -->


### PR DESCRIPTION
The Raven library from Sentry is no longer supported.  This updates
Keywhiz to use the dropwizard-sentry library (forked from
dropwizard-raven and updated), which is based on the new Sentry
library.