### PR TITLE
Replace deprecated getStringField method

### DIFF
--- a/server/src/main/java/keywhiz/auth/cookie/AuthenticatedEncryptedCookieFactory.java
+++ b/server/src/main/java/keywhiz/auth/cookie/AuthenticatedEncryptedCookieFactory.java
@@ -123,7 +123,7 @@ public class AuthenticatedEncryptedCookieFactory {
 
     Response response = newResponse();
     response.addCookie(cookie);
-    return NewCookie.valueOf(response.getHttpFields().getStringField(HttpHeader.SET_COOKIE));
+    return NewCookie.valueOf(response.getHttpFields().get(HttpHeader.SET_COOKIE));
   }
 
   private Response newResponse() {

--- a/server/src/main/java/keywhiz/auth/xsrf/XsrfProtection.java
+++ b/server/src/main/java/keywhiz/auth/xsrf/XsrfProtection.java
@@ -71,7 +71,7 @@ public class XsrfProtection {
         config.getPath(), -1, config.isHttpOnly(), config.isSecure());
     Response response = newResponse();
     response.addCookie(cookie);
-    return NewCookie.valueOf(response.getHttpFields().getStringField(HttpHeader.SET_COOKIE));
+    return NewCookie.valueOf(response.getHttpFields().get(HttpHeader.SET_COOKIE));
   }
 
   public static boolean isValid(String header, String session) {


### PR DESCRIPTION
[getStringField](http://www.eclipse.org/jetty/javadoc/9.4.11.v20180605/org/eclipse/jetty/http/HttpFields.html#getStringField-org.eclipse.jetty.http.HttpHeader-) is now deprecated and calls [get](http://www.eclipse.org/jetty/javadoc/9.4.11.v20180605/org/eclipse/jetty/http/HttpFields.html#get-org.eclipse.jetty.http.HttpHeader-)