### PR TITLE
Add unique secret name constraint

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -432,8 +432,8 @@ public class SecretDAO {
    * Unlike the "delete" endpoints above, THIS REMOVAL IS PERMANENT and cannot be undone by editing
    * the database to restore the "current" entries.
    *
-   * @param deletedBefore the cutoff date; secrets deleted before this date will be removed from
-   * the database
+   * @param deletedBefore the cutoff date; secrets deleted before this date will be removed from the
+   * database
    * @param sleepMillis how many milliseconds to sleep between each batch of removals
    */
   public void dangerPermanentlyRemoveSecretsDeletedBeforeDate(DateTime deletedBefore,

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -215,8 +215,13 @@ public class SecretSeriesDAO {
   public void deleteSecretSeriesByName(String name) {
     long now = OffsetDateTime.now().toEpochSecond();
     dslContext.transaction(configuration -> {
+      // find the record and lock it until this transaction is complete
       SecretsRecord r = DSL.using(configuration)
-          .fetchOne(SECRETS, SECRETS.NAME.eq(name).and(SECRETS.CURRENT.isNotNull()));
+          .select()
+          .from(SECRETS)
+          .where(SECRETS.NAME.eq(name).and(SECRETS.CURRENT.isNotNull()))
+          .forUpdate()
+          .fetchOneInto(SECRETS);
       if (r != null) {
         DSL.using(configuration)
             .update(SECRETS)
@@ -237,8 +242,13 @@ public class SecretSeriesDAO {
   public void deleteSecretSeriesById(long id) {
     long now = OffsetDateTime.now().toEpochSecond();
     dslContext.transaction(configuration -> {
+      // find the record and lock it until this transaction is complete
       SecretsRecord r = DSL.using(configuration)
-          .fetchOne(SECRETS, SECRETS.ID.eq(id).and(SECRETS.CURRENT.isNotNull()));
+          .select()
+          .from(SECRETS)
+          .where(SECRETS.ID.eq(id).and(SECRETS.CURRENT.isNotNull()))
+          .forUpdate()
+          .fetchOneInto(SECRETS);
       if (r != null) {
         DSL.using(configuration)
             .update(SECRETS)

--- a/server/src/main/resources/db/h2/migration/V9__add_unique_constraint_on_secret_name.sql
+++ b/server/src/main/resources/db/h2/migration/V9__add_unique_constraint_on_secret_name.sql
@@ -1,0 +1,4 @@
+ALTER TABLE secrets DROP INDEX secrets_name_idx;
+CREATE UNIQUE INDEX secrets_name_idx ON secrets (name);
+-- while not incorrect, this index is redundant with UNIQUE indices on both id and name
+ALTER TABLE secrets DROP INDEX name_id_idx;

--- a/server/src/main/resources/db/mysql/migration/V9__add_unique_constraint_on_secret_name.sql
+++ b/server/src/main/resources/db/mysql/migration/V9__add_unique_constraint_on_secret_name.sql
@@ -1,0 +1,4 @@
+DROP INDEX name ON secrets;
+CREATE UNIQUE INDEX name ON secrets (name);
+-- while not incorrect, this index is redundant with UNIQUE indices on both id and name
+DROP INDEX name_id_idx ON secrets;

--- a/server/src/test/java/keywhiz/auth/bcrypt/BcryptAuthenticatorTest.java
+++ b/server/src/test/java/keywhiz/auth/bcrypt/BcryptAuthenticatorTest.java
@@ -63,7 +63,7 @@ public class BcryptAuthenticatorTest {
 
     Optional<User> missingUser =
         bcryptAuthenticator.authenticate(new BasicCredentials("sysadmin", "badpass"));
-    assertThat(missingUser.isPresent()).isFalse();
+    assertThat(missingUser).isEmpty();
   }
 
   @Test
@@ -73,7 +73,7 @@ public class BcryptAuthenticatorTest {
 
     Optional<User> missingUser =
         bcryptAuthenticator.authenticate(new BasicCredentials("invaliduser", "validpass"));
-    assertThat(missingUser.isPresent()).isFalse();
+    assertThat(missingUser).isEmpty();
   }
 
   @Test
@@ -81,7 +81,7 @@ public class BcryptAuthenticatorTest {
     String crazyUsername = "sysadmin)`~!@#$%^&*()+=[]{}\\|;:'\",<>?/\r\n\t";
     Optional<User> missingUser =
         bcryptAuthenticator.authenticate(new BasicCredentials(crazyUsername, "validpass"));
-    assertThat(missingUser.isPresent()).isFalse();
+    assertThat(missingUser).isEmpty();
   }
 
 }

--- a/server/src/test/java/keywhiz/auth/ldap/LdapAuthenticatorTest.java
+++ b/server/src/test/java/keywhiz/auth/ldap/LdapAuthenticatorTest.java
@@ -106,7 +106,7 @@ public class LdapAuthenticatorTest {
 
     Optional<User> missingUser =
         ldapAuthenticator.authenticate(new BasicCredentials("sysadmin", "badpass"));
-    assertThat(missingUser.isPresent()).isFalse();
+    assertThat(missingUser).isEmpty();
   }
 
   @Ignore
@@ -115,13 +115,13 @@ public class LdapAuthenticatorTest {
     String crazyUsername = "sysadmin)`~!@#$%^&*()+=[]{}\\|;:'\",<>?/\r\n\t";
     Optional<User> missingUser =
         ldapAuthenticator.authenticate(new BasicCredentials(crazyUsername, "badpass"));
-    assertThat(missingUser.isPresent()).isFalse();
+    assertThat(missingUser).isEmpty();
   }
 
   @Ignore
   @Test
   public void ldapAuthenticatorRejectsEmptyPassword() throws Exception {
     Optional<User> user = ldapAuthenticator.authenticate(new BasicCredentials("sysadmin", ""));
-    assertThat(user.isPresent()).isFalse();
+    assertThat(user).isEmpty();
   }
 }

--- a/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
@@ -114,14 +114,14 @@ public class SecretContentDAOTest {
     assertThat(tableSize()).isEqualTo(before + PRUNE_CUTOFF_ITEMS + 1);
 
     for (int i = 0; i < (ids.length - PRUNE_CUTOFF_ITEMS - 1); i++) {
-      assertThat(secretContentDAO.getSecretContentById(ids[i]).isPresent()).isFalse();
+      assertThat(secretContentDAO.getSecretContentById(ids[i])).isEmpty();
     }
     for (int i = (ids.length - PRUNE_CUTOFF_ITEMS - 1); i < ids.length; i++) {
-      assertThat(secretContentDAO.getSecretContentById(ids[i]).isPresent()).isTrue();
+      assertThat(secretContentDAO.getSecretContentById(ids[i])).isPresent();
     }
 
     // Other secrets contents left intact
-    assertThat(secretContentDAO.getSecretContentById(secretContent1.id()).isPresent()).isTrue();
+    assertThat(secretContentDAO.getSecretContentById(secretContent1.id())).isPresent();
   }
 
   @Test public void pruneIgnores45DaysOrLess() throws Exception {
@@ -154,7 +154,7 @@ public class SecretContentDAOTest {
 
     // Nothing pruned
     for (int i = 0; i < ids.length; i++) {
-      assertThat(secretContentDAO.getSecretContentById(ids[i]).isPresent()).isTrue();
+      assertThat(secretContentDAO.getSecretContentById(ids[i])).isPresent();
     }
   }
 

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -399,20 +399,20 @@ public class SecretDAOTest {
 
   @Test public void getSecretByNameOneReturnsEmptyWhenRowIsMissing() {
     String name = "nonExistantSecret";
-    assertThat(secretDAO.getSecretByName(name).isPresent()).isFalse();
+    assertThat(secretDAO.getSecretByName(name)).isEmpty();
 
     long newId = secretDAO.createSecret(name, "content",
         cryptographer.computeHmac("content".getBytes(UTF_8)), "creator", ImmutableMap.of(), 0, "",
         null, ImmutableMap.of());
     SecretSeriesAndContent newSecret = secretDAO.getSecretById(newId).get();
 
-    assertThat(secretDAO.getSecretByName(name).isPresent()).isTrue();
+    assertThat(secretDAO.getSecretByName(name)).isPresent();
 
     jooqContext.deleteFrom(SECRETS_CONTENT)
         .where(SECRETS_CONTENT.ID.eq(newSecret.content().id()))
         .execute();
 
-    assertThat(secretDAO.getSecretByName(name).isPresent()).isFalse();
+    assertThat(secretDAO.getSecretByName(name)).isEmpty();
   }
 
   @Test public void getSecretById() {
@@ -460,7 +460,7 @@ public class SecretDAOTest {
 
     Optional<SecretSeriesAndContent> secret =
         secretDAO.getSecretByName("toBeDeleted_deleteSecretsByName");
-    assertThat(secret.isPresent()).isFalse();
+    assertThat(secret).isEmpty();
   }
 
   @Test public void deleteSecretsByNameAndRecreate() {
@@ -471,13 +471,13 @@ public class SecretDAOTest {
     secretDAO.deleteSecretsByName("toBeDeletedAndReplaced");
 
     Optional<SecretSeriesAndContent> secret = secretDAO.getSecretByName("toBeDeletedAndReplaced");
-    assertThat(secret.isPresent()).isFalse();
+    assertThat(secret).isEmpty();
 
     secretDAO.createSecret("toBeDeletedAndReplaced", "secretsgohere",
         cryptographer.computeHmac("secretsgohere".getBytes(UTF_8)), "creator",
         ImmutableMap.of(), 0, "", null, null);
     secret = secretDAO.getSecretByName("toBeDeletedAndReplaced");
-    assertThat(secret.isPresent()).isTrue();
+    assertThat(secret).isPresent();
   }
 
   @Test public void deleteSecretsByNameAndRecreateWithUpdate() {
@@ -488,18 +488,18 @@ public class SecretDAOTest {
     secretDAO.deleteSecretsByName("toBeDeletedAndReplaced");
 
     Optional<SecretSeriesAndContent> secret = secretDAO.getSecretByName("toBeDeletedAndReplaced");
-    assertThat(secret.isPresent()).isFalse();
+    assertThat(secret).isEmpty();
 
     secretDAO.createOrUpdateSecret("toBeDeletedAndReplaced", "secretsgohere",
         cryptographer.computeHmac("secretsgohere".getBytes(UTF_8)), "creator",
         ImmutableMap.of(), 0, "", null, null);
     secret = secretDAO.getSecretByName("toBeDeletedAndReplaced");
-    assertThat(secret.isPresent()).isTrue();
+    assertThat(secret).isPresent();
 
     // The old version of the secret should not be available
     Optional<ImmutableList<SanitizedSecret>> versions =
         secretDAO.getSecretVersionsByName("toBeDeletedAndReplaced", 0, 50);
-    assertThat(versions.isPresent()).isTrue();
+    assertThat(versions).isPresent();
     assertThat(versions.get().size()).isEqualTo(1);
   }
 

--- a/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
@@ -18,18 +18,16 @@ package keywhiz.service.daos;
 
 import com.google.common.collect.ImmutableMap;
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import javax.inject.Inject;
 import keywhiz.KeywhizTestRunner;
 import keywhiz.api.ApiDate;
-import keywhiz.api.model.SecretContent;
 import keywhiz.api.model.SecretSeries;
 import keywhiz.service.daos.SecretSeriesDAO.SecretSeriesDAOFactory;
 import org.jooq.DSLContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Optional;
 
 import static keywhiz.jooq.tables.Secrets.SECRETS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,15 +55,15 @@ public class SecretSeriesDAOTest {
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
 
-    SecretSeries expected = SecretSeries.of(id, "newSecretSeries", "desc", nowDate, "creator", nowDate,
-        "creator", null, ImmutableMap.of("foo", "bar"), contentId);
+    SecretSeries expected =
+        SecretSeries.of(id, "newSecretSeries", "desc", nowDate, "creator", nowDate,
+            "creator", null, ImmutableMap.of("foo", "bar"), contentId);
 
     assertThat(tableSize()).isEqualTo(before + 1);
 
     SecretSeries actual = secretSeriesDAO.getSecretSeriesById(id)
         .orElseThrow(RuntimeException::new);
-    assertThat(actual).isEqualToIgnoringGivenFields(expected,"id");
-
+    assertThat(actual).isEqualToIgnoringGivenFields(expected, "id");
 
     actual = secretSeriesDAO.getSecretSeriesByName("newSecretSeries")
         .orElseThrow(RuntimeException::new);
@@ -111,10 +109,14 @@ public class SecretSeriesDAOTest {
     long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
-    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName").get().currentVersion().isPresent()).isTrue();
+    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName")
+        .get()
+        .currentVersion()
+        .isPresent()).isTrue();
 
     secretSeriesDAO.deleteSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName");
-    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName").isPresent()).isFalse();
+    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName")
+        .isPresent()).isFalse();
     assertThat(secretSeriesDAO.getSecretSeriesById(id).isPresent()).isFalse();
   }
 
@@ -125,10 +127,14 @@ public class SecretSeriesDAOTest {
     long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
-    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced").get().currentVersion().isPresent()).isTrue();
+    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced")
+        .get()
+        .currentVersion()
+        .isPresent()).isTrue();
 
     secretSeriesDAO.deleteSecretSeriesByName("toBeDeletedAndReplaced");
-    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced").isPresent()).isFalse();
+    assertThat(
+        secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced").isPresent()).isFalse();
     assertThat(secretSeriesDAO.getSecretSeriesById(id).isPresent()).isFalse();
 
     id = secretSeriesDAO.createSecretSeries("toBeDeletedAndReplaced", "creator",
@@ -136,7 +142,10 @@ public class SecretSeriesDAOTest {
     contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah2",
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
-    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced").get().currentVersion().isPresent()).isTrue();
+    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced")
+        .get()
+        .currentVersion()
+        .isPresent()).isTrue();
   }
 
   @Test public void deleteSecretSeriesById() {

--- a/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
@@ -63,7 +63,7 @@ public class SecretSeriesDAOTest {
 
     SecretSeries actual = secretSeriesDAO.getSecretSeriesById(id)
         .orElseThrow(RuntimeException::new);
-    assertThat(actual).isEqualToIgnoringGivenFields(expected, "id");
+    assertThat(actual).isEqualTo(expected);
 
     actual = secretSeriesDAO.getSecretSeriesByName("newSecretSeries")
         .orElseThrow(RuntimeException::new);
@@ -77,7 +77,7 @@ public class SecretSeriesDAOTest {
     long id = secretSeriesDAO.createSecretSeries("toBeDeleted_deleteSecretSeriesByName", "creator",
         "", null, null, now);
     Optional<SecretSeries> secretSeriesById = secretSeriesDAO.getSecretSeriesById(id);
-    assertThat(secretSeriesById.isPresent()).isFalse();
+    assertThat(secretSeriesById).isEmpty();
 
     long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
@@ -111,13 +111,13 @@ public class SecretSeriesDAOTest {
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
     assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName")
         .get()
-        .currentVersion()
-        .isPresent()).isTrue();
+        .currentVersion())
+        .isPresent();
 
     secretSeriesDAO.deleteSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName");
-    assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName")
-        .isPresent()).isFalse();
-    assertThat(secretSeriesDAO.getSecretSeriesById(id).isPresent()).isFalse();
+    assertThat(
+        secretSeriesDAO.getSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName")).isEmpty();
+    assertThat(secretSeriesDAO.getSecretSeriesById(id)).isEmpty();
   }
 
   @Test public void deleteSecretSeriesByNameAndRecreate() {
@@ -129,13 +129,13 @@ public class SecretSeriesDAOTest {
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
     assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced")
         .get()
-        .currentVersion()
-        .isPresent()).isTrue();
+        .currentVersion())
+        .isPresent();
 
     secretSeriesDAO.deleteSecretSeriesByName("toBeDeletedAndReplaced");
     assertThat(
-        secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced").isPresent()).isFalse();
-    assertThat(secretSeriesDAO.getSecretSeriesById(id).isPresent()).isFalse();
+        secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced")).isEmpty();
+    assertThat(secretSeriesDAO.getSecretSeriesById(id)).isEmpty();
 
     id = secretSeriesDAO.createSecretSeries("toBeDeletedAndReplaced", "creator",
         "", null, null, now);
@@ -144,8 +144,8 @@ public class SecretSeriesDAOTest {
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
     assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced")
         .get()
-        .currentVersion()
-        .isPresent()).isTrue();
+        .currentVersion())
+        .isPresent();
   }
 
   @Test public void deleteSecretSeriesById() {
@@ -155,10 +155,10 @@ public class SecretSeriesDAOTest {
     long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
-    assertThat(secretSeriesDAO.getSecretSeriesById(id).get().currentVersion().isPresent()).isTrue();
+    assertThat(secretSeriesDAO.getSecretSeriesById(id).get().currentVersion()).isPresent();
 
     secretSeriesDAO.deleteSecretSeriesById(id);
-    assertThat(secretSeriesDAO.getSecretSeriesById(id).isPresent()).isFalse();
+    assertThat(secretSeriesDAO.getSecretSeriesById(id)).isEmpty();
   }
 
   @Test public void getNonExistentSecretSeries() {

--- a/server/src/test/java/keywhiz/service/daos/UserDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/UserDAOTest.java
@@ -55,7 +55,7 @@ public class UserDAOTest {
 
   @Test
   public void getNonexistentUser() {
-    assertThat(userDAO.getHashedPassword("non-user").isPresent()).isFalse();
+    assertThat(userDAO.getHashedPassword("non-user")).isEmpty();
   }
 
 }


### PR DESCRIPTION
This re-adds the database constraint that secrets must have unique names which was removed in #337 (that attempt to enforce uniqueness through code proved prone to race conditions).  The original issue (users being able to access the contents of deleted secrets by making a new secret with the same name) is now addressed by renaming secrets to an invalid name once they are deleted.

This PR still does not allow retrieving deleted secret series (a constraint which was introduced in #337).  Since all uses of the secret series retrieval that I could find assumed the series were non-deleted if present (including uses which weren't changed in #337), changing that assumption seemed likely to cause subtle bugs or at least unexpected behavior (such as being able to grant groups access to deleted secrets after deletion).

In addition, this PR cleans up some test files' assertions about Optionals.