### PR TITLE
Rename secrets on deletion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.6</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -26,6 +26,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
@@ -215,6 +216,7 @@ public class SecretSeriesDAO {
       if (r != null) {
         DSL.using(configuration)
             .update(SECRETS)
+            .set(SECRETS.NAME, transformNameForDeletion(name))
             .set(SECRETS.CURRENT, (Long) null)
             .set(SECRETS.UPDATEDAT, now)
             .where(SECRETS.ID.eq(r.getId()))
@@ -271,5 +273,12 @@ public class SecretSeriesDAO {
       DSLContext dslContext = DSL.using(checkNotNull(configuration));
       return new SecretSeriesDAO(dslContext, objectMapper, secretSeriesMapper);
     }
+  }
+
+  // create a new name for the deleted secret, so that deleted secret names can be reused, while
+  // still having a unique constraint on the name field in the DB
+  private String transformNameForDeletion(String name) {
+    long now = OffsetDateTime.now().toEpochSecond();
+    return String.format(".%s.deleted.%d.%s", name, now, UUID.randomUUID().toString());
   }
 }

--- a/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
@@ -118,6 +118,27 @@ public class SecretSeriesDAOTest {
     assertThat(secretSeriesDAO.getSecretSeriesById(id).isPresent()).isFalse();
   }
 
+  @Test public void deleteSecretSeriesByNameAndRecreate() {
+    long now = OffsetDateTime.now().toEpochSecond();
+    long id = secretSeriesDAO.createSecretSeries("toBeDeletedAndReplaced", "creator",
+        "", null, null, now);
+    long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
+        "checksum", "creator", null, 0, now);
+    secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
+    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced").get().currentVersion().isPresent()).isTrue();
+
+    secretSeriesDAO.deleteSecretSeriesByName("toBeDeletedAndReplaced");
+    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced").isPresent()).isFalse();
+    assertThat(secretSeriesDAO.getSecretSeriesById(id).isPresent()).isFalse();
+
+    id = secretSeriesDAO.createSecretSeries("toBeDeletedAndReplaced", "creator",
+        "", null, null, now);
+    contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah2",
+        "checksum", "creator", null, 0, now);
+    secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
+    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced").get().currentVersion().isPresent()).isTrue();
+  }
+
   @Test public void deleteSecretSeriesById() {
     long now = OffsetDateTime.now().toEpochSecond();
     long id = secretSeriesDAO.createSecretSeries("toBeDeleted_deleteSecretSeriesById",


### PR DESCRIPTION
We construct a unique new name that contains the original name, the word "deleted", and a timestamp. This way deleted secrets can be found, but the original name can be reused safely.

Also adds a restriction on secret names starting with a period, to ensure that the auto-generated names for deleted secrets can't be taken (as they start with a period).

This is being added in preparation for adding a uniqueness constraint for secret names to the database. We want to add the uniqueness constraint because we enforce uniqueness in a different layer of our secrets management system, and we're experiencing a race condition where multiple secrets with the same name are being created essentially simultaneously, and it's causing some maintenance pain.

The tests I've added to delete and then re-create a secret with the same name don't add a lot of value at this stage, but will serve as regression tests when the uniqueness constraint is added. Directly verifying in tests that the rename is as expected would be a bit more complicated since a) the new names are unique and not guessable, and b) would require querying the database directly from the test, since the current database abstraction layer deliberately excludes deleted secrets. Right now, I think the tests sufficiently prove that we can still properly delete secrets after this change.