### PR TITLE
Update dropwizard-raven library so it conforms to dropwizard 1.2.x API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <dropwizard.version>1.2.9</dropwizard.version>
+    <!-- 1.2.0-1 is the last version of dropwizard-raven JAR. The development continues under dropwizard-sentry -->
+    <dropwizard-raven.version>1.2.0-1</dropwizard-raven.version>
     <guice.version>4.2.2</guice.version>
     <jackson.version>2.9.6</jackson.version>
     <jooq.version>3.11.5</jooq.version>
@@ -105,9 +107,9 @@
         <version>${logback.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.tradier</groupId>
+        <groupId>org.dhatim</groupId>
         <artifactId>dropwizard-raven</artifactId>
-        <version>0.9.3</version>
+        <version>${dropwizard-raven.version}</version>
       </dependency>
       <dependency>
         <groupId>com.beust</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -129,7 +129,7 @@
       <artifactId>dropwizard-views-mustache</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.tradier</groupId>
+      <groupId>org.dhatim</groupId>
       <artifactId>dropwizard-raven</artifactId>
     </dependency>
 


### PR DESCRIPTION
It seems that github.com/tradier/dropwizard-raven has stopped receiving updates
(particularly there's a
[PR](https://github.com/tradier/dropwizard-raven/pull/20) that
specifically makes the lib compatible with dropwizard 1.2.x that has not
been merged since Nov 7, 2017). The maintenance work continues in the
[fork](github.com/dhatim/dropwizard-sentry) and there's one 1.2.x JAR
release under org.dhatim.dropwizard-raven. The project has seen been
renamed to dropwizard-sentry and new versions of the library (1.3.x+)
are published under org.dhatim.dropwizard-sentry, which I have noted in
the comments.