### PR TITLE
add metadata field to row_hmac for secrets_content

### DIFF
--- a/server/src/main/java/keywhiz/commands/DbSeedCommand.java
+++ b/server/src/main/java/keywhiz/commands/DbSeedCommand.java
@@ -104,6 +104,11 @@ public class DbSeedCommand extends ConfiguredCommand<KeywhizConfig> {
     return computeHmac(hmacContent.getBytes(UTF_8));
   }
 
+  private static String computeRowHmac(String table, String content, String metadata, long id) {
+    String hmacContent = table + "|" + content + "|" + metadata + "|" + id;
+    return computeHmac(hmacContent.getBytes(UTF_8));
+  }
+
   /**
    * Inserts test data using dslContext.
    *
@@ -144,16 +149,16 @@ public class DbSeedCommand extends ConfiguredCommand<KeywhizConfig> {
     String encrypted946 = "{\"derivationInfo\":\"Deleted_Secret\",\"content\":\"GC8/ZvEfqpxhtAkThgZ8/+vPesh9\",\"iv\":\"oRf3CMnB7jv63K33dJFeFg\"}";
     dslContext
         .insertInto(SECRETS_CONTENT, SECRETS_CONTENT.ID, SECRETS_CONTENT.SECRETID, SECRETS_CONTENT.CREATEDAT, SECRETS_CONTENT.UPDATEDAT, SECRETS_CONTENT.ENCRYPTED_CONTENT, SECRETS_CONTENT.METADATA, SECRETS_CONTENT.ROW_HMAC)
-        .values(937L, 737L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:00:47Z").toEpochSecond(), encrypted937, "{\"mode\":\"0400\",\"owner\":\"nobody\"}", computeRowHmac(SECRETS_CONTENT.getName(), encrypted937, 937L))
-        .values(938L, 738L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:01:59Z").toEpochSecond(), encrypted938, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted938, 938L))
-        .values(939L, 739L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:02:06Z").toEpochSecond(), encrypted939, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted939, 939L))
-        .values(940L, 740L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:02:06Z").toEpochSecond(), encrypted940, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted940, 940L))
-        .values(941L, 741L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:02:06Z").toEpochSecond(), encrypted941, "{\"owner\":\"NonExistant\",\"mode\":\"0400\"}", computeRowHmac(SECRETS_CONTENT.getName(), encrypted941, 941L))
-        .values(942L, 742L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:02:06Z").toEpochSecond(), encrypted942, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted942, 942L))
-        .values(943L, 742L, OffsetDateTime.parse("2011-09-29T16:46:00Z").toEpochSecond(), OffsetDateTime.parse("2011-09-29T16:46:00Z").toEpochSecond(), encrypted943, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted943, 943L))
-        .values(944L, 742L, OffsetDateTime.parse("2011-09-29T17:46:00Z").toEpochSecond(), OffsetDateTime.parse("2011-09-29T17:46:00Z").toEpochSecond(), encrypted944, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted944, 944L))
-        .values(945L, 742L, OffsetDateTime.parse("2011-09-29T18:46:00Z").toEpochSecond(), OffsetDateTime.parse("2011-09-29T18:46:00Z").toEpochSecond(), encrypted945, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted945, 945L))
-        .values(946L, 743L, OffsetDateTime.parse("2016-06-08T02:03:04Z").toEpochSecond(), OffsetDateTime.parse("2016-06-08T02:03:04Z").toEpochSecond(), encrypted946, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted946, 946L))
+        .values(937L, 737L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:00:47Z").toEpochSecond(), encrypted937, "{\"mode\":\"0400\",\"owner\":\"nobody\"}", computeRowHmac(SECRETS_CONTENT.getName(), encrypted937, "{\"mode\":\"0400\",\"owner\":\"nobody\"}", 937L))
+        .values(938L, 738L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:01:59Z").toEpochSecond(), encrypted938, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted938, "", 938L))
+        .values(939L, 739L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:02:06Z").toEpochSecond(), encrypted939, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted939, "", 939L))
+        .values(940L, 740L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:02:06Z").toEpochSecond(), encrypted940, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted940, "", 940L))
+        .values(941L, 741L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:02:06Z").toEpochSecond(), encrypted941, "{\"owner\":\"NonExistant\",\"mode\":\"0400\"}", computeRowHmac(SECRETS_CONTENT.getName(), encrypted941, "{\"owner\":\"NonExistant\",\"mode\":\"0400\"}", 941L))
+        .values(942L, 742L, OffsetDateTime.parse("2011-09-29T15:46:00Z").toEpochSecond(), OffsetDateTime.parse("2015-01-07T12:02:06Z").toEpochSecond(), encrypted942, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted942, "", 942L))
+        .values(943L, 742L, OffsetDateTime.parse("2011-09-29T16:46:00Z").toEpochSecond(), OffsetDateTime.parse("2011-09-29T16:46:00Z").toEpochSecond(), encrypted943, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted943, "", 943L))
+        .values(944L, 742L, OffsetDateTime.parse("2011-09-29T17:46:00Z").toEpochSecond(), OffsetDateTime.parse("2011-09-29T17:46:00Z").toEpochSecond(), encrypted944, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted944, "", 944L))
+        .values(945L, 742L, OffsetDateTime.parse("2011-09-29T18:46:00Z").toEpochSecond(), OffsetDateTime.parse("2011-09-29T18:46:00Z").toEpochSecond(), encrypted945, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted945, "", 945L))
+        .values(946L, 743L, OffsetDateTime.parse("2016-06-08T02:03:04Z").toEpochSecond(), OffsetDateTime.parse("2016-06-08T02:03:04Z").toEpochSecond(), encrypted946, "", computeRowHmac(SECRETS_CONTENT.getName(), encrypted946, "", 946L))
         .execute();
 
     dslContext

--- a/server/src/main/java/keywhiz/service/crypto/RowHmacGenerator.java
+++ b/server/src/main/java/keywhiz/service/crypto/RowHmacGenerator.java
@@ -35,6 +35,11 @@ public class RowHmacGenerator {
     return cryptographer.computeHmacWithSecretKey(hmacContent.getBytes(UTF_8), hmacKey);
   }
 
+  public String computeRowHmac(String table, String content, String metadata, long id) {
+    String hmacContent = table + "|" + content + "|" + metadata + "|" + id;
+    return cryptographer.computeHmacWithSecretKey(hmacContent.getBytes(UTF_8), hmacKey);
+  }
+
   /**
    * The random long generated with random.nextLong only uses 48 bits of randomness,
    * meaning it will not return all possible long values. Instead we generate a long from 8

--- a/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretContentDAOTest.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import keywhiz.KeywhizTestRunner;
 import keywhiz.api.ApiDate;
 import keywhiz.api.model.SecretContent;
+import keywhiz.service.crypto.RowHmacGenerator;
 import keywhiz.service.daos.SecretContentDAO.SecretContentDAOFactory;
 import org.jooq.DSLContext;
 import org.jooq.tools.json.JSONObject;
@@ -39,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 public class SecretContentDAOTest {
   @Inject DSLContext jooqContext;
   @Inject SecretContentDAOFactory secretContentDAOFactory;
+  @Inject private RowHmacGenerator rowHmacGenerator;
 
   final static ApiDate date = ApiDate.now();
   ImmutableMap<String, String> metadata = ImmutableMap.of("foo", "bar");
@@ -68,7 +70,9 @@ public class SecretContentDAOTest {
         .set(SECRETS_CONTENT.UPDATEDBY, secretContent1.updatedBy())
         .set(SECRETS_CONTENT.METADATA, JSONObject.toJSONString(secretContent1.metadata()))
         .set(SECRETS_CONTENT.EXPIRY, 1136214245L)
-        .set(SECRETS_CONTENT.ROW_HMAC, "2FE12084DF2D9E60B2362AE6CCF63C8059552640E805B07CD65E4A92930E3922")
+        .set(SECRETS_CONTENT.ROW_HMAC, rowHmacGenerator.computeRowHmac(SECRETS_CONTENT.getName(),
+            secretContent1.encryptedContent(), JSONObject.toJSONString(secretContent1.metadata()),
+            secretContent1.id()))
         .execute();
   }
 

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -117,7 +117,9 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.METADATA,
             objectMapper.writeValueAsString(secret1.content().metadata()))
         .set(SECRETS_CONTENT.ROW_HMAC, rowHmacGenerator.computeRowHmac(SECRETS_CONTENT.getName(),
-            secret1.content().encryptedContent(), secret1.content().id()))
+            secret1.content().encryptedContent(),
+            objectMapper.writeValueAsString(secret1.content().metadata()),
+            secret1.content().id()))
         .execute();
 
     jooqContext.insertInto(SECRETS)
@@ -143,7 +145,9 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.METADATA,
             objectMapper.writeValueAsString(secret2a.content().metadata()))
         .set(SECRETS_CONTENT.ROW_HMAC, rowHmacGenerator.computeRowHmac(SECRETS_CONTENT.getName(),
-            secret2a.content().encryptedContent(), secret2a.content().id()))
+            secret2a.content().encryptedContent(),
+            objectMapper.writeValueAsString(secret2a.content().metadata()),
+            secret2a.content().id()))
         .execute();
 
     jooqContext.insertInto(SECRETS_CONTENT)
@@ -158,7 +162,9 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.METADATA,
             objectMapper.writeValueAsString(secret2b.content().metadata()))
         .set(SECRETS_CONTENT.ROW_HMAC, rowHmacGenerator.computeRowHmac(SECRETS_CONTENT.getName(),
-            secret2b.content().encryptedContent(), secret2b.content().id()))
+            secret2b.content().encryptedContent(),
+            objectMapper.writeValueAsString(secret2b.content().metadata()),
+            secret2b.content().id()))
         .execute();
 
     jooqContext.insertInto(SECRETS)
@@ -184,7 +190,9 @@ public class SecretDAOTest {
         .set(SECRETS_CONTENT.METADATA,
             objectMapper.writeValueAsString(secret3.content().metadata()))
         .set(SECRETS_CONTENT.ROW_HMAC, rowHmacGenerator.computeRowHmac(SECRETS_CONTENT.getName(),
-            secret3.content().encryptedContent(), secret3.content().id()))
+            secret3.content().encryptedContent(),
+            objectMapper.writeValueAsString(secret3.content().metadata()),
+            secret3.content().id()))
         .execute();
 
     secretDAO = secretDAOFactory.readwrite();


### PR DESCRIPTION
keysync uses the metadata field in secrets_content for file permissions when writing secrets to disk. we need to include this value in the hmac to prevent secrets from being made world-readable by attackers