### PR TITLE
Register command with Keywhiz server and fix parameter error

### DIFF
--- a/server/src/main/java/keywhiz/KeywhizService.java
+++ b/server/src/main/java/keywhiz/KeywhizService.java
@@ -32,9 +32,11 @@ import keywhiz.auth.mutualssl.ClientCertificateFilter;
 import keywhiz.auth.xsrf.XsrfServletFilter;
 import keywhiz.commands.AddUserCommand;
 import keywhiz.commands.DbSeedCommand;
+import keywhiz.commands.DropDeletedSecretsCommand;
 import keywhiz.commands.GenerateAesKeyCommand;
 import keywhiz.commands.MigrateCommand;
 import keywhiz.commands.PreviewMigrateCommand;
+import keywhiz.service.daos.SecretDAO;
 import keywhiz.service.filters.CookieRenewingFilter;
 import keywhiz.service.filters.SecurityHeadersFilter;
 import keywhiz.service.providers.AuthResolver;
@@ -103,6 +105,7 @@ public class KeywhizService extends Application<KeywhizConfig> {
     bootstrap.addCommand(new DbSeedCommand());
     bootstrap.addCommand(new GenerateAesKeyCommand());
     bootstrap.addCommand(new AddUserCommand());
+    bootstrap.addCommand(new DropDeletedSecretsCommand());
   }
 
   @SuppressWarnings("unchecked")

--- a/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java
@@ -42,7 +42,7 @@ import static keywhiz.jooq.tables.SecretsContent.SECRETS_CONTENT;
 /**
  * Interacts with 'secrets_content' table and actions on {@link SecretContent} entities.
  */
-class SecretContentDAO {
+public class SecretContentDAO {
   // Number of old contents we keep around before we prune
   @VisibleForTesting static final int PRUNE_CUTOFF_ITEMS = 10;
 

--- a/server/src/main/java/keywhiz/service/daos/SecretContentMapper.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretContentMapper.java
@@ -27,12 +27,12 @@ import keywhiz.api.model.SecretContent;
 import keywhiz.jooq.tables.records.SecretsContentRecord;
 import org.jooq.RecordMapper;
 
-class SecretContentMapper implements RecordMapper<SecretsContentRecord, SecretContent> {
+public class SecretContentMapper implements RecordMapper<SecretsContentRecord, SecretContent> {
   private static final TypeReference MAP_STRING_STRING_TYPE =
       new TypeReference<Map<String, String>>() {};
   private final ObjectMapper mapper;
 
-  @Inject SecretContentMapper(ObjectMapper mapper) {
+  @Inject public SecretContentMapper(ObjectMapper mapper) {
     this.mapper = mapper;
   }
 

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -76,7 +76,7 @@ public class SecretDAO {
   // to permanently remove secrets
   private static final int MAX_ROWS_REMOVED_PER_TRANSACTION = 1000;
 
-  private SecretDAO(DSLContext dslContext, SecretContentDAOFactory secretContentDAOFactory,
+  public SecretDAO(DSLContext dslContext, SecretContentDAOFactory secretContentDAOFactory,
       SecretSeriesDAOFactory secretSeriesDAOFactory, ContentCryptographer cryptographer) {
     this.dslContext = dslContext;
     this.secretContentDAOFactory = secretContentDAOFactory;

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesMapper.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesMapper.java
@@ -26,12 +26,12 @@ import keywhiz.api.model.SecretSeries;
 import keywhiz.jooq.tables.records.SecretsRecord;
 import org.jooq.RecordMapper;
 
-class SecretSeriesMapper implements RecordMapper<SecretsRecord, SecretSeries> {
+public class SecretSeriesMapper implements RecordMapper<SecretsRecord, SecretSeries> {
   private static final TypeReference MAP_STRING_STRING_TYPE =
       new TypeReference<Map<String, String>>() {};
   private final ObjectMapper mapper;
 
-  @Inject SecretSeriesMapper(ObjectMapper mapper) {
+  @Inject public SecretSeriesMapper(ObjectMapper mapper) {
     this.mapper = mapper;
   }
 

--- a/server/src/test/java/keywhiz/commands/DropDeletedSecretsCommandTest.java
+++ b/server/src/test/java/keywhiz/commands/DropDeletedSecretsCommandTest.java
@@ -165,7 +165,7 @@ public class DropDeletedSecretsCommandTest {
   }
 
   @Test
-  public void testSecretDeletion_allDeletedSecrets() {
+  public void testSecretDeletion_allDeletedSecrets() throws Exception {
     runCommandWithConfirmationAndDate("yes", "2019-02-01T00:00:00Z", 0);
 
     // check the database state; secret2 and secret3 should have been removed
@@ -175,7 +175,7 @@ public class DropDeletedSecretsCommandTest {
   }
 
   @Test
-  public void testSecretDeletion_filterByDate_someSecretsRemoved() {
+  public void testSecretDeletion_filterByDate_someSecretsRemoved() throws Exception {
     runCommandWithConfirmationAndDate("yes", "2018-02-01T00:00:00Z", 0);
 
     // check the database state; only secret2 should have been removed
@@ -185,7 +185,7 @@ public class DropDeletedSecretsCommandTest {
   }
 
   @Test
-  public void testSecretDeletion_filterByDate_noSecretsRemoved() {
+  public void testSecretDeletion_filterByDate_noSecretsRemoved() throws Exception {
     runCommandWithConfirmationAndDate("yes", "2017-02-01T00:00:00Z", 0);
 
     // check the database state; no secrets should have been removed
@@ -195,7 +195,7 @@ public class DropDeletedSecretsCommandTest {
   }
 
   @Test
-  public void testSecretDeletion_futureDate() {
+  public void testSecretDeletion_futureDate() throws Exception {
     runCommandWithConfirmationAndDate("yes", "5000-02-01T00:00:00Z", 0);
 
     // check the database state; secrets should NOT have been removed
@@ -205,7 +205,7 @@ public class DropDeletedSecretsCommandTest {
   }
 
   @Test
-  public void testSecretDeletion_invalidDate() {
+  public void testSecretDeletion_invalidDate() throws Exception {
     runCommandWithConfirmationAndDate("yes", "notadate", 0);
 
     // check the database state; secrets should NOT have been removed
@@ -215,7 +215,7 @@ public class DropDeletedSecretsCommandTest {
   }
 
   @Test
-  public void testSecretDeletion_noConfirmation() {
+  public void testSecretDeletion_noConfirmation() throws Exception {
     runCommandWithConfirmationAndDate("no", "2019-02-01T00:00:00Z", 0);
 
     // check the database state; secrets should NOT have been removed
@@ -225,8 +225,8 @@ public class DropDeletedSecretsCommandTest {
   }
 
   @Test
-  public void testSecretDeletion_negativeSleep() {
-    runCommandWithConfirmationAndDate("no", "2019-02-01T00:00:00Z", -10);
+  public void testSecretDeletion_negativeSleep() throws Exception {
+    runCommandWithConfirmationAndDate("yes", "2019-02-01T00:00:00Z", -10);
 
     // check the database state; secrets should NOT have been removed
     checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());
@@ -235,7 +235,7 @@ public class DropDeletedSecretsCommandTest {
   }
 
   private void runCommandWithConfirmationAndDate(String confirmation, String date,
-      int sleepMillis) {
+      int sleepMillis) throws Exception {
     SecretDAO secretDAO = secretDAOFactory.readwrite();
     // confirm that the expected secrets are present
     checkExpectedSecretSeries(ImmutableList.of(series1, series2, series3), ImmutableList.of());


### PR DESCRIPTION
This adds a method to manually construct a SecretDAO instance
from an injected DSLContext.  This is more error-prone than using
injection; however, injection doesn't appear to be available at the
bootstrapping phase.