### PR TITLE
Fix docker image with h2 profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@
 #     docker volume create --name keywhiz-db-devel
 #
 #   Initialize the database, apply migrations, and add administrative user:
-#     docker run -v keywhiz-db-devel:/data square/keywhiz migrate
-#     docker run -it -v keywhiz-db-devel:/data square/keywhiz add-user
+#     docker run --rm -v keywhiz-db-devel:/data square/keywhiz migrate
+#     docker run --rm -it -v keywhiz-db-devel:/data square/keywhiz add-user
 #
 #   Finally, run the server with the default development config:
-#     docker run -it -p 4444:4444 -v keywhiz-db-devel:/data square/keywhiz server
+#     docker run --rm -it -p 4444:4444 -v keywhiz-db-devel:/data square/keywhiz server
 #
 # *** Production setup wizard ***
 #   For production deployments, we have setup wizard that will initialize
@@ -45,7 +45,7 @@
 #
 FROM maven:3.5-jdk-11
 
-ARG MAVEN_PROFILE=h2
+ARG MAVEN_PROFILE=docker
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends --no-upgrade \
@@ -84,6 +84,7 @@ RUN useradd -ms /bin/false keywhiz && \
     chown keywhiz:keywhiz /data && \
     mkdir /secrets && \
     chown keywhiz:keywhiz /secrets
+
 USER keywhiz
 
 # Expose API port by default. Note that the admin console port

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -81,6 +81,21 @@
         <jooq.input-schema>PUBLIC</jooq.input-schema>
       </properties>
     </profile>
+
+    <profile>
+      <id>docker</id>
+      <properties>
+        <skipResetDatabase>true</skipResetDatabase>
+        <db.driver>org.h2.Driver</db.driver>
+        <db.create-url>jdbc:h2:/tmp/h2_data/keywhizdb_test</db.create-url>
+        <db.migrate-url>jdbc:h2:/tmp/h2_data/keywhizdb_test</db.migrate-url>
+        <db.username>root</db.username>
+        <db.migrations-path>h2/migration</db.migrations-path>
+        <jooq.dialect>org.jooq.meta.h2.H2Database</jooq.dialect>
+        <jooq.excludes />
+        <jooq.input-schema>PUBLIC</jooq.input-schema>
+      </properties>
+    </profile>
   </profiles>
 
   <build>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -36,6 +36,14 @@
         <test-yaml>src/test/resources/keywhiz-test.yaml.h2</test-yaml>
       </properties>
     </profile>
+
+    <profile>
+      <id>docker</id>
+      <properties>
+        <development-yaml>src/main/resources/keywhiz-development.yaml.docker</development-yaml>
+        <test-yaml>src/test/resources/keywhiz-test.yaml.docker</test-yaml>
+      </properties>
+    </profile>
   </profiles>
 
   <dependencies>

--- a/server/src/main/resources/keywhiz-development.yaml.docker
+++ b/server/src/main/resources/keywhiz-development.yaml.docker
@@ -1,0 +1,118 @@
+# Copyright 2013 Square, Inc.
+
+# ORIGINAL FILE IS keywhiz-development.yaml.h2. IF MODIFYING keywhiz-development.yaml CHANGES
+# MAY BE OVERWRITTEN!
+
+# Passwords/secrets should not be checked into SCM. However, sprinkled below are some passwords and
+# keys that are NOT considered sensitive and only to be used in development and testing.
+---
+
+server:
+  applicationConnectors:
+    - type: https
+      port: 4444
+      # The keystore stores your server's TLS certificate.
+      keyStorePath: server/src/main/resources/dev_and_test_keystore.p12
+      keyStorePassword: ponies
+      keyStoreType: PKCS12
+      # The trust store determines which certificates the server trusts.  This should contain your
+      # cert for the CA root that issues client certificates.
+      trustStorePath: server/src/main/resources/dev_and_test_truststore.p12
+      trustStorePassword: ponies
+      trustStoreType: PKCS12
+      # We want clients to provide a client cert.
+      wantClientAuth: true
+      # In the dev_and_test key material, we use the same CA for the client and server for easy
+      # management, but in production we issue client certs off a seperate root.  Because only
+      # that root is in the trustStore above, Dropwizard must be told not to validate its own cert
+      validateCerts: false
+      # Dropwizard changed validatePeers and validateCerts defaults from true to false in 1.1.x
+      validatePeers: true
+      # We don't use CRLDP or OCSP.
+      enableCRLDP: false
+      enableOCSP: false
+      crlPath: server/src/main/resources/dev_and_test.crl
+      supportedProtocols: [TLSv1.2]
+      supportedCipherSuites:
+        - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+        - TLS_RSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+        - TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+  adminConnectors:
+    - type: http
+      bindHost: localhost
+      port: 8085
+
+logging:
+  appenders:
+    - type: console
+      threshold: ALL
+
+## Use this logging configuration if you want EVERYTHING
+# logging:
+#   level: ALL
+
+environment: development
+
+database:
+  driverClass: org.h2.Driver
+  url: jdbc:h2:/data/keywhizdb_development
+  user: root
+  properties:
+    charSet: UTF-8
+  initialSize: 10
+  minSize: 10
+  maxSize: 10
+  # There is explicitly no password. Do not uncomment.
+  # password:
+
+readonlyDatabase:
+  driverClass: org.h2.Driver
+  url: jdbc:h2:/data/keywhizdb_development
+  user: root
+  properties:
+    charSet: UTF-8
+  readOnlyByDefault: true
+  initialSize: 32
+  minSize: 32
+  maxSize: 32
+  # There is explicitly no password. Do not uncomment.
+  # password:
+
+migrationsDir:
+  db/h2/migration
+
+statusCacheExpiry: PT1S
+
+userAuth:
+  type: bcrypt
+
+# Contains base64 of "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA". A real key could be generated with
+# `head -c 32 /dev/urandom | base64 > cookiekey.base64`.
+cookieKey: external:server/src/main/resources/dev_and_test_cookiekey.base64
+
+sessionCookie:
+  name: session
+  path: /admin
+
+xsrfCookie:
+  name: XSRF-TOKEN
+  path: /
+  httpOnly: false
+
+contentKeyStore:
+  path: derivation.jceks
+  type: JCEKS
+  password: CHANGE
+  alias: basekey


### PR DESCRIPTION
Docker container won't start out of the box.

1.  _/tmp/h2_data_ directory is created under _root_ ownership (on _mvn install_ step when testing performed) and when container is switched to _keywhiz_ migration step would fail with **permission denied** error.
```
keywhiz@0c938f337f4f:/usr/src/app$ ls /tmp/ -la
drwxr-xr-x 2 root    root    4096 Oct 29 16:54 h2_data
```
2. Starting the server requires _/tmp/h2_data_ volume to be persistent between _migrate_, _add-user_ and _server_ steps.