### PR TITLE
generate and verify row_hmac

### DIFF
--- a/server/src/main/java/keywhiz/commands/DropDeletedSecretsCommand.java
+++ b/server/src/main/java/keywhiz/commands/DropDeletedSecretsCommand.java
@@ -152,14 +152,17 @@ public class DropDeletedSecretsCommand extends ConfiguredCommand<KeywhizConfig> 
         dslContext,
         dslContext,
         bootstrap.getObjectMapper(),
-        new SecretContentMapper(bootstrap.getObjectMapper())
+        new SecretContentMapper(bootstrap.getObjectMapper()),
+        null,
+        null
     );
 
     SecretSeriesDAOFactory secretSeriesDAOFactory = new SecretSeriesDAOFactory(
         dslContext,
         dslContext,
         bootstrap.getObjectMapper(),
-        new SecretSeriesMapper(bootstrap.getObjectMapper())
+        new SecretSeriesMapper(bootstrap.getObjectMapper()),
+        null
     );
 
     return new SecretDAO(

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -382,7 +382,6 @@ public class SecretDAO {
    */
   public void setCurrentSecretVersionByName(String name, long versionId, String updater) {
     checkArgument(!name.isEmpty());
-    checkArgument(versionId >= 0);
 
     SecretSeriesDAO secretSeriesDAO = secretSeriesDAOFactory.using(dslContext.configuration());
     SecretSeries series = secretSeriesDAO.getSecretSeriesByName(name).orElseThrow(


### PR DESCRIPTION
In reference to issue #182, we are adding a new column to clients, secrets, accessgrants, memberships, and secrets_content to protect against db admins tampering with the database. We generate an hmac for each of these tables to ensure that data can't be tampered without access to the private key.

Instead of auto-incrementing id's we generate random 64 bit id's which are concatenated with the other identifying columns in each respective table (ie. for client we use the name column and for secrets_content we use the encrypted content). This value is then hmac'd, stored, and verified whenever a secret is retrieved.

The hmac verification is only guaranteed on Secret(s)DeliveryResource. Other locations are either admin endpoints or only show secret details and not actual secret content.

This change will not affect users beyond having to set a new flag in the config. Setting rowHmacCheck to disabled will turn off row_hmac verification. The row_hmac column will still be set even if this flag is disabled. A future PR will add backfills to generate row_hmacs for prior database entries. The migration will default to an empty string and with rowHmacCheck disabled, this should not affect keywhiz operations.