### PR TITLE
Update Dropwizard and Jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,14 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <dropwizard.version>1.3.8</dropwizard.version>
+    <dropwizard.version>1.3.13</dropwizard.version>
     <!-- 1.2.0-1 is the last version of dropwizard-raven JAR. The development continues under dropwizard-sentry -->
     <dropwizard-raven.version>1.2.0-1</dropwizard-raven.version>
     <guice.version>4.2.2</guice.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.9.9.1</jackson.version>
+    <!-- Some jackson libraries have not received a patch update, so peg them to the latest 2.9.x -->
+    <jackson-annotations.version>2.9.9</jackson-annotations.version>
+    <jackson-jdk8.version>2.9.9</jackson-jdk8.version>
     <jooq.version>3.11.5</jooq.version>
     <powermock.version>1.7.4</powermock.version>
     <slf4j.version>1.7.25</slf4j.version>
@@ -119,7 +122,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson-annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -129,12 +132,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jdk8</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson-jdk8.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson-jdk8.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>


### PR DESCRIPTION
This should address [CVE-2019-12814](https://nvd.nist.gov/vuln/detail/CVE-2019-12814).