### PR TITLE
Upgrade maven javadoc plugin to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>


### PR DESCRIPTION
Version [3.1.0](https://blog.soebes.de/blog/2019/03/04/apache-maven-javadoc-plugin-version-3-dot-1.0-released/) resolves of a lot of bugs, some specifically effecting JDK 11