### PR TITLE
Add command to remove database rows for deleted secrets

### DIFF
--- a/server/src/main/java/keywhiz/commands/DropDeletedSecretsCommand.java
+++ b/server/src/main/java/keywhiz/commands/DropDeletedSecretsCommand.java
@@ -1,0 +1,110 @@
+package keywhiz.commands;
+
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.setup.Bootstrap;
+import java.io.Console;
+import java.util.Scanner;
+import javax.inject.Inject;
+import keywhiz.KeywhizConfig;
+import keywhiz.service.daos.SecretDAO;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.joda.time.DateTime;
+
+import static java.lang.String.format;
+
+/**
+ * Secrets which are deleted from Keywhiz--whether through the admin client or the automation
+ * interface--are not actually removed from Keywhiz' database.  Instead, the link between the
+ * "secret series" and "secret contents" tables is broken, but it is still possible to reconnect
+ * them manually and restore a deleted secret.
+ *
+ * This command permanently drops information about deleted secrets from the database.  This is
+ * clearly dangerous, so it should be run only when it is certain that the deleted secrets will not
+ * need to be manually recovered.
+ */
+public class DropDeletedSecretsCommand extends ConfiguredCommand<KeywhizConfig> {
+  protected static final String INPUT_DELETED_BEFORE = "deleted-before";
+  private SecretDAO secretDAO;
+
+  @Inject
+  protected DropDeletedSecretsCommand(SecretDAO secretDAO) {
+    super("drop-deleted-secrets", "PERMANENTLY REMOVES database records for deleted secrets");
+    this.secretDAO = secretDAO;
+  }
+
+  @Override public void configure(Subparser subparser) {
+    subparser.addArgument("--deleted-before")
+        .dest(INPUT_DELETED_BEFORE)
+        .type(String.class)
+        .required(true)
+        .help(
+            "secrets deleted before this date will be PERMANENTLY REMOVED.  Format: 2006-01-02T15:04:05Z");
+  }
+
+  @Override public void run(Bootstrap<KeywhizConfig> bootstrap, Namespace namespace,
+      KeywhizConfig config) {
+    // validate the input
+    String deletedBeforeStr = namespace.getString(INPUT_DELETED_BEFORE);
+    DateTime deletedBefore = getDateIfValid(deletedBeforeStr);
+    if (deletedBefore == null) {
+      return;
+    }
+
+    // determine how many secrets would be affected and get user confirmation
+    long affectedCount = secretDAO.countSecretsDeletedBeforeDate(deletedBefore);
+
+    System.out.format(
+        "WARNING: This will PERMANENTLY remove all secrets deleted before %s.  %d secrets will be removed.  Confirm? (y/n)\n",
+        deletedBefore.toString(), affectedCount);
+
+    String confirm;
+    if (System.console() != null) {
+      Console console = System.console();
+      confirm = console.readLine();
+    } else {
+      // In test environments, system.console may not be set; fall back to System.in.
+      Scanner scanner = new Scanner(System.in);
+      confirm = scanner.nextLine();
+    }
+    if (confirm == null || !(confirm.equalsIgnoreCase("y") || confirm.equalsIgnoreCase("yes"))) {
+      System.out.format("Received `%s` which is not 'y'/'yes'; not removing secrets.\n", confirm);
+      return;
+    }
+
+    // remove the secrets
+    System.out.format("Removing %d secrets which were deleted before %s from the database\n",
+        affectedCount, deletedBefore.toString());
+    secretDAO.dangerPermanentlyRemoveSecretsDeletedBeforeDate(deletedBefore);
+  }
+
+  private DateTime getDateIfValid(String deletedBeforeStr) {
+    // the date string must be specified
+    if (deletedBeforeStr == null || deletedBeforeStr.isEmpty()) {
+      System.out.println(
+          "Empty input for deleted-before; must specify a valid date in the format 2006-01-02T15:04:05Z");
+      return null;
+    }
+
+    // the date must parse
+    DateTime before;
+    try {
+      before = new DateTime(deletedBeforeStr);
+    } catch (Exception e) {
+      System.out.println(
+          "Invalid input for deleted-before; must specify a valid date in the format 2006-01-02T15:04:05Z.  Parsing threw exception.");
+      e.printStackTrace();
+      return null;
+    }
+
+    // the date must be in the past
+    if (before.isAfterNow() || before.isEqualNow()) {
+      System.out.println(
+          format("Cutoff date for deletion must be before current time; input of %s was invalid",
+              before.toString()));
+      return null;
+    }
+
+    return before;
+  }
+}

--- a/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
@@ -132,8 +132,7 @@ class SecretContentDAO {
   }
 
   public Optional<ImmutableList<SecretContent>> getSecretVersionsBySecretId(long id,
-      int versionIdx,
-      int numVersions) {
+      int versionIdx, int numVersions) {
     Result<SecretsContentRecord> r = dslContext.selectFrom(SECRETS_CONTENT)
         .where(SECRETS_CONTENT.SECRETID.eq(id))
         .orderBy(SECRETS_CONTENT.CREATEDAT.desc())
@@ -147,6 +146,20 @@ class SecretContentDAO {
     } else {
       return Optional.empty();
     }
+  }
+
+  /**
+   * PERMANENTLY REMOVE database records from `secrets_contents` which are associated with the given
+   * list of SECRETS IDs.  (Does not affect the `secrets` table.)
+   *
+   * @param ids IDs in the `secrets` table; `secrets_contents` records linked to these by
+   * `secrets_content.secretid` will be PERMANENTLY REMOVED
+   * @returns the number of records which were removed
+   */
+  public long dangerPermanentlyRemoveRecordsForGivenSecretsIDs(List<Long> ids) {
+    return dslContext.deleteFrom(SECRETS_CONTENT)
+        .where(SECRETS_CONTENT.SECRETID.in(ids))
+        .execute();
   }
 
   public static class SecretContentDAOFactory implements DAOFactory<SecretContentDAO> {

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -404,6 +404,14 @@ public class SecretDAO {
   }
 
   /**
+   * Counts the total number of deleted secrets.
+   */
+  public int countDeletedSecrets() {
+    return secretSeriesDAOFactory.using(dslContext.configuration())
+        .countDeletedSecretSeries();
+  }
+
+  /**
    * Counts the number of secrets deleted before the specified cutoff.
    *
    * @param deleteBefore the cutoff date; secrets deleted before this date will be counted
@@ -424,17 +432,18 @@ public class SecretDAO {
    * Unlike the "delete" endpoints above, THIS REMOVAL IS PERMANENT and cannot be undone by editing
    * the database to restore the "current" entries.
    *
-   * @param deleteBefore the cutoff date; secrets deleted before this date will be deleted
+   * @param deletedBefore the cutoff date; secrets deleted before this date will be removed from
+   * the database
    * @param sleepMillis how many milliseconds to sleep between each batch of removals
    */
-  public void dangerPermanentlyRemoveSecretsDeletedBeforeDate(DateTime deleteBefore,
+  public void dangerPermanentlyRemoveSecretsDeletedBeforeDate(DateTime deletedBefore,
       int sleepMillis) throws InterruptedException {
-    checkArgument(deleteBefore != null);
+    checkArgument(deletedBefore != null);
     SecretSeriesDAO secretSeriesDAO = secretSeriesDAOFactory.using(dslContext.configuration());
     SecretContentDAO secretContentDAO = secretContentDAOFactory.using(dslContext.configuration());
 
     // identify the secrets deleted before this date
-    List<Long> ids = secretSeriesDAO.getIdsForSecretSeriesDeletedBeforeDate(deleteBefore);
+    List<Long> ids = secretSeriesDAO.getIdsForSecretSeriesDeletedBeforeDate(deletedBefore);
 
     // batch the list of secrets to be removed, to reduce load on the database
     List<List<Long>> partitionedIds = Lists.partition(ids, MAX_ROWS_REMOVED_PER_TRANSACTION);

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -425,8 +425,10 @@ public class SecretDAO {
    * the database to restore the "current" entries.
    *
    * @param deleteBefore the cutoff date; secrets deleted before this date will be deleted
+   * @param sleepMillis how many milliseconds to sleep between each batch of removals
    */
-  public void dangerPermanentlyRemoveSecretsDeletedBeforeDate(DateTime deleteBefore) {
+  public void dangerPermanentlyRemoveSecretsDeletedBeforeDate(DateTime deleteBefore,
+      int sleepMillis) throws InterruptedException {
     checkArgument(deleteBefore != null);
     SecretSeriesDAO secretSeriesDAO = secretSeriesDAOFactory.using(dslContext.configuration());
     SecretContentDAO secretContentDAO = secretContentDAOFactory.using(dslContext.configuration());
@@ -442,6 +444,9 @@ public class SecretDAO {
 
       // permanently remove the `secrets` entries for these secrets
       secretSeriesDAO.dangerPermanentlyRemoveRecordsForGivenIDs(idBatch);
+
+      // sleep
+      Thread.sleep(sleepMillis);
     }
   }
 

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -48,6 +48,7 @@ import static keywhiz.jooq.tables.Accessgrants.ACCESSGRANTS;
 import static keywhiz.jooq.tables.Groups.GROUPS;
 import static keywhiz.jooq.tables.Secrets.SECRETS;
 import static keywhiz.jooq.tables.SecretsContent.SECRETS_CONTENT;
+import static org.jooq.impl.DSL.count;
 import static org.jooq.impl.DSL.decode;
 import static org.jooq.impl.DSL.least;
 import static org.jooq.impl.DSL.val;
@@ -249,6 +250,17 @@ public class SecretSeriesDAO {
           .where(ACCESSGRANTS.SECRETID.eq(id))
           .execute();
     });
+  }
+
+  /**
+   * Count the number of deleted secret series
+   */
+  public int countDeletedSecretSeries() {
+    return dslContext.selectCount()
+        .from(SECRETS)
+        .where(SECRETS.CURRENT.isNull())
+        .fetchOne()
+        .value1();
   }
 
   /**

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -34,6 +34,7 @@ import keywhiz.api.model.Group;
 import keywhiz.api.model.SecretSeries;
 import keywhiz.jooq.tables.records.SecretsRecord;
 import keywhiz.service.config.Readonly;
+import org.joda.time.DateTime;
 import org.jooq.Configuration;
 import org.jooq.DSLContext;
 import org.jooq.Field;
@@ -160,12 +161,14 @@ public class SecretSeriesDAO {
   }
 
   public Optional<SecretSeries> getSecretSeriesById(long id) {
-    SecretsRecord r = dslContext.fetchOne(SECRETS, SECRETS.ID.eq(id).and(SECRETS.CURRENT.isNotNull()));
+    SecretsRecord r =
+        dslContext.fetchOne(SECRETS, SECRETS.ID.eq(id).and(SECRETS.CURRENT.isNotNull()));
     return Optional.ofNullable(r).map(secretSeriesMapper::map);
   }
 
   public Optional<SecretSeries> getSecretSeriesByName(String name) {
-    SecretsRecord r = dslContext.fetchOne(SECRETS, SECRETS.NAME.eq(name).and(SECRETS.CURRENT.isNotNull()));
+    SecretsRecord r =
+        dslContext.fetchOne(SECRETS, SECRETS.NAME.eq(name).and(SECRETS.CURRENT.isNotNull()));
     return Optional.ofNullable(r).map(secretSeriesMapper::map);
   }
 
@@ -212,7 +215,8 @@ public class SecretSeriesDAO {
   public void deleteSecretSeriesByName(String name) {
     long now = OffsetDateTime.now().toEpochSecond();
     dslContext.transaction(configuration -> {
-      SecretsRecord r = DSL.using(configuration).fetchOne(SECRETS, SECRETS.NAME.eq(name).and(SECRETS.CURRENT.isNotNull()));
+      SecretsRecord r = DSL.using(configuration)
+          .fetchOne(SECRETS, SECRETS.NAME.eq(name).and(SECRETS.CURRENT.isNotNull()));
       if (r != null) {
         DSL.using(configuration)
             .update(SECRETS)
@@ -245,6 +249,33 @@ public class SecretSeriesDAO {
           .where(ACCESSGRANTS.SECRETID.eq(id))
           .execute();
     });
+  }
+
+  /**
+   * Identify all secret series which were deleted before the given date.
+   *
+   * @param deleteBefore the cutoff date; secrets deleted before this date will be counted
+   */
+  public List<Long> getIdsForSecretSeriesDeletedBeforeDate(DateTime deleteBefore) {
+    long deleteBeforeSeconds = deleteBefore.getMillis() / 1000;
+    return dslContext.select(SECRETS.ID)
+        .from(SECRETS)
+        .where(SECRETS.CURRENT.isNull())
+        .and(SECRETS.UPDATEDAT.le(deleteBeforeSeconds))
+        .fetch(SECRETS.ID);
+  }
+
+  /**
+   * PERMANENTLY REMOVE database records from `secrets` which have the given list of IDs. Does not
+   * affect the `secrets_content` table.
+   *
+   * @param ids the IDs in the `secrets` table to be PERMANENTLY REMOVED
+   * @returns the number of records which were removed
+   */
+  public long dangerPermanentlyRemoveRecordsForGivenIDs(List<Long> ids) {
+    return dslContext.deleteFrom(SECRETS)
+        .where(SECRETS.ID.in(ids))
+        .execute();
   }
 
   public static class SecretSeriesDAOFactory implements DAOFactory<SecretSeriesDAO> {

--- a/server/src/test/java/keywhiz/commands/DropDeletedSecretsCommandTest.java
+++ b/server/src/test/java/keywhiz/commands/DropDeletedSecretsCommandTest.java
@@ -1,0 +1,275 @@
+package keywhiz.commands;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import javax.inject.Inject;
+import keywhiz.KeywhizTestRunner;
+import keywhiz.api.ApiDate;
+import keywhiz.api.model.SecretContent;
+import keywhiz.api.model.SecretSeries;
+import keywhiz.api.model.SecretSeriesAndContent;
+import keywhiz.service.crypto.ContentCryptographer;
+import keywhiz.service.crypto.CryptoFixtures;
+import keywhiz.service.daos.SecretDAO;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.jooq.DSLContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toList;
+import static keywhiz.jooq.tables.Secrets.SECRETS;
+import static keywhiz.jooq.tables.SecretsContent.SECRETS_CONTENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(KeywhizTestRunner.class)
+public class DropDeletedSecretsCommandTest {
+  @Inject private DSLContext jooqContext;
+  @Inject private ObjectMapper objectMapper;
+  @Inject private SecretDAO.SecretDAOFactory secretDAOFactory;
+
+  private final static ContentCryptographer cryptographer = CryptoFixtures.contentCryptographer();
+  private final static ApiDate january18 = ApiDate.parse("2018-01-01T00:00:00Z");
+  private final static ApiDate january19 = ApiDate.parse("2019-01-01T00:00:00Z");
+  private ImmutableMap<String, String> emptyMetadata = ImmutableMap.of();
+
+  // an undeleted secret
+  private SecretSeries series1 =
+      SecretSeries.of(1, "secret1", "desc1", january18, "creator", january19, "updater", null, null,
+          101L);
+  private String content = "c2VjcmV0MQ==";
+  private String encryptedContent =
+      cryptographer.encryptionKeyDerivedFrom(series1.name()).encrypt(content);
+  private SecretContent content1 =
+      SecretContent.of(101, 1, encryptedContent, "checksum", january18, "creator", january18,
+          "updater", emptyMetadata, 0);
+  private SecretSeriesAndContent secret1 = SecretSeriesAndContent.of(series1, content1);
+
+  // a secret deleted on 2018-01-01T00:00:00Z
+  private SecretSeries series2 =
+      SecretSeries.of(2, "secret2", "desc2", january18, "creator", january18, "updater", null, null,
+          null);
+  private SecretContent content2a =
+      SecretContent.of(102, 2, encryptedContent, "checksum", january18, "creator", january18,
+          "updater", emptyMetadata, 0);
+  private SecretSeriesAndContent secret2a = SecretSeriesAndContent.of(series2, content2a);
+
+  private SecretContent content2b =
+      SecretContent.of(103, 2, "some other content", "checksum", january18, "creator", january18,
+          "updater", emptyMetadata, 0);
+  private SecretSeriesAndContent secret2b = SecretSeriesAndContent.of(series2, content2b);
+
+  // a secret deleted on 2019-01-01T00:00:00Z
+  private SecretSeries series3 =
+      SecretSeries.of(3, "secret3", "desc3", january18, "creator", january19, "updater", null, null,
+          null);
+  private SecretContent content3 =
+      SecretContent.of(104, 3, encryptedContent, "checksum", january18, "creator", january18,
+          "updater", emptyMetadata, 0);
+  private SecretSeriesAndContent secret3 = SecretSeriesAndContent.of(series3, content3);
+
+  @Before
+  public void setUp() throws Exception {
+    // store an undeleted secret
+    jooqContext.insertInto(SECRETS)
+        .set(SECRETS.ID, series1.id())
+        .set(SECRETS.NAME, series1.name())
+        .set(SECRETS.DESCRIPTION, series1.description())
+        .set(SECRETS.CREATEDBY, series1.createdBy())
+        .set(SECRETS.CREATEDAT, series1.createdAt().toEpochSecond())
+        .set(SECRETS.UPDATEDBY, series1.updatedBy())
+        .set(SECRETS.UPDATEDAT, series1.updatedAt().toEpochSecond())
+        .set(SECRETS.CURRENT, series1.currentVersion().orElse(null))
+        .execute();
+
+    jooqContext.insertInto(SECRETS_CONTENT)
+        .set(SECRETS_CONTENT.ID, secret1.content().id())
+        .set(SECRETS_CONTENT.SECRETID, secret1.series().id())
+        .set(SECRETS_CONTENT.ENCRYPTED_CONTENT, secret1.content().encryptedContent())
+        .set(SECRETS_CONTENT.CONTENT_HMAC, "checksum")
+        .set(SECRETS_CONTENT.CREATEDBY, secret1.content().createdBy())
+        .set(SECRETS_CONTENT.CREATEDAT, secret1.content().createdAt().toEpochSecond())
+        .set(SECRETS_CONTENT.UPDATEDBY, secret1.content().updatedBy())
+        .set(SECRETS_CONTENT.UPDATEDAT, secret1.content().updatedAt().toEpochSecond())
+        .set(SECRETS_CONTENT.METADATA,
+            objectMapper.writeValueAsString(secret1.content().metadata()))
+        .execute();
+
+    // store a secret deleted on 2018-01-01T00:00:00Z
+    jooqContext.insertInto(SECRETS)
+        .set(SECRETS.ID, series2.id())
+        .set(SECRETS.NAME, series2.name())
+        .set(SECRETS.DESCRIPTION, series2.description())
+        .set(SECRETS.CREATEDBY, series2.createdBy())
+        .set(SECRETS.CREATEDAT, series2.createdAt().toEpochSecond())
+        .set(SECRETS.UPDATEDBY, series2.updatedBy())
+        .set(SECRETS.UPDATEDAT, series2.updatedAt().toEpochSecond())
+        .set(SECRETS.CURRENT, series2.currentVersion().orElse(null))
+        .execute();
+
+    jooqContext.insertInto(SECRETS_CONTENT)
+        .set(SECRETS_CONTENT.ID, secret2a.content().id())
+        .set(SECRETS_CONTENT.SECRETID, secret2a.series().id())
+        .set(SECRETS_CONTENT.ENCRYPTED_CONTENT, secret2a.content().encryptedContent())
+        .set(SECRETS_CONTENT.CONTENT_HMAC, "checksum")
+        .set(SECRETS_CONTENT.CREATEDBY, secret2a.content().createdBy())
+        .set(SECRETS_CONTENT.CREATEDAT, secret2a.content().createdAt().toEpochSecond())
+        .set(SECRETS_CONTENT.UPDATEDBY, secret2a.content().updatedBy())
+        .set(SECRETS_CONTENT.UPDATEDAT, secret2a.content().updatedAt().toEpochSecond())
+        .set(SECRETS_CONTENT.METADATA,
+            objectMapper.writeValueAsString(secret2a.content().metadata()))
+        .execute();
+
+    jooqContext.insertInto(SECRETS_CONTENT)
+        .set(SECRETS_CONTENT.ID, secret2b.content().id())
+        .set(SECRETS_CONTENT.SECRETID, secret2b.series().id())
+        .set(SECRETS_CONTENT.ENCRYPTED_CONTENT, secret2b.content().encryptedContent())
+        .set(SECRETS_CONTENT.CONTENT_HMAC, "checksum")
+        .set(SECRETS_CONTENT.CREATEDBY, secret2b.content().createdBy())
+        .set(SECRETS_CONTENT.CREATEDAT, secret2b.content().createdAt().toEpochSecond())
+        .set(SECRETS_CONTENT.UPDATEDBY, secret2b.content().updatedBy())
+        .set(SECRETS_CONTENT.UPDATEDAT, secret2b.content().updatedAt().toEpochSecond())
+        .set(SECRETS_CONTENT.METADATA,
+            objectMapper.writeValueAsString(secret2b.content().metadata()))
+        .execute();
+
+    // store a secret deleted on 2019-01-01T00:00:00Z
+    jooqContext.insertInto(SECRETS)
+        .set(SECRETS.ID, series3.id())
+        .set(SECRETS.NAME, series3.name())
+        .set(SECRETS.DESCRIPTION, series3.description())
+        .set(SECRETS.CREATEDBY, series3.createdBy())
+        .set(SECRETS.CREATEDAT, series3.createdAt().toEpochSecond())
+        .set(SECRETS.UPDATEDBY, series3.updatedBy())
+        .set(SECRETS.UPDATEDAT, series3.updatedAt().toEpochSecond())
+        .set(SECRETS.CURRENT, series3.currentVersion().orElse(null))
+        .execute();
+
+    jooqContext.insertInto(SECRETS_CONTENT)
+        .set(SECRETS_CONTENT.ID, secret3.content().id())
+        .set(SECRETS_CONTENT.SECRETID, secret3.series().id())
+        .set(SECRETS_CONTENT.ENCRYPTED_CONTENT, secret3.content().encryptedContent())
+        .set(SECRETS_CONTENT.CONTENT_HMAC, "checksum")
+        .set(SECRETS_CONTENT.CREATEDBY, secret3.content().createdBy())
+        .set(SECRETS_CONTENT.CREATEDAT, secret3.content().createdAt().toEpochSecond())
+        .set(SECRETS_CONTENT.UPDATEDBY, secret3.content().updatedBy())
+        .set(SECRETS_CONTENT.UPDATEDAT, secret3.content().updatedAt().toEpochSecond())
+        .set(SECRETS_CONTENT.METADATA,
+            objectMapper.writeValueAsString(secret3.content().metadata()))
+        .execute();
+  }
+
+  @Test
+  public void testSecretDeletion_allDeletedSecrets() {
+    runCommandWithConfirmationAndDate("yes", "2019-02-01T00:00:00Z");
+
+    // check the database state; secret2 and secret3 should have been deleted
+    checkExpectedSecretSeries(ImmutableList.of(series1), ImmutableList.of(series2, series3));
+    checkExpectedSecretContents(ImmutableList.of(content1),
+        ImmutableList.of(content2a, content2b, content3));
+  }
+
+  @Test
+  public void testSecretDeletion_filterByDate_someSecretsRemoved() {
+    runCommandWithConfirmationAndDate("yes", "2018-02-01T00:00:00Z");
+
+    // check the database state; only secret2 should have been deleted
+    checkExpectedSecretSeries(ImmutableList.of(series1, series3), ImmutableList.of(series2));
+    checkExpectedSecretContents(ImmutableList.of(content1, content3),
+        ImmutableList.of(content2a, content2b));
+  }
+
+  @Test
+  public void testSecretDeletion_filterByDate_noSecretsRemoved() {
+    runCommandWithConfirmationAndDate("yes", "2017-02-01T00:00:00Z");
+
+    // check the database state; no secrets should have been deleted
+    checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
+    checkExpectedSecretContents(ImmutableList.of(content1, content2a, content2b, content3),
+        ImmutableList.of());
+  }
+
+  @Test
+  public void testSecretDeletion_futureDate() {
+    runCommandWithConfirmationAndDate("yes", "5000-02-01T00:00:00Z");
+
+    // check the database state; secrets should NOT have been deleted
+    checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
+    checkExpectedSecretContents(ImmutableList.of(content1, content2a, content2b, content3),
+        ImmutableList.of());
+  }
+
+  @Test
+  public void testSecretDeletion_invalidDate() {
+    runCommandWithConfirmationAndDate("yes", "notadate");
+
+    // check the database state; secrets should NOT have been deleted
+    checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
+    checkExpectedSecretContents(ImmutableList.of(content1, content2a, content2b, content3),
+        ImmutableList.of());
+  }
+
+  @Test
+  public void testSecretDeletion_noConfirmation() {
+    runCommandWithConfirmationAndDate("no", "2019-02-01T00:00:00Z");
+
+    // check the database state; secrets should NOT have been deleted
+    checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
+    checkExpectedSecretContents(ImmutableList.of(content1, content2a, content2b, content3),
+        ImmutableList.of());
+  }
+
+  private void runCommandWithConfirmationAndDate(String confirmation, String date) {
+    SecretDAO secretDAO = secretDAOFactory.readwrite();
+    // confirm that the expected secrets are present
+    checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
+    checkExpectedSecretContents(ImmutableList.of(content1, content2a, content2b, content3),
+        ImmutableList.of());
+
+    DropDeletedSecretsCommand command = new DropDeletedSecretsCommand(secretDAO);
+
+    // remove secrets
+    InputStream in = new ByteArrayInputStream(confirmation.getBytes(UTF_8));
+    System.setIn(in);
+    command.run(null,
+        new Namespace(ImmutableMap.of(DropDeletedSecretsCommand.INPUT_DELETED_BEFORE, date)),
+        null);
+    System.setIn(System.in);
+  }
+
+  /**
+   * Verify that the given sets of secrets are present/not present in the database.
+   */
+  private void checkExpectedSecretSeries(List<SecretSeries> expectedPresentSeries,
+      List<SecretSeries> expectedMissingSeries) {
+    List<Long> secretSeriesIds = jooqContext.select(SECRETS.ID).from(SECRETS).fetch(SECRETS.ID);
+    assertThat(secretSeriesIds).containsAll(
+        expectedPresentSeries.stream().map(SecretSeries::id).collect(toList()));
+
+    if (!expectedMissingSeries.isEmpty()) {
+      assertThat(secretSeriesIds).doesNotContainAnyElementsOf(
+          expectedMissingSeries.stream().map(SecretSeries::id).collect(toList()));
+    }
+  }
+
+  /**
+   * Verify that the given sets of secrets are present/not present in the database.
+   */
+  private void checkExpectedSecretContents(List<SecretContent> expectedPresentContents,
+      List<SecretContent> expectedMissingContents) {
+    List<Long> secretContentsIds =
+        jooqContext.select(SECRETS_CONTENT.ID).from(SECRETS_CONTENT).fetch(SECRETS_CONTENT.ID);
+    assertThat(secretContentsIds).containsAll(
+        expectedPresentContents.stream().map(SecretContent::id).collect(toList()));
+
+    if (!expectedMissingContents.isEmpty()) {
+      assertThat(secretContentsIds).doesNotContainAnyElementsOf(
+          expectedMissingContents.stream().map(SecretContent::id).collect(toList()));
+    }
+  }
+}

--- a/server/src/test/java/keywhiz/commands/DropDeletedSecretsCommandTest.java
+++ b/server/src/test/java/keywhiz/commands/DropDeletedSecretsCommandTest.java
@@ -168,7 +168,7 @@ public class DropDeletedSecretsCommandTest {
   public void testSecretDeletion_allDeletedSecrets() {
     runCommandWithConfirmationAndDate("yes", "2019-02-01T00:00:00Z", 0);
 
-    // check the database state; secret2 and secret3 should have been deleted
+    // check the database state; secret2 and secret3 should have been removed
     checkExpectedSecretSeries(ImmutableList.of(series1), ImmutableList.of(series2, series3));
     checkExpectedSecretContents(ImmutableList.of(content1),
         ImmutableList.of(content2a, content2b, content3));
@@ -178,7 +178,7 @@ public class DropDeletedSecretsCommandTest {
   public void testSecretDeletion_filterByDate_someSecretsRemoved() {
     runCommandWithConfirmationAndDate("yes", "2018-02-01T00:00:00Z", 0);
 
-    // check the database state; only secret2 should have been deleted
+    // check the database state; only secret2 should have been removed
     checkExpectedSecretSeries(ImmutableList.of(series1, series3), ImmutableList.of(series2));
     checkExpectedSecretContents(ImmutableList.of(content1, content3),
         ImmutableList.of(content2a, content2b));
@@ -188,7 +188,7 @@ public class DropDeletedSecretsCommandTest {
   public void testSecretDeletion_filterByDate_noSecretsRemoved() {
     runCommandWithConfirmationAndDate("yes", "2017-02-01T00:00:00Z", 0);
 
-    // check the database state; no secrets should have been deleted
+    // check the database state; no secrets should have been removed
     checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
     checkExpectedSecretContents(ImmutableList.of(content1, content2a, content2b, content3),
         ImmutableList.of());
@@ -198,7 +198,7 @@ public class DropDeletedSecretsCommandTest {
   public void testSecretDeletion_futureDate() {
     runCommandWithConfirmationAndDate("yes", "5000-02-01T00:00:00Z", 0);
 
-    // check the database state; secrets should NOT have been deleted
+    // check the database state; secrets should NOT have been removed
     checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
     checkExpectedSecretContents(ImmutableList.of(content1, content2a, content2b, content3),
         ImmutableList.of());
@@ -208,7 +208,7 @@ public class DropDeletedSecretsCommandTest {
   public void testSecretDeletion_invalidDate() {
     runCommandWithConfirmationAndDate("yes", "notadate", 0);
 
-    // check the database state; secrets should NOT have been deleted
+    // check the database state; secrets should NOT have been removed
     checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
     checkExpectedSecretContents(ImmutableList.of(content1, content2a, content2b, content3),
         ImmutableList.of());
@@ -218,7 +218,7 @@ public class DropDeletedSecretsCommandTest {
   public void testSecretDeletion_noConfirmation() {
     runCommandWithConfirmationAndDate("no", "2019-02-01T00:00:00Z", 0);
 
-    // check the database state; secrets should NOT have been deleted
+    // check the database state; secrets should NOT have been removed
     checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
     checkExpectedSecretContents(ImmutableList.of(content1, content2a, content2b, content3),
         ImmutableList.of());
@@ -228,7 +228,7 @@ public class DropDeletedSecretsCommandTest {
   public void testSecretDeletion_negativeSleep() {
     runCommandWithConfirmationAndDate("no", "2019-02-01T00:00:00Z", -10);
 
-    // check the database state; secrets should NOT have been deleted
+    // check the database state; secrets should NOT have been removed
     checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
     checkExpectedSecretContents(ImmutableList.of(content1, content2a, content2b, content3),
         ImmutableList.of());

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -514,6 +514,16 @@ public class SecretDAOTest {
   // permanentlyRemoveSecret
   //---------------------------------------------------------------------------------------
   @Test
+  public void countDeletedSecrets() {
+    // one secret was deleted in the initial test setup
+    assertThat(secretDAO.countDeletedSecrets()).isEqualTo(1);
+
+    // delete a secret and recount
+    secretDAO.deleteSecretsByName(series2.name());
+    assertThat(secretDAO.countDeletedSecrets()).isEqualTo(2);
+  }
+
+  @Test
   public void countSecretsDeletedBeforeDate() {
     // some secrets may have been deleted in test setup
     int initialCount = secretDAO.countSecretsDeletedBeforeDate(DateTime.now().plusDays(30));

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -17,9 +17,10 @@
 package keywhiz.service.daos;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import java.util.AbstractMap.SimpleEntry;
+import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
@@ -27,12 +28,14 @@ import javax.ws.rs.NotFoundException;
 import keywhiz.KeywhizTestRunner;
 import keywhiz.api.ApiDate;
 import keywhiz.api.automation.v2.PartialUpdateSecretRequestV2;
+import keywhiz.api.model.SanitizedSecret;
 import keywhiz.api.model.SecretContent;
 import keywhiz.api.model.SecretSeries;
 import keywhiz.api.model.SecretSeriesAndContent;
 import keywhiz.service.crypto.ContentCryptographer;
 import keywhiz.service.crypto.CryptoFixtures;
 import keywhiz.service.daos.SecretDAO.SecretDAOFactory;
+import org.joda.time.DateTime;
 import org.jooq.DSLContext;
 import org.jooq.Table;
 import org.jooq.exception.DataAccessException;
@@ -41,6 +44,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toList;
 import static keywhiz.jooq.tables.Secrets.SECRETS;
 import static keywhiz.jooq.tables.SecretsContent.SECRETS_CONTENT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,25 +59,33 @@ public class SecretDAOTest {
   private final static ApiDate date = ApiDate.now();
   private ImmutableMap<String, String> emptyMetadata = ImmutableMap.of();
 
-  private SecretSeries series1 = SecretSeries.of(1, "secret1", "desc1", date, "creator", date, "updater", null, null, 101L);
+  private SecretSeries series1 =
+      SecretSeries.of(1, "secret1", "desc1", date, "creator", date, "updater", null, null, 101L);
   private String content = "c2VjcmV0MQ==";
-  private String encryptedContent = cryptographer.encryptionKeyDerivedFrom(series1.name()).encrypt(content);
-  private SecretContent content1 = SecretContent.of(101, 1, encryptedContent, "checksum", date, "creator", date, "updater", emptyMetadata,
-      0);
+  private String encryptedContent =
+      cryptographer.encryptionKeyDerivedFrom(series1.name()).encrypt(content);
+  private SecretContent content1 =
+      SecretContent.of(101, 1, encryptedContent, "checksum", date, "creator", date, "updater",
+          emptyMetadata, 0);
   private SecretSeriesAndContent secret1 = SecretSeriesAndContent.of(series1, content1);
 
-  private SecretSeries series2 = SecretSeries.of(2, "secret2", "desc2", date, "creator", date, "updater", null, null, 103L);
-  private SecretContent content2a = SecretContent.of(102, 2, encryptedContent, "checksum", date, "creator", date, "updater", emptyMetadata,
-      0);
+  private SecretSeries series2 =
+      SecretSeries.of(2, "secret2", "desc2", date, "creator", date, "updater", null, null, 103L);
+  private SecretContent content2a =
+      SecretContent.of(102, 2, encryptedContent, "checksum", date, "creator", date, "updater",
+          emptyMetadata, 0);
   private SecretSeriesAndContent secret2a = SecretSeriesAndContent.of(series2, content2a);
 
-  private SecretContent content2b = SecretContent.of(103, 2, "some other content", "checksum", date, "creator", date, "updater",
-      emptyMetadata, 0);
+  private SecretContent content2b =
+      SecretContent.of(103, 2, "some other content", "checksum", date, "creator", date, "updater",
+          emptyMetadata, 0);
   private SecretSeriesAndContent secret2b = SecretSeriesAndContent.of(series2, content2b);
 
-  private SecretSeries series3 = SecretSeries.of(3, "secret3", "desc3", date, "creator", date, "updater", null, null, null);
-  private SecretContent content3 = SecretContent.of(104, 3, encryptedContent, "checksum", date, "creator", date, "updater", emptyMetadata,
-      0);
+  private SecretSeries series3 =
+      SecretSeries.of(3, "secret3", "desc3", date, "creator", date, "updater", null, null, null);
+  private SecretContent content3 =
+      SecretContent.of(104, 3, encryptedContent, "checksum", date, "creator", date, "updater",
+          emptyMetadata, 0);
   private SecretSeriesAndContent secret3 = SecretSeriesAndContent.of(series3, content3);
 
   private SecretDAO secretDAO;
@@ -124,7 +136,8 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.CREATEDAT, secret2a.content().createdAt().toEpochSecond())
         .set(SECRETS_CONTENT.UPDATEDBY, secret2a.content().updatedBy())
         .set(SECRETS_CONTENT.UPDATEDAT, secret2a.content().updatedAt().toEpochSecond())
-        .set(SECRETS_CONTENT.METADATA, objectMapper.writeValueAsString(secret2a.content().metadata()))
+        .set(SECRETS_CONTENT.METADATA,
+            objectMapper.writeValueAsString(secret2a.content().metadata()))
         .execute();
 
     jooqContext.insertInto(SECRETS_CONTENT)
@@ -136,7 +149,8 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.CREATEDAT, secret2b.content().createdAt().toEpochSecond())
         .set(SECRETS_CONTENT.UPDATEDBY, secret2b.content().updatedBy())
         .set(SECRETS_CONTENT.UPDATEDAT, secret2b.content().updatedAt().toEpochSecond())
-        .set(SECRETS_CONTENT.METADATA, objectMapper.writeValueAsString(secret2b.content().metadata()))
+        .set(SECRETS_CONTENT.METADATA,
+            objectMapper.writeValueAsString(secret2b.content().metadata()))
         .execute();
 
     jooqContext.insertInto(SECRETS)
@@ -159,9 +173,9 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.CREATEDAT, secret3.content().createdAt().toEpochSecond())
         .set(SECRETS_CONTENT.UPDATEDBY, secret3.content().updatedBy())
         .set(SECRETS_CONTENT.UPDATEDAT, secret3.content().updatedAt().toEpochSecond())
-        .set(SECRETS_CONTENT.METADATA, objectMapper.writeValueAsString(secret3.content().metadata()))
+        .set(SECRETS_CONTENT.METADATA,
+            objectMapper.writeValueAsString(secret3.content().metadata()))
         .execute();
-
 
     secretDAO = secretDAOFactory.readwrite();
   }
@@ -192,33 +206,40 @@ public class SecretDAOTest {
   @Test(expected = DataAccessException.class)
   public void createSecretFailsIfSecretExists() {
     String name = "newSecret";
-    secretDAO.createSecret(name, "some secret", "checksum", "creator", ImmutableMap.of(), 0, "", null, ImmutableMap.of());
-    secretDAO.createSecret(name, "some secret", "checksum", "creator", ImmutableMap.of(), 0, "", null, ImmutableMap.of());
+    secretDAO.createSecret(name, "some secret", "checksum", "creator", ImmutableMap.of(), 0, "",
+        null, ImmutableMap.of());
+    secretDAO.createSecret(name, "some secret", "checksum", "creator", ImmutableMap.of(), 0, "",
+        null, ImmutableMap.of());
   }
 
   @Test(expected = BadRequestException.class)
   public void createSecretFailsIfNameHasLeadingPeriod() {
     String name = ".newSecret";
-    secretDAO.createSecret(name, "some secret", "checksum", "creator", ImmutableMap.of(), 0, "", null, ImmutableMap.of());
+    secretDAO.createSecret(name, "some secret", "checksum", "creator", ImmutableMap.of(), 0, "",
+        null, ImmutableMap.of());
   }
 
   @Test(expected = BadRequestException.class)
   public void createSecretFailsIfNameIsTooLong() {
-    String name = "newSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecret";
-    secretDAO.createSecret(name, "some secret", "checksum", "creator", ImmutableMap.of(), 0, "", null, ImmutableMap.of());
+    String name =
+        "newSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecretnewSecret";
+    secretDAO.createSecret(name, "some secret", "checksum", "creator", ImmutableMap.of(), 0, "",
+        null, ImmutableMap.of());
   }
 
   @Test public void createSecretSucceedsIfCurrentVersionIsNull() {
     String name = "newSecret";
-    long firstId = secretDAO.createSecret(name, "content1", cryptographer.computeHmac("content1".getBytes(UTF_8)), "creator1",
+    long firstId = secretDAO.createSecret(name, "content1",
+        cryptographer.computeHmac("content1".getBytes(UTF_8)), "creator1",
         ImmutableMap.of("foo", "bar"), 1000, "description1", "type1", ImmutableMap.of());
 
     jooqContext.update(SECRETS)
-        .set(SECRETS.CURRENT, (Long)null)
+        .set(SECRETS.CURRENT, (Long) null)
         .where(SECRETS.ID.eq(firstId))
         .execute();
 
-    long secondId = secretDAO.createSecret(name, "content2", cryptographer.computeHmac("content2".getBytes(UTF_8)), "creator2",
+    long secondId = secretDAO.createSecret(name, "content2",
+        cryptographer.computeHmac("content2".getBytes(UTF_8)), "creator2",
         ImmutableMap.of("foo2", "bar2"), 2000, "description2", "type2", ImmutableMap.of());
     assertThat(secondId).isGreaterThan(firstId);
 
@@ -257,10 +278,12 @@ public class SecretDAOTest {
 
   @Test public void createOrUpdateSecretWhenSecretExists() {
     String name = "newSecret";
-    long firstId = secretDAO.createSecret(name, "content1", cryptographer.computeHmac("content1".getBytes(UTF_8)), "creator1",
+    long firstId = secretDAO.createSecret(name, "content1",
+        cryptographer.computeHmac("content1".getBytes(UTF_8)), "creator1",
         ImmutableMap.of("foo", "bar"), 1000, "description1", "type1", ImmutableMap.of());
 
-    long secondId = secretDAO.createOrUpdateSecret(name, "content2", cryptographer.computeHmac("content2".getBytes(UTF_8)), "creator2",
+    long secondId = secretDAO.createOrUpdateSecret(name, "content2",
+        cryptographer.computeHmac("content2".getBytes(UTF_8)), "creator2",
         ImmutableMap.of("foo2", "bar2"), 2000, "description2", "type2", ImmutableMap.of());
     assertThat(secondId).isEqualTo(firstId);
 
@@ -364,7 +387,6 @@ public class SecretDAOTest {
     assertThat(newSecret.content().expiry()).isEqualTo(12345L);
   }
 
-
   //---------------------------------------------------------------------------------------
 
   @Test public void getSecretByName() {
@@ -376,7 +398,7 @@ public class SecretDAOTest {
     String name = secret1.series().name();
 
     jooqContext.update(SECRETS)
-        .set(SECRETS.CURRENT, (Long)null)
+        .set(SECRETS.CURRENT, (Long) null)
         .where(SECRETS.ID.eq(series1.id()))
         .execute();
     assertThat(secretDAO.getSecretByName(name)).isEmpty();
@@ -386,7 +408,9 @@ public class SecretDAOTest {
     String name = "nonExistantSecret";
     assertThat(secretDAO.getSecretByName(name).isPresent()).isFalse();
 
-    long newId = secretDAO.createSecret(name, "content", cryptographer.computeHmac("content".getBytes(UTF_8)), "creator", ImmutableMap.of(), 0, "", null, ImmutableMap.of());
+    long newId = secretDAO.createSecret(name, "content",
+        cryptographer.computeHmac("content".getBytes(UTF_8)), "creator", ImmutableMap.of(), 0, "",
+        null, ImmutableMap.of());
     SecretSeriesAndContent newSecret = secretDAO.getSecretById(newId).get();
 
     assertThat(secretDAO.getSecretByName(name).isPresent()).isTrue();
@@ -404,7 +428,7 @@ public class SecretDAOTest {
 
   @Test public void getSecretByIdOneReturnsEmptyWhenCurrentVersionIsNull() {
     jooqContext.update(SECRETS)
-        .set(SECRETS.CURRENT, (Long)null)
+        .set(SECRETS.CURRENT, (Long) null)
         .where(SECRETS.ID.eq(series2.id()))
         .execute();
     assertThat(secretDAO.getSecretById(series2.id())).isEmpty();
@@ -435,12 +459,14 @@ public class SecretDAOTest {
   }
 
   @Test public void deleteSecretsByName() {
-    secretDAO.createSecret("toBeDeleted_deleteSecretsByName", "encryptedShhh", cryptographer.computeHmac("encryptedShhh".getBytes(UTF_8)), "creator",
+    secretDAO.createSecret("toBeDeleted_deleteSecretsByName", "encryptedShhh",
+        cryptographer.computeHmac("encryptedShhh".getBytes(UTF_8)), "creator",
         ImmutableMap.of(), 0, "", null, null);
 
     secretDAO.deleteSecretsByName("toBeDeleted_deleteSecretsByName");
 
-    Optional<SecretSeriesAndContent> secret = secretDAO.getSecretByName("toBeDeleted_deleteSecretsByName");
+    Optional<SecretSeriesAndContent> secret =
+        secretDAO.getSecretByName("toBeDeleted_deleteSecretsByName");
     assertThat(secret.isPresent()).isFalse();
   }
 
@@ -454,10 +480,105 @@ public class SecretDAOTest {
     Optional<SecretSeriesAndContent> secret = secretDAO.getSecretByName("toBeDeletedAndReplaced");
     assertThat(secret.isPresent()).isFalse();
 
-    secretDAO.createSecret("toBeDeletedAndReplaced", "secretsgohere", cryptographer.computeHmac("secretsgohere".getBytes(UTF_8)), "creator",
+    secretDAO.createSecret("toBeDeletedAndReplaced", "secretsgohere",
+        cryptographer.computeHmac("secretsgohere".getBytes(UTF_8)), "creator",
         ImmutableMap.of(), 0, "", null, null);
     secret = secretDAO.getSecretByName("toBeDeletedAndReplaced");
     assertThat(secret.isPresent()).isTrue();
+  }
+
+  @Test public void deleteSecretsByNameAndRecreateWithUpdate() {
+    secretDAO.createSecret("toBeDeletedAndReplaced", "encryptedShhh",
+        cryptographer.computeHmac("encryptedShhh".getBytes(UTF_8)), "creator",
+        ImmutableMap.of(), 0, "", null, null);
+
+    secretDAO.deleteSecretsByName("toBeDeletedAndReplaced");
+
+    Optional<SecretSeriesAndContent> secret = secretDAO.getSecretByName("toBeDeletedAndReplaced");
+    assertThat(secret.isPresent()).isFalse();
+
+    secretDAO.createOrUpdateSecret("toBeDeletedAndReplaced", "secretsgohere",
+        cryptographer.computeHmac("secretsgohere".getBytes(UTF_8)), "creator",
+        ImmutableMap.of(), 0, "", null, null);
+    secret = secretDAO.getSecretByName("toBeDeletedAndReplaced");
+    assertThat(secret.isPresent()).isTrue();
+
+    // The old version of the secret should not be available
+    Optional<ImmutableList<SanitizedSecret>> versions =
+        secretDAO.getSecretVersionsByName("toBeDeletedAndReplaced", 0, 50);
+    assertThat(versions.isPresent()).isTrue();
+    assertThat(versions.get().size()).isEqualTo(1);
+  }
+
+  //---------------------------------------------------------------------------------------
+  // permanentlyRemoveSecret
+  //---------------------------------------------------------------------------------------
+  @Test
+  public void countSecretsDeletedBeforeDate() {
+    // some secrets may have been deleted in test setup
+    int initialCount = secretDAO.countSecretsDeletedBeforeDate(DateTime.now().plusDays(30));
+
+    // delete a secret and recount
+    secretDAO.deleteSecretsByName(series2.name());
+    assertThat(secretDAO.countSecretsDeletedBeforeDate(DateTime.now().plusDays(30))).isEqualTo(
+        initialCount + 1);
+  }
+
+  @Test
+  public void permanentlyRemoveSecret() {
+    // Initially, all secrets should be present in the database
+    checkExpectedSecretSeriesInDatabase(ImmutableList.of(series1, series2, series3),
+        ImmutableList.of());
+    checkExpectedSecretContentsInDatabase(
+        ImmutableList.of(content1, content2a, content2b, content3), ImmutableList.of());
+
+    // After deleting the secret, the secrets should still be present in the database
+    // (though the series will have current = null)
+    secretDAO.deleteSecretsByName(series2.name());
+    checkExpectedSecretSeriesInDatabase(ImmutableList.of(series1, series2, series3),
+        ImmutableList.of());
+    checkExpectedSecretContentsInDatabase(
+        ImmutableList.of(content1, content2a, content2b, content3), ImmutableList.of());
+
+    // This method does not validate whether the date is in the future, though the command does
+    secretDAO.dangerPermanentlyRemoveSecretsDeletedBeforeDate(DateTime.now().plusDays(30));
+
+    // series2 and series3's associated information should be missing from the database.
+    checkExpectedSecretSeriesInDatabase(ImmutableList.of(series1),
+        ImmutableList.of(series2, series3));
+    checkExpectedSecretContentsInDatabase(ImmutableList.of(content1),
+        ImmutableList.of(content2a, content2b, content3));
+  }
+
+  /**
+   * Verify that the given sets of secrets are present/not present in the database.
+   */
+  private void checkExpectedSecretSeriesInDatabase(List<SecretSeries> expectedPresentSeries,
+      List<SecretSeries> expectedMissingSeries) {
+    List<Long> secretSeriesIds = jooqContext.select(SECRETS.ID).from(SECRETS).fetch(SECRETS.ID);
+    assertThat(secretSeriesIds).containsAll(
+        expectedPresentSeries.stream().map(SecretSeries::id).collect(toList()));
+
+    if (!expectedMissingSeries.isEmpty()) {
+      assertThat(secretSeriesIds).doesNotContainAnyElementsOf(
+          expectedMissingSeries.stream().map(SecretSeries::id).collect(toList()));
+    }
+  }
+
+  /**
+   * Verify that the given sets of secrets are present/not present in the database.
+   */
+  private void checkExpectedSecretContentsInDatabase(List<SecretContent> expectedPresentContents,
+      List<SecretContent> expectedMissingContents) {
+    List<Long> secretContentsIds =
+        jooqContext.select(SECRETS_CONTENT.ID).from(SECRETS_CONTENT).fetch(SECRETS_CONTENT.ID);
+    assertThat(secretContentsIds).containsAll(
+        expectedPresentContents.stream().map(SecretContent::id).collect(toList()));
+
+    if (!expectedMissingContents.isEmpty()) {
+      assertThat(secretContentsIds).doesNotContainAnyElementsOf(
+          expectedMissingContents.stream().map(SecretContent::id).collect(toList()));
+    }
   }
 
   private int tableSize(Table table) {

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -525,7 +525,7 @@ public class SecretDAOTest {
   }
 
   @Test
-  public void permanentlyRemoveSecret() {
+  public void permanentlyRemoveSecret() throws Exception {
     // Initially, all secrets should be present in the database
     checkExpectedSecretSeriesInDatabase(ImmutableList.of(series1, series2, series3),
         ImmutableList.of());
@@ -541,7 +541,7 @@ public class SecretDAOTest {
         ImmutableList.of(content1, content2a, content2b, content3), ImmutableList.of());
 
     // This method does not validate whether the date is in the future, though the command does
-    secretDAO.dangerPermanentlyRemoveSecretsDeletedBeforeDate(DateTime.now().plusDays(30));
+    secretDAO.dangerPermanentlyRemoveSecretsDeletedBeforeDate(DateTime.now().plusDays(30), 0);
 
     // series2 and series3's associated information should be missing from the database.
     checkExpectedSecretSeriesInDatabase(ImmutableList.of(series1),


### PR DESCRIPTION
Deleted secrets in Keywhiz are still present in the database;
the only difference between a deleted secret and an existing secret
is that `secrets.current` for a deleted secret is null, while it's
the ID of a row in the `secrets_content` table for an existing
secret.

This adds a command to remove database rows for secrets which have
been deleted before an input date.  This command must be treated
extremely carefully, since its effects are permanent unless the
database is restored from a backup.

This command will be valuable in removing unused deleted secrets
since a recent commit changed the naming pattern for deleted secrets.