### PR TITLE
Bump auto-value from 1.5.4 to 1.6.5

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>auto-value</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+    <autovalue.version>1.6.5</autovalue.version>
     <dropwizard.version>1.3.13</dropwizard.version>
     <!-- 1.2.0-1 is the last version of dropwizard-raven JAR. The development continues under dropwizard-sentry -->
     <dropwizard-raven.version>1.2.0-1</dropwizard-raven.version>
@@ -147,7 +148,12 @@
       <dependency>
         <groupId>com.google.auto.value</groupId>
         <artifactId>auto-value</artifactId>
-        <version>1.5.4</version>
+        <version>${autovalue.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auto.value</groupId>
+        <artifactId>auto-value-annotations</artifactId>
+        <version>${autovalue.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>


### PR DESCRIPTION
Manually updated the dep, in lieu of #434 (auto-prepared by @dependabot), which is broken.

Basically, auto-value, created a separate artifact for annotations in 1.6.x.