### PR TITLE
Do not collect warnings by default

### DIFF
--- a/server/src/main/java/keywhiz/utility/DSLContexts.java
+++ b/server/src/main/java/keywhiz/utility/DSLContexts.java
@@ -48,6 +48,7 @@ public class DSLContexts {
     }
     return DSL.using(dataSource, dialect,
             new Settings()
+                .withFetchWarnings(false)
                 .withRenderSchema(false)
                 .withRenderNameStyle(RenderNameStyle.AS_IS));
     }


### PR DESCRIPTION
This saves an extra query on each database transaction.  Currently,
SHOW WARNINGS is a common and essentially unused query in Keywhiz'
regular operations.