### PR TITLE
Update changelog and bump version to 0.9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,49 @@
+v0.9.0: 2018-11-07
+
+  * Migrated to JDK 11 (now required to build Keywhiz)
+
+  * Added tracking of expiration of client certificates in the DB (#369)
+
+  * Added endpoint for encrypted group backup that allows to perform automated backups of secrets 
+    for groups that are required for bootstrapping a new datacenter by periodically calling the 
+    endpoint to produce a GPG-encrypted archive. The GPG key that is used for export should ideally 
+    be kept offline, only to be used in an emergency situation. (#361)
+
+  * Added an endpoint for retrieving a SanitizedSecret by name (#359)
+
+  * Improved BCrypt hash check on login (#374)
+
+  * Fixed building Docker image (#382 and #383)
+
+  * Removed PostgreSQL support (#347)
+
+  * Updated dependencies
+    - dropwizard updated to 1.2.9
+    - guice updated to 4.2.2
+    - jackson updated to 2.9.6
+    - jooq updated to 3.11.5
+    - mysql updated to 5.1.45
+    - logback updated to 1.2.3
+    - slf4j updated to 1.7.25
+    - powermock updated to 1.7.4
+    - updated dropwizard-raven to 1.2.0
+    - flyway updated to 4.2.0
+    - easymock updated to 3.6
+    - unboundid-ldapsdk updated to 4.0.1
+    - okhttp updated to 3.9.1
+    - mockito updated to 2.23.0
+    - hibernate-validator updated to 5.3.4
+    - jBcrypt updated to 0.4.1
+    - guava updated to 23.5
+    - auto-value updated to 1.5.4
+    - maven-shade-plugin updated to 3.0.0
+    - javax.annotation-api added
+    - jaxb-api added
+    - jaxb-runtime added
+    - jaxb-xjc added
+    - jaxb-jxc added
+
+
 v0.8.0: 2017-06-27
 
   * Removed old Web UI.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.squareup.keywhiz</groupId>
     <artifactId>keywhiz-parent</artifactId>
-    <version>0.8.1-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>keywhiz-api</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.squareup.keywhiz</groupId>
     <artifactId>keywhiz-parent</artifactId>
-    <version>0.8.1-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>keywhiz-cli</artifactId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.squareup.keywhiz</groupId>
     <artifactId>keywhiz-parent</artifactId>
-    <version>0.8.1-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>keywhiz-client</artifactId>

--- a/hkdf/pom.xml
+++ b/hkdf/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.squareup.keywhiz</groupId>
     <artifactId>keywhiz-parent</artifactId>
-    <version>0.8.1-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>keywhiz-hkdf</artifactId>

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>keywhiz-parent</artifactId>
     <groupId>com.squareup.keywhiz</groupId>
-    <version>0.8.1-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.squareup.keywhiz</groupId>
     <artifactId>keywhiz-parent</artifactId>
-    <version>0.8.1-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>keywhiz-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.squareup.keywhiz</groupId>
   <artifactId>keywhiz-parent</artifactId>
-  <version>0.8.1-SNAPSHOT</version>
+  <version>0.9.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Keywhiz (Parent)</name>
@@ -604,7 +604,7 @@ Place the jars in this directory: `/usr/libexec/java_home -v
               <version>1.1.3</version>
             </docletArtifact>
             <links>
-              <link>https://square.github.io/keywhiz/javadoc/</link>
+              <link>https://square.github.io/keywhiz/javadocs/</link>
             </links>
           </configuration>
         </plugin>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.squareup.keywhiz</groupId>
     <artifactId>keywhiz-parent</artifactId>
-    <version>0.8.1-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>keywhiz-server</artifactId>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>com.squareup.keywhiz</groupId>
       <artifactId>keywhiz-log</artifactId>
-      <version>0.8.1-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
     <!-- Logging -->

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.squareup.keywhiz</groupId>
     <artifactId>keywhiz-parent</artifactId>
-    <version>0.8.1-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>keywhiz-testing</artifactId>

--- a/update-javadocs.sh
+++ b/update-javadocs.sh
@@ -3,7 +3,7 @@
 # For whatever reason, javadocs only works for me if I've got a release checked
 # out, like `git checkout v0.8.0`
 
-mvn javadocs:javadocs
+mvn javadoc:javadoc
 
 for dir in api cli client hkdf log model server testing; do
   rm -r docs/javadocs/$dir


### PR DESCRIPTION
I'm not entirely sure what's the exact process of releasing 0.9, but my assumption was the following:
1. update changelog and keywhiz version to `0.9.1-SNAPSHOT` everywhere
2.branch off `0.9`, make version change to `0.9.0` and tag `v0.9.0`
3. release to maven
4. rebuild javadocs and merge changes.