### PR TITLE
Revert "Use dropwizard-sentry rather than dropwizard-raven for alerts"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
         <version>${logback.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.dhatim</groupId>
-        <artifactId>dropwizard-sentry</artifactId>
-        <version>1.3.5-1</version>
+        <groupId>com.tradier</groupId>
+        <artifactId>dropwizard-raven</artifactId>
+        <version>0.7.1</version>
       </dependency>
       <dependency>
         <groupId>com.beust</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -133,9 +133,8 @@
       <artifactId>dropwizard-java8-auth</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.dhatim</groupId>
-      <artifactId>dropwizard-sentry</artifactId>
-      <version>1.3.5-1</version>
+      <groupId>com.tradier</groupId>
+      <artifactId>dropwizard-raven</artifactId>
     </dependency>
 
     <!-- Necessary for object type detection. -->


### PR DESCRIPTION
This reverts commit 699f4bef4e96af78b4cef2fd635e0010781a70ba.

Dropwizard-sentry requires a version of Dropwizard significantly
after version 0.8.4 which the rest of Keywhiz uses.