### PR TITLE
Bump logback version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <powermock.version>1.7.4</powermock.version>
     <slf4j.version>1.7.25</slf4j.version>
     <mysql.version>5.1.45</mysql.version>
-    <logback.version>1.1.7</logback.version>
+    <logback.version>1.2.3</logback.version>
 
     <custom.build.directory>target</custom.build.directory>
   </properties>


### PR DESCRIPTION
This version matches current version of logback used by dropwizard.

Also, this fixes a crash when a file appender is used for logging, e.g.:

```
logging:
  level: INFO
  appenders:
    - type: file
      currentLogFilename: /tmp/log/keywhiz.log.active
      archive: true
      archivedLogFilenamePattern: /tmp/log/keywhiz/keywhiz.log.%d.gz
      archivedFileCount: 10
```