### PR TITLE
Upgrade maven-shade-plugin to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,7 +449,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.2.1</version>
           <configuration>
             <shadedArtifactAttached>true</shadedArtifactAttached>
             <shadedClassifierName>shaded</shadedClassifierName>


### PR DESCRIPTION
Version [3.2.1](https://blogs.apache.org/maven/entry/apache-maven-shade-plugin-version2) officially [supports JDK 11](https://issues.apache.org/jira/browse/MSHADE-301)