### PR TITLE
Add index by group ID on the memberships table

### DIFF
--- a/server/src/main/resources/db/h2/migration/V8__add_memberships_group_index.sql
+++ b/server/src/main/resources/db/h2/migration/V8__add_memberships_group_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX memberships_groupid_idx ON memberships (groupid);

--- a/server/src/main/resources/db/mysql/migration/V8__add_memberships_group_index.sql
+++ b/server/src/main/resources/db/mysql/migration/V8__add_memberships_group_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX memberships_groupid_idx ON memberships (groupid);


### PR DESCRIPTION
This should improve the behavior of the lookup for clients
associated with a secret, which requires JOINing on
the group ID in the memberships table.