### PR TITLE
Fix self-signed certificate in a certificate chain

### DIFF
--- a/docker/wizard.sh
+++ b/docker/wizard.sh
@@ -93,7 +93,7 @@ echo -n "Bundling certificate and private key into PKCS#12 keystore... "
 rm -f $KEYSTORE_PATH
 openssl pkcs12 \
     -export -out $KEYSTORE_PATH -inkey $PRIVATE_KEY_PEM -in $CERT_CHAIN_PEM \
-    -password "pass:$KEYSTORE_PASSWORD" -certfile $CA_BUNDLE_PEM
+    -password "pass:$KEYSTORE_PASSWORD"
 echo "done"
 
 echo "Bundling CA bundle into PKCS#12 trust store... "


### PR DESCRIPTION
When deploying using `wizard`, self-signed certificate happens to be in a certificate chain of the server.

`CERT_CHAIN_PEM` should contain end-point and all intermediaries (except self-signed).

Steps to reproduce:
Create CA and server certs:
```
mkdir certs && cd certs
certstrap init --key-bits "2048" --common-name "Keywhiz Server CA"
certstrap request-cert --key-bits "2048" --common-name "Keywhiz Server" \
    --domain localhost --ip 127.0.0.1
certstrap sign --CA "Keywhiz Server CA" "Keywhiz Server"
```
Run wizard:
```
docker run --rm -it -p 4444:4444 \
    -v keywhiz-data:/data \
    -v keywhiz-secrets:/secrets \
    square/keywhiz wizard
```
Copy certs and key:
```
docker cp out/Keywhiz_Server.crt `docker ps -lq`:/secrets/keywhiz.pem
docker cp out/Keywhiz_Server.key `docker ps -lq`:/secrets/keywhiz-key.pem
docker cp out/Keywhiz_Server_CA.crt `docker ps -lq`:/secrets/ca-bundle.pem
docker cp out/Keywhiz_Server_CA.crl `docker ps -lq`:/secrets/ca-crl.pem
```
Run the server:
```
docker run --rm -it -p 4444:4444 \
    -e KEYWHIZ_CONFIG=/data/keywhiz-docker.yaml \
    -v keywhiz-data:/data \
    -v keywhiz-secrets:/secrets square/keywhiz \
    server
```

Check that self-signed is in the chain:
`openssl s_client -connect localhost:4444 -showcerts`
