### PR TITLE
Adds restriction on secret name length

### DIFF
--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -202,6 +202,12 @@ public class SecretDAOTest {
     secretDAO.createSecret(name, "some secret", "checksum", "creator", ImmutableMap.of(), 0, "", null, ImmutableMap.of());
   }
 
+  @Test(expected = BadRequestException.class)
+  public void createSecretFailsIfNameIsTooLong() {
+    String name = "newSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecret";
+    secretDAO.createSecret(name, "some secret", "checksum", "creator", ImmutableMap.of(), 0, "", null, ImmutableMap.of());
+  }
+
   @Test public void createSecretSucceedsIfCurrentVersionIsNull() {
     String name = "newSecret";
     long firstId = secretDAO.createSecret(name, "content1", cryptographer.computeHmac("content1".getBytes(UTF_8)), "creator1",


### PR DESCRIPTION
The database field has a limit of 255 characters, and the new feature to rename on deletion makes secret names longer when they are deleted. A max length restriction is necessary to prevent a lengthy name from being un-deletable.