### PR TITLE
Fix configuration of key store path for templated-https connector

### DIFF
--- a/server/src/main/java/keywhiz/service/config/TemplatedHttpsConnectorFactory.java
+++ b/server/src/main/java/keywhiz/service/config/TemplatedHttpsConnectorFactory.java
@@ -34,7 +34,7 @@ public class TemplatedHttpsConnectorFactory extends HttpsConnectorFactory {
 
   @Override protected SslContextFactory configureSslContextFactory(SslContextFactory factory) {
     factory = super.configureSslContextFactory(factory);
-    String templatedPath = factory.getKeyStorePath();
+    String templatedPath = super.getKeyStorePath();
     factory.setKeyStorePath(convertTemplatedPath(templatedPath));
     return factory;
   }


### PR DESCRIPTION
As part of the jackson and dropwizard upgrade (#385)
ResourcesHttpsConnectorFactory received changes to fetching path to
KeyStore file, but TemplatedHttpsConnectorFactory got ommitted. This
commit fixes a problem that occurs when initializing a KeyStore using
hostname
substitution, e.g. the following config would crash keywhiz server:

```
server:
  applicationConnectors:
    - type: templated-https
      port: 4444
      keyStorePath: /path/to/keywhiz/secrets/keywhiz-%hostname%-s2s.jceks
      keyStorePassword: secret
      keyStoreType: JCEKS
```