### PR TITLE
Add additional constraints to endpoint for listing expiring secrets

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/SecretController.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretController.java
@@ -75,7 +75,7 @@ public class SecretController {
    * @return all existing secrets matching criteria.
    * */
   public List<Secret> getSecretsForGroup(Group group) {
-    return secretDAO.getSecrets(null, group).stream()
+    return secretDAO.getSecrets(null, group, null, null, null).stream()
         .map(transformer::transform)
         .collect(toList());
   }
@@ -85,18 +85,23 @@ public class SecretController {
    * @param group limit results to secrets assigned to this group, if provided.
    * @return all existing sanitized secrets matching criteria.
    * */
-  public List<SanitizedSecret> getSanitizedSecrets(@Nullable Long expireMaxTime, Group group) {
-    return secretDAO.getSecrets(expireMaxTime, group).stream()
+  public List<SanitizedSecret> getSanitizedSecrets(@Nullable Long expireMaxTime, @Nullable Group group) {
+    return secretDAO.getSecrets(expireMaxTime, group, null, null, null).stream()
         .map(SanitizedSecret::fromSecretSeriesAndContent)
         .collect(toList());
   }
 
   /**
    * @param expireMaxTime timestamp for farthest expiry to include
+   * @param expireMinTime timestamp for smallest expiry to include
+   * @param limit limit on number of results to return
+   * @param offset offset into the list of results to use; must be specified with "limit"
    * @return all existing sanitized secrets and their groups matching criteria.
    * */
-  public List<SanitizedSecretWithGroups> getExpiringSanitizedSecrets(@Nullable Long expireMaxTime) {
-    ImmutableList<SecretSeriesAndContent> secrets = secretDAO.getSecrets(expireMaxTime, null);
+  public List<SanitizedSecretWithGroups> getSanitizedSecretsWithGroups(@Nullable Long expireMaxTime,
+      @Nullable Long expireMinTime, @Nullable Integer limit, @Nullable Integer offset) {
+    ImmutableList<SecretSeriesAndContent> secrets = secretDAO.getSecrets(expireMaxTime, null,
+        expireMinTime, limit, offset);
 
     Map<Long, SecretSeriesAndContent> secretIds = secrets.stream()
         .collect(toMap(s -> s.series().id(), s -> s));

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -285,14 +285,16 @@ public class SecretDAO {
 
   /** @return list of secrets. can limit/sort by expiry, and for group if given */
   public ImmutableList<SecretSeriesAndContent> getSecrets(@Nullable Long expireMaxTime,
-      Group group) {
+      @Nullable Group group, @Nullable Long expireMinTime, @Nullable Integer limit,
+      @Nullable Integer offset) {
     return dslContext.transactionResult(configuration -> {
       SecretContentDAO secretContentDAO = secretContentDAOFactory.using(configuration);
       SecretSeriesDAO secretSeriesDAO = secretSeriesDAOFactory.using(configuration);
 
       ImmutableList.Builder<SecretSeriesAndContent> secretsBuilder = ImmutableList.builder();
 
-      for (SecretSeries series : secretSeriesDAO.getSecretSeries(expireMaxTime, group)) {
+      for (SecretSeries series : secretSeriesDAO.getSecretSeries(expireMaxTime, group,
+          expireMinTime, limit, offset)) {
         SecretContent content =
             secretContentDAO.getSecretContentById(series.currentVersion().get()).get();
         SecretSeriesAndContent seriesAndContent = SecretSeriesAndContent.of(series, content);

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -198,14 +198,14 @@ public class SecretSeriesDAO {
       // Set a lower bound of "now" on the expiration only if it isn't configured separately
       if (expireMinTime == null || expireMinTime == 0) {
         long now = System.currentTimeMillis() / 1000L;
-        select.addConditions(SECRETS_CONTENT.EXPIRY.greaterOrEqual(now));
+        select.addConditions(SECRETS_CONTENT.EXPIRY.greaterThan(now));
       }
       select.addConditions(SECRETS_CONTENT.EXPIRY.lessOrEqual(expireMaxTime));
     }
 
     // Set a lower bound on expiration dates
     if (expireMinTime != null && expireMinTime > 0) {
-      select.addConditions(SECRETS_CONTENT.EXPIRY.greaterOrEqual(expireMinTime));
+      select.addConditions(SECRETS_CONTENT.EXPIRY.greaterThan(expireMinTime));
     }
 
     if (group != null) {

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -186,16 +186,26 @@ public class SecretSeriesDAO {
     return Optional.ofNullable(r).map(secretSeriesMapper::map);
   }
 
-  public ImmutableList<SecretSeries> getSecretSeries(@Nullable Long expireMaxTime, Group group) {
+  public ImmutableList<SecretSeries> getSecretSeries(@Nullable Long expireMaxTime,
+      @Nullable Group group, @Nullable Long expireMinTime, @Nullable Integer limit, @Nullable Integer offset) {
     SelectQuery<Record> select = dslContext
         .select().from(SECRETS).join(SECRETS_CONTENT).on(SECRETS.CURRENT.equal(SECRETS_CONTENT.ID))
         .where(SECRETS.CURRENT.isNotNull()).getQuery();
+    select.addOrderBy(SECRETS_CONTENT.EXPIRY.asc().nullsLast());
 
+    // Set an upper bound on expiration dates
     if (expireMaxTime != null && expireMaxTime > 0) {
-      select.addOrderBy(SECRETS_CONTENT.EXPIRY.asc().nullsLast());
-      long now = System.currentTimeMillis() / 1000L;
-      select.addConditions(SECRETS_CONTENT.EXPIRY.greaterThan(now));
+      // Set a lower bound of "now" on the expiration only if it isn't configured separately
+      if (expireMinTime == null || expireMinTime == 0) {
+        long now = System.currentTimeMillis() / 1000L;
+        select.addConditions(SECRETS_CONTENT.EXPIRY.greaterOrEqual(now));
+      }
       select.addConditions(SECRETS_CONTENT.EXPIRY.lessOrEqual(expireMaxTime));
+    }
+
+    // Set a lower bound on expiration dates
+    if (expireMinTime != null && expireMinTime > 0) {
+      select.addConditions(SECRETS_CONTENT.EXPIRY.greaterOrEqual(expireMinTime));
     }
 
     if (group != null) {
@@ -203,6 +213,16 @@ public class SecretSeriesDAO {
       select.addJoin(GROUPS, GROUPS.ID.eq(ACCESSGRANTS.GROUPID));
       select.addConditions(GROUPS.NAME.eq(group.getName()));
     }
+
+    if (limit != null && limit >= 0) {
+      select.addLimit(limit);
+
+      // The offset syntax requires a limit to be specified
+      if (offset != null && offset >= 0) {
+        select.addOffset(offset);
+      }
+    }
+
     List<SecretSeries> r = select.fetchInto(SECRETS).map(secretSeriesMapper);
     return ImmutableList.copyOf(r);
   }

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -325,19 +325,34 @@ public class SecretResource {
   }
 
   /**
-   * Retrieve listing of secrets expiring soon
+   * Retrieve listing of secrets expiring soon (i. e. before the time specified in "maxTime").
+   * The query parameters can be used to introduce pagination.  Instead of retrieving all secrets
+   * expiring before maxTime, clients can retrieve all secrets expiring between minTime and maxTime,
+   * or up to "limit" secrets expiring between minTime and maxTime, or "limit" secrets starting
+   * at offset "offset" between minTime and maxTime.
+   *
+   * Since limit + offset will be slow for large offsets, pagination should primarily be enforced
+   * by adjusting minTime and maxTime.
+   *
+   * The returned secrets will be sorted in increasing order of expiration time.
    *
    * @excludeParams automationClient
-   * @param time timestamp for farthest expiry to include
+   * @param maxTime timestamp for farthest expiry to include (inclusive)
+   * @param minTime timestamp for nearest expiry to include (inclusive)
+   * @param limit maximum number of secrets and groups to return
+   * @param offset offset to use into the list of secrets and groups; ignored if "limit" is not
+   *               specified
    *
    * @responseMessage 200 List of secrets expiring soon
    */
   @Timed @ExceptionMetered
-  @Path("expiring/v3/{time}")
+  @Path("expiring/v3/{maxtime}")
   @GET
   @Produces(APPLICATION_JSON)
-  public Iterable<SanitizedSecretWithGroups> secretListingExpiringV3(@Auth AutomationClient automationClient, @PathParam("time") Long time) {
-    List<SanitizedSecretWithGroups> secrets = secretControllerReadOnly.getExpiringSanitizedSecrets(time);
+  public Iterable<SanitizedSecretWithGroups> secretListingExpiringV3(@Auth AutomationClient automationClient,
+      @PathParam("maxtime") Long maxTime, @QueryParam("mintime") Long minTime,
+      @QueryParam("limit") Integer limit, @QueryParam("offset") Integer offset) {
+    List<SanitizedSecretWithGroups> secrets = secretControllerReadOnly.getSanitizedSecretsWithGroups(maxTime, minTime, limit, offset);
     return secrets;
   }
 

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -338,7 +338,7 @@ public class SecretResource {
    *
    * @excludeParams automationClient
    * @param maxTime timestamp for farthest expiry to include (inclusive)
-   * @param minTime timestamp for nearest expiry to include (inclusive)
+   * @param minTime timestamp for nearest expiry to include (exclusive)
    * @param limit maximum number of secrets and groups to return
    * @param offset offset to use into the list of secrets and groups; ignored if "limit" is not
    *               specified

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -222,7 +222,7 @@ public class SecretDAOTest {
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore + 1);
 
     newSecret = secretDAO.getSecretByName(newSecret.series().name()).get();
-    assertThat(secretDAO.getSecrets(null, null)).containsOnly(secret1, secret2b, newSecret);
+    assertThat(secretDAO.getSecrets(null, null, null, null, null)).containsOnly(secret1, secret2b, newSecret);
   }
 
   @Test(expected = DataAccessException.class)
@@ -288,7 +288,7 @@ public class SecretDAOTest {
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore + 1);
 
     newSecret = secretDAO.getSecretByName(newSecret.series().name()).get();
-    assertThat(secretDAO.getSecrets(null, null)).containsOnly(secret1, secret2b, newSecret);
+    assertThat(secretDAO.getSecrets(null, null, null, null, null)).containsOnly(secret1, secret2b, newSecret);
   }
 
   @Test public void createOrUpdateSecretWhenSecretExists() {
@@ -464,7 +464,7 @@ public class SecretDAOTest {
   }
 
   @Test public void getSecrets() {
-    assertThat(secretDAO.getSecrets(null, null)).containsOnly(secret1, secret2b);
+    assertThat(secretDAO.getSecrets(null, null, null, null, null)).containsOnly(secret1, secret2b);
   }
 
   @Test public void getSecretsByNameOnly() {

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -184,7 +184,7 @@ public class SecretResourceTest {
     Response httpResponse = mutualSslClient.newCall(post).execute();
     assertThat(httpResponse.code()).isEqualTo(404);
   }
-  
+
   //---------------------------------------------------------------------------------------
   // secretInfo
   //---------------------------------------------------------------------------------------
@@ -355,7 +355,7 @@ public class SecretResourceTest {
         .name("secret12")
         .content(encoder.encodeToString("supa secret12".getBytes(UTF_8)))
         .build());
-    
+
     createGroup("testGroup");
     ModifyGroupsRequestV2 request = ModifyGroupsRequestV2.builder()
         .addGroups("testGroup", "secret12")
@@ -582,7 +582,7 @@ public class SecretResourceTest {
     assertThat(s4.get(1).name()).isEqualTo("secret19");
     assertThat(s4.get(1).expiry()).isEqualTo(now + 86400 * 2);
 
-    List<SanitizedSecretWithGroups> s5 = listExpiringV3(now + 86400 * 2, null);
+    List<SanitizedSecretWithGroups> s5 = listExpiringV3(now + 86400 * 2, null, null, null, null);
     assertThat(s5).hasSize(2);
     assertThat(s5.get(0).secret().name()).isEqualTo("secret18");
     assertThat(s5.get(0).secret().expiry()).isEqualTo(now + 86400);
@@ -590,6 +590,23 @@ public class SecretResourceTest {
     assertThat(s5.get(1).secret().name()).isEqualTo("secret19");
     assertThat(s5.get(1).secret().expiry()).isEqualTo(now + 86400 * 2);
     assertThat(s5.get(1).groups().stream().map(Group::getName).collect(toList())).containsExactly("group15b");
+
+    List<SanitizedSecretWithGroups> s6 = listExpiringV3(now + 86400 * 4, null, now + 86400 * 2, null, null);
+    assertThat(s6).hasSize(2);
+    assertThat(s6.get(0).secret().name()).isEqualTo("secret19");
+    assertThat(s6.get(0).groups().stream().map(Group::getName).collect(toList())).containsExactly("group15b");
+    assertThat(s6.get(1).secret().name()).isEqualTo("secret17");
+    assertThat(s6.get(1).groups().stream().map(Group::getName).collect(toList())).containsExactlyInAnyOrder("group15a", "group15b");
+
+    List<SanitizedSecretWithGroups> s7 = listExpiringV3(now + 86400 * 4, null, now + 86400 * 2, 3, 1);
+    assertThat(s7).hasSize(1);
+    assertThat(s7.get(0).secret().name()).isEqualTo("secret17");
+    assertThat(s7.get(0).groups().stream().map(Group::getName).collect(toList())).containsExactlyInAnyOrder("group15a", "group15b");
+
+    List<SanitizedSecretWithGroups> s8 = listExpiringV3(now + 86400 * 4, null, now + 86400 * 2, 1, 0);
+    assertThat(s8).hasSize(1);
+    assertThat(s8.get(0).secret().name()).isEqualTo("secret19");
+    assertThat(s8.get(0).groups().stream().map(Group::getName).collect(toList())).containsExactly("group15b");
   }
 
   //---------------------------------------------------------------------------------------
@@ -918,14 +935,45 @@ public class SecretResourceTest {
     });
   }
 
-  List<SanitizedSecretWithGroups> listExpiringV3(Long time, String groupName) throws IOException {
+  List<SanitizedSecretWithGroups> listExpiringV3(Long maxTime, String groupName, Long minTime,
+      Integer limit, Integer offset) throws IOException {
     String requestURL = "/automation/v2/secrets/expiring/v3/";
-    if (time != null && time > 0) {
-      requestURL += time.toString() + '/';
+    if (maxTime != null && maxTime > 0) {
+      requestURL += maxTime.toString() + '/';
     }
     if (groupName != null && groupName.length() > 0) {
       requestURL += groupName;
     }
+
+    // This should probably be replaced with a proper query library
+    if (minTime != null || limit != null || offset != null) {
+      requestURL += "?";
+
+      boolean firstQueryParam = true;
+      if (minTime != null) {
+        requestURL += "mintime=";
+        requestURL += minTime.toString();
+        firstQueryParam = false;
+      }
+
+      if (limit != null) {
+        if(!firstQueryParam) {
+          requestURL += "&";
+        }
+        requestURL += "limit=";
+        requestURL += limit.toString();
+        firstQueryParam = false;
+      }
+
+      if (offset != null) {
+        if(!firstQueryParam) {
+          requestURL += "&";
+        }
+        requestURL += "offset=";
+        requestURL += offset.toString();
+      }
+    }
+
     Request get = clientRequest(requestURL).get().build();
     Response httpResponse = mutualSslClient.newCall(get).execute();
     assertThat(httpResponse.code()).isEqualTo(200);

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -591,19 +591,19 @@ public class SecretResourceTest {
     assertThat(s5.get(1).secret().expiry()).isEqualTo(now + 86400 * 2);
     assertThat(s5.get(1).groups().stream().map(Group::getName).collect(toList())).containsExactly("group15b");
 
-    List<SanitizedSecretWithGroups> s6 = listExpiringV3(now + 86400 * 4, null, now + 86400 * 2, null, null);
+    List<SanitizedSecretWithGroups> s6 = listExpiringV3(now + 86400 * 4, null, now + 86400, null, null);
     assertThat(s6).hasSize(2);
     assertThat(s6.get(0).secret().name()).isEqualTo("secret19");
     assertThat(s6.get(0).groups().stream().map(Group::getName).collect(toList())).containsExactly("group15b");
     assertThat(s6.get(1).secret().name()).isEqualTo("secret17");
     assertThat(s6.get(1).groups().stream().map(Group::getName).collect(toList())).containsExactlyInAnyOrder("group15a", "group15b");
 
-    List<SanitizedSecretWithGroups> s7 = listExpiringV3(now + 86400 * 4, null, now + 86400 * 2, 3, 1);
+    List<SanitizedSecretWithGroups> s7 = listExpiringV3(now + 86400 * 4, null, now + 86400, 3, 1);
     assertThat(s7).hasSize(1);
     assertThat(s7.get(0).secret().name()).isEqualTo("secret17");
     assertThat(s7.get(0).groups().stream().map(Group::getName).collect(toList())).containsExactlyInAnyOrder("group15a", "group15b");
 
-    List<SanitizedSecretWithGroups> s8 = listExpiringV3(now + 86400 * 4, null, now + 86400 * 2, 1, 0);
+    List<SanitizedSecretWithGroups> s8 = listExpiringV3(now + 86400 * 4, null, now + 86400, 1, 0);
     assertThat(s8).hasSize(1);
     assertThat(s8.get(0).secret().name()).isEqualTo("secret19");
     assertThat(s8.get(0).groups().stream().map(Group::getName).collect(toList())).containsExactly("group15b");


### PR DESCRIPTION
This adds the ability to specify a minimum expiration date (as well
as a maximum), a maximum number of records to return, and an offset
within the number of records returned to the endpoint which returns
a list of expiring secrets and their associated groups.  This allows
clients to restrict the number of secrets that will be retrieved,
either by specifying a limit and offset (noting that this will be
slow for large offsets) or by adjusting the minimum and maximum
expiration dates retrieved and using limits and offsets as needed
to further constrain the total number of records retrieved.