### PR TITLE
Upgrade jacoco maven plugin to 0.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
+        <version>0.8.4</version>
         <executions>
           <execution>
             <id>prepare-agent</id>


### PR DESCRIPTION
The current version [0.8.2]( https://github.com/jacoco/jacoco/releases/tag/v0.8.2) is only experimental support for JDK 11 & 12.
Version [0.8.3]( https://github.com/jacoco/jacoco/releases/tag/v0.8.3) completes official support for JDK 11
Version [0.8.4]( https://github.com/jacoco/jacoco/releases/tag/v0.8.4) completes official support for JDK 12