### PR TITLE
add row_hmac to most tables

### DIFF
--- a/server/src/main/resources/db/h2/migration/V10__add_row_hmacs.sql
+++ b/server/src/main/resources/db/h2/migration/V10__add_row_hmacs.sql
@@ -1,0 +1,5 @@
+ALTER TABLE accessGrants ADD row_hmac varchar(64) not null default '';
+ALTER TABLE memberships ADD row_hmac varchar(64) not null default '';
+ALTER TABLE clients ADD row_hmac varchar(64) not null default '';
+ALTER TABLE secrets ADD row_hmac varchar(64) not null default '';
+ALTER TABLE secrets_content ADD row_hmac varchar(64) not null default '';

--- a/server/src/main/resources/db/mysql/migration/V10__add_row_hmacs.sql
+++ b/server/src/main/resources/db/mysql/migration/V10__add_row_hmacs.sql
@@ -1,0 +1,5 @@
+ALTER TABLE accessgrants ADD row_hmac varchar(64) not null default "";
+ALTER TABLE memberships ADD row_hmac varchar(64) not null default "";
+ALTER TABLE clients ADD row_hmac varchar(64) not null default "";
+ALTER TABLE secrets ADD row_hmac varchar(64) not null default "";
+ALTER TABLE secrets_content ADD row_hmac varchar(64) not null default "";


### PR DESCRIPTION
adding row_hmac to most tables to enable us to distrust the database. See https://github.com/square/keywhiz/issues/182