### PR TITLE
Add endpoint to retrieve expiring secrets with pagination

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,7 +14,7 @@
     <!-- External Dependencies -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -67,6 +67,12 @@
       <artifactId>keywhiz-testing</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-jackson</artifactId>
+      <version>1.3.14</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/api/src/main/java/keywhiz/api/model/SanitizedSecretWithGroupsListAndCursor.java
+++ b/api/src/main/java/keywhiz/api/model/SanitizedSecretWithGroupsListAndCursor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keywhiz.api.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import java.util.List;
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * {@link Secret} object, but without the secret content and with group metadata, and
+ * a cursor that can be used to retrieve the next secrets in a list ordered by expiration and name
+ */
+@AutoValue
+public abstract class SanitizedSecretWithGroupsListAndCursor {
+  @JsonCreator public static SanitizedSecretWithGroupsListAndCursor of(
+      @JsonProperty("secrets") List<SanitizedSecretWithGroups> secretsWithGroups,
+      @JsonProperty("cursor") @Nullable String cursor) {
+    return new AutoValue_SanitizedSecretWithGroupsListAndCursor(secretsWithGroups, cursor);
+  }
+
+  @JsonProperty public abstract List<SanitizedSecretWithGroups> secrets();
+  @JsonProperty @Nullable public abstract String cursor();
+
+  @Nullable public SecretRetrievalCursor decodedCursor() {
+    return SecretRetrievalCursor.fromUrlEncodedString(cursor());
+  }
+}

--- a/api/src/main/java/keywhiz/api/model/SecretRetrievalCursor.java
+++ b/api/src/main/java/keywhiz/api/model/SecretRetrievalCursor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keywhiz.api.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auto.value.AutoValue;
+import io.dropwizard.jackson.Jackson;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import javax.annotation.Nullable;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * a cursor for use when retrieving secrets with pagination
+ */
+@AutoValue
+public abstract class SecretRetrievalCursor {
+  @JsonCreator public static SecretRetrievalCursor of(
+      @JsonProperty("name") String name,
+      @JsonProperty("expiry") long expiry) {
+    return new AutoValue_SecretRetrievalCursor(name, expiry);
+  }
+
+  @Nullable public static SecretRetrievalCursor fromUrlEncodedString(@Nullable String encodedJson) {
+    if (encodedJson == null) {
+      return null;
+    }
+    String jsonDecoded = URLDecoder.decode(encodedJson, UTF_8);
+    ObjectMapper mapper = Jackson.newObjectMapper();
+    try {
+      return mapper.readValue(jsonDecoded, SecretRetrievalCursor.class);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  @Nullable public static String toUrlEncodedString(@Nullable SecretRetrievalCursor cursor)
+      throws JsonProcessingException {
+    if (cursor == null) {
+      return null;
+    }
+    ObjectMapper mapper = Jackson.newObjectMapper();
+    // URL-encode the JSON value
+    return URLEncoder.encode(mapper.writeValueAsString(cursor), UTF_8);
+  }
+
+  @Nullable public static String toString(@Nullable SecretRetrievalCursor cursor)
+      throws JsonProcessingException {
+    if (cursor == null) {
+      return null;
+    }
+    ObjectMapper mapper = Jackson.newObjectMapper();
+    return mapper.writeValueAsString(cursor);
+  }
+
+  @JsonProperty public abstract String name();
+
+  @JsonProperty public abstract Long expiry();
+}

--- a/api/src/test/java/keywhiz/api/model/SanitizedSecretWithGroupsListAndCursorTest.java
+++ b/api/src/test/java/keywhiz/api/model/SanitizedSecretWithGroupsListAndCursorTest.java
@@ -1,0 +1,58 @@
+package keywhiz.api.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import keywhiz.api.ApiDate;
+import org.junit.Before;
+import org.junit.Test;
+
+import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.jsonFixture;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SanitizedSecretWithGroupsListAndCursorTest {
+  private SanitizedSecretWithGroupsListAndCursor sanitizedSecretWithGroupsListAndCursor;
+
+  @Before
+  public void setUp() throws Exception {
+    sanitizedSecretWithGroupsListAndCursor = SanitizedSecretWithGroupsListAndCursor.of(
+        ImmutableList.of(
+            SanitizedSecretWithGroups.of(
+                SanitizedSecret.of(
+                    767,
+                    "trapdoor",
+                    "v1",
+                    "checksum",
+                    ApiDate.parse("2013-03-28T21:42:42.000Z"),
+                    "keywhizAdmin",
+                    ApiDate.parse("2013-03-28T21:42:42.000Z"),
+                    "keywhizAdmin",
+                    ImmutableMap.of("owner", "the king"),
+                    "password",
+                    ImmutableMap.of("favoriteFood", "PB&J sandwich"),
+                    1136214245,
+                    1L,
+                    ApiDate.parse("2013-03-28T21:42:42.000Z"),
+                    "keywhizAdmin"),
+                ImmutableList.of(
+                    new Group(100, "group1", "test-group-1",
+                        ApiDate.parse("2013-03-28T21:42:42.000Z"),
+                        "keywhizAdmin",
+                        ApiDate.parse("2013-03-28T21:42:42.000Z"),
+                        "keywhizAdmin",
+                        ImmutableMap.of("owner", "the king")),
+                    new Group(100, "group2", "test-group-1",
+                        ApiDate.parse("2013-03-28T21:42:42.000Z"),
+                        null,
+                        ApiDate.parse("2013-03-28T21:42:42.000Z"), null, null))
+
+            )),
+        SecretRetrievalCursor.toString(SecretRetrievalCursor.of("test-secret-2", 1234567)));
+  }
+
+  @Test
+  public void serializesCorrectly() throws Exception {
+    assertThat(asJson(sanitizedSecretWithGroupsListAndCursor))
+        .isEqualTo(jsonFixture("fixtures/sanitizedSecretWithGroupsListAndCursor.json"));
+  }
+}

--- a/api/src/test/java/keywhiz/api/model/SecretRetrievalCursorTest.java
+++ b/api/src/test/java/keywhiz/api/model/SecretRetrievalCursorTest.java
@@ -1,0 +1,25 @@
+package keywhiz.api.model;
+
+import org.junit.Test;
+
+import static keywhiz.testing.JsonHelpers.asJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecretRetrievalCursorTest {
+  @Test
+  public void serializesCorrectly() throws Exception {
+    SecretRetrievalCursor cursor = SecretRetrievalCursor.of("test-secret", 1234567);
+    assertThat(asJson(cursor))
+        .isEqualTo("{\"name\":\"test-secret\",\"expiry\":1234567}");
+  }
+
+  @Test
+  public void roundTrip() throws Exception {
+    SecretRetrievalCursor cursor = SecretRetrievalCursor.of("test_secret-123.crt", 1234567);
+    SecretRetrievalCursor roundtripped =
+        SecretRetrievalCursor.fromUrlEncodedString(
+            SecretRetrievalCursor.toUrlEncodedString(cursor));
+
+    assertThat(roundtripped).isEqualTo(cursor);
+  }
+}

--- a/api/src/test/resources/fixtures/sanitizedSecretWithGroupsListAndCursor.json
+++ b/api/src/test/resources/fixtures/sanitizedSecretWithGroupsListAndCursor.json
@@ -1,0 +1,52 @@
+{
+  "secrets": [
+    {
+      "secret": {
+        "id": 767,
+        "name": "trapdoor",
+        "description": "v1",
+        "checksum": "checksum",
+        "createdAt": "2013-03-28T21:42:42.000Z",
+        "createdBy": "keywhizAdmin",
+        "updatedAt": "2013-03-28T21:42:42.000Z",
+        "updatedBy": "keywhizAdmin",
+        "metadata": {
+          "owner": "the king"
+        },
+        "type": "password",
+        "generationOptions": {
+          "favoriteFood": "PB&J sandwich"
+        },
+        "expiry": 1136214245,
+        "version": 1,
+        "contentCreatedAt": "2013-03-28T21:42:42.000Z",
+        "contentCreatedBy": "keywhizAdmin"
+      },
+      "groups": [
+        {
+          "id": 100,
+          "name": "group1",
+          "description": "test-group-1",
+          "createdAt": "2013-03-28T21:42:42.000Z",
+          "createdBy": "keywhizAdmin",
+          "updatedAt": "2013-03-28T21:42:42.000Z",
+          "updatedBy": "keywhizAdmin",
+          "metadata": {
+            "owner": "the king"
+          }
+        },
+        {
+          "id": 100,
+          "name": "group2",
+          "description": "test-group-1",
+          "createdAt": "2013-03-28T21:42:42.000Z",
+          "createdBy": "",
+          "updatedAt": "2013-03-28T21:42:42.000Z",
+          "updatedBy": "",
+          "metadata": {}
+        }
+      ]
+    }
+  ],
+  "cursor": "{\"name\":\"test-secret-2\",\"expiry\":1234567}"
+}

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -285,8 +285,8 @@ public class SecretDAO {
 
   /** @return list of secrets. can limit/sort by expiry, and for group if given */
   public ImmutableList<SecretSeriesAndContent> getSecrets(@Nullable Long expireMaxTime,
-      @Nullable Group group, @Nullable Long expireMinTime, @Nullable Integer limit,
-      @Nullable Integer offset) {
+      @Nullable Group group, @Nullable Long expireMinTime, @Nullable String minName,
+      @Nullable Integer limit, @Nullable Integer offset) {
     return dslContext.transactionResult(configuration -> {
       SecretContentDAO secretContentDAO = secretContentDAOFactory.using(configuration);
       SecretSeriesDAO secretSeriesDAO = secretSeriesDAOFactory.using(configuration);
@@ -294,7 +294,7 @@ public class SecretDAO {
       ImmutableList.Builder<SecretSeriesAndContent> secretsBuilder = ImmutableList.builder();
 
       for (SecretSeries series : secretSeriesDAO.getSecretSeries(expireMaxTime, group,
-          expireMinTime, limit, offset)) {
+          expireMinTime, minName, limit, offset)) {
         SecretContent content =
             secretContentDAO.getSecretContentById(series.currentVersion().get()).get();
         SecretSeriesAndContent seriesAndContent = SecretSeriesAndContent.of(series, content);

--- a/server/src/test/java/keywhiz/service/daos/SecretControllerTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretControllerTest.java
@@ -1,0 +1,180 @@
+package keywhiz.service.daos;
+
+import com.google.common.collect.ImmutableList;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.inject.Inject;
+import keywhiz.KeywhizTestRunner;
+import keywhiz.api.automation.v2.CreateSecretRequestV2;
+import keywhiz.api.model.SanitizedSecretWithGroups;
+import keywhiz.api.model.SanitizedSecretWithGroupsListAndCursor;
+import keywhiz.api.model.SecretRetrievalCursor;
+import org.jooq.DSLContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(KeywhizTestRunner.class)
+public class SecretControllerTest {
+  private long now = OffsetDateTime.now().toEpochSecond();
+  private long firstExpiry = now + 10000;
+  private long secondExpiry = now + 20000;
+  private long thirdExpiry = now + 30000;
+  private long fourthExpiry = now + 40000;
+
+  private long firstId;
+  private long secondId;
+  private long thirdId;
+  private long fourthId;
+  private long fifthId;
+
+  @Inject DSLContext jooqContext;
+  @Inject SecretSeriesDAO.SecretSeriesDAOFactory secretSeriesDAOFactory;
+  @Inject SecretContentDAO.SecretContentDAOFactory secretContentDAOFactory;
+  @Inject SecretController secretController;
+
+  SecretSeriesDAO secretSeriesDAO;
+  SecretContentDAO secretContentDAO;
+
+  @Before public void setUp() {
+    secretSeriesDAO = secretSeriesDAOFactory.readwrite();
+    secretContentDAO = secretContentDAOFactory.readwrite();
+
+    // create secrets
+    firstId = createSecret(CreateSecretRequestV2.builder()
+        .name("expiringFirst")
+        .expiry(firstExpiry)
+        .content("blah")
+        .build());
+
+    secondId = createSecret(CreateSecretRequestV2.builder()
+        .name("expiringSecond")
+        .expiry(secondExpiry)
+        .content("blah")
+        .build());
+
+    fourthId = createSecret(CreateSecretRequestV2.builder()
+        .name("expiringFourth")
+        .expiry(fourthExpiry)
+        .content("blah")
+        .build());
+
+    thirdId = createSecret(CreateSecretRequestV2.builder()
+        .name("expiringThird")
+        .expiry(thirdExpiry)
+        .content("blah")
+        .build());
+
+    fifthId = createSecret(CreateSecretRequestV2.builder()
+        .name("laterInAlphabetExpiringFourth")
+        .expiry(fourthExpiry)
+        .content("blah")
+        .build());
+  }
+
+  @Test
+  public void getSanitizedSecretsWithGroupsAndCursor_allSecrets() {
+    // Retrieving secrets with no parameters should retrieve all created secrets (although given
+    // the shared database, it's likely to also retrieve others)
+    List<SanitizedSecretWithGroups> retrievedSecrets = getAllSecretsWithCursor(null, null);
+    assertListContainsSecretsWithIds(retrievedSecrets,
+        ImmutableList.of(firstId, secondId, thirdId, fourthId, fifthId));
+
+    retrievedSecrets = getAllSecretsWithCursor(null, 4);
+    assertListContainsSecretsWithIds(retrievedSecrets,
+        ImmutableList.of(firstId, secondId, thirdId, fourthId, fifthId));
+
+    retrievedSecrets = getAllSecretsWithCursor(null, 3);
+    assertListContainsSecretsWithIds(retrievedSecrets,
+        ImmutableList.of(firstId, secondId, thirdId, fourthId, fifthId));
+
+    retrievedSecrets = getAllSecretsWithCursor(null, 1);
+    assertListContainsSecretsWithIds(retrievedSecrets,
+        ImmutableList.of(firstId, secondId, thirdId, fourthId, fifthId));
+  }
+
+  @Test
+  public void getSanitizedSecretsWithGroupsAndCursor_maxExpiryRestricted() {
+    // Retrieving secrets with no parameters should retrieve all created secrets (although given
+    // the shared database, it's likely to also retrieve others)
+    List<SanitizedSecretWithGroups> retrievedSecrets =
+        getAllSecretsWithCursor(fourthExpiry - 100, null);
+    assertListContainsSecretsWithIds(retrievedSecrets,
+        ImmutableList.of(firstId, secondId, thirdId));
+    assertListDoesNotContainSecretsWithIds(retrievedSecrets, ImmutableList.of(fourthId, fifthId));
+
+    retrievedSecrets = getAllSecretsWithCursor(fourthExpiry - 100, 4);
+    assertListContainsSecretsWithIds(retrievedSecrets,
+        ImmutableList.of(firstId, secondId, thirdId));
+    assertListDoesNotContainSecretsWithIds(retrievedSecrets, ImmutableList.of(fourthId, fifthId));
+
+    retrievedSecrets = getAllSecretsWithCursor(fourthExpiry - 100, 1);
+    assertListContainsSecretsWithIds(retrievedSecrets,
+        ImmutableList.of(firstId, secondId, thirdId));
+    assertListDoesNotContainSecretsWithIds(retrievedSecrets, ImmutableList.of(fourthId, fifthId));
+  }
+
+  /**
+   * Get all secrets matching the given criteria, using the cursor.  (This verifies that even if
+   * the cursor's implementation changes slightly, the underlying behavior remains the same).
+   *
+   * @param expireMaxTime the maximum expiration time to return
+   * @param limit the maximum number of records to return per batch
+   * @return a list of secrets matching the criteria above
+   */
+  private List<SanitizedSecretWithGroups> getAllSecretsWithCursor(Long expireMaxTime, Integer limit) {
+    List<SanitizedSecretWithGroups> allRetrievedSecrets = new ArrayList<>();
+    SecretRetrievalCursor cursor = null;
+    do {
+      SanitizedSecretWithGroupsListAndCursor retrievedSecretsAndCursor =
+          secretController.getSanitizedSecretsWithGroupsAndCursor(expireMaxTime, limit, cursor);
+      cursor = retrievedSecretsAndCursor.decodedCursor();
+
+      List<SanitizedSecretWithGroups> secrets = retrievedSecretsAndCursor.secrets();
+      assertThat(secrets).isNotNull();
+      if (limit != null) {
+        assertThat(secrets.size()).isLessThanOrEqualTo(limit);
+      }
+
+      allRetrievedSecrets.addAll(secrets);
+    } while (cursor != null);
+    return allRetrievedSecrets;
+  }
+
+  private long createSecret(CreateSecretRequestV2 createSecretRequest) {
+    long seriesId = secretSeriesDAO.createSecretSeries(createSecretRequest.name(),
+        "creator", createSecretRequest.description(), createSecretRequest.type(), null, now);
+    long contentId = secretContentDAO.createSecretContent(seriesId,
+        createSecretRequest.content(), "checksum", "creator", createSecretRequest.metadata(),
+        createSecretRequest.expiry(), now);
+    secretSeriesDAO.setCurrentVersion(seriesId, contentId, "creator", now);
+    return seriesId;
+  }
+
+  private void assertListContainsSecretsWithIds(List<SanitizedSecretWithGroups> secrets, List<Long> ids) {
+    List<Long> foundIds = new ArrayList<>();
+    for (SanitizedSecretWithGroups secretWithGroups : secrets) {
+      if (ids.contains(secretWithGroups.secret().id())) {
+        foundIds.add(secretWithGroups.secret().id());
+      }
+    }
+    assertThat(foundIds).as("List should contain secrets with IDs %s; found IDs %s in secret list %s", ids, foundIds, secrets)
+        .containsExactlyElementsOf(ids);
+  }
+
+  private void assertListDoesNotContainSecretsWithIds(List<SanitizedSecretWithGroups> secrets, List<Long> ids) {
+    Set<Long> foundIds = new HashSet<>();
+    for (SanitizedSecretWithGroups secretWithGroups : secrets) {
+      if (ids.contains(secretWithGroups.secret().id())) {
+        foundIds.add(secretWithGroups.secret().id());
+      }
+    }
+    assertThat(foundIds).as("List should NOT contain secrets with IDs %s; found IDs %s in secret list %s", ids, foundIds, secrets)
+        .isEmpty();
+  }
+}

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -222,7 +222,7 @@ public class SecretDAOTest {
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore + 1);
 
     newSecret = secretDAO.getSecretByName(newSecret.series().name()).get();
-    assertThat(secretDAO.getSecrets(null, null, null, null, null)).containsOnly(secret1, secret2b, newSecret);
+    assertThat(secretDAO.getSecrets(null, null, null,null, null, null)).containsOnly(secret1, secret2b, newSecret);
   }
 
   @Test(expected = DataAccessException.class)
@@ -288,7 +288,7 @@ public class SecretDAOTest {
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore + 1);
 
     newSecret = secretDAO.getSecretByName(newSecret.series().name()).get();
-    assertThat(secretDAO.getSecrets(null, null, null, null, null)).containsOnly(secret1, secret2b, newSecret);
+    assertThat(secretDAO.getSecrets(null, null, null, null, null, null)).containsOnly(secret1, secret2b, newSecret);
   }
 
   @Test public void createOrUpdateSecretWhenSecretExists() {
@@ -464,7 +464,7 @@ public class SecretDAOTest {
   }
 
   @Test public void getSecrets() {
-    assertThat(secretDAO.getSecrets(null, null, null, null, null)).containsOnly(secret1, secret2b);
+    assertThat(secretDAO.getSecrets(null, null, null, null, null, null)).containsOnly(secret1, secret2b);
   }
 
   @Test public void getSecretsByNameOnly() {

--- a/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
@@ -43,9 +43,11 @@ public class SecretSeriesDAOTest {
   @Inject SecretContentDAO.SecretContentDAOFactory secretContentDAOFactory;
 
   SecretSeriesDAO secretSeriesDAO;
+  SecretContentDAO secretContentDAO;
 
   @Before public void setUp() {
     secretSeriesDAO = secretSeriesDAOFactory.readwrite();
+    secretContentDAO = secretContentDAOFactory.readwrite();
   }
 
   @Test public void createAndLookupSecretSeries() {
@@ -55,7 +57,7 @@ public class SecretSeriesDAOTest {
 
     long id = secretSeriesDAO.createSecretSeries("newSecretSeries", "creator", "desc", null,
         ImmutableMap.of("foo", "bar"), now);
-    long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
+    long contentId = secretContentDAO.createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
 
@@ -83,7 +85,7 @@ public class SecretSeriesDAOTest {
     Optional<SecretSeries> secretSeriesById = secretSeriesDAO.getSecretSeriesById(id);
     assertThat(secretSeriesById).isEmpty();
 
-    long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
+    long contentId = secretContentDAO.createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "updater", now + 3600);
 
@@ -100,7 +102,7 @@ public class SecretSeriesDAOTest {
         null, null, now);
     long other = secretSeriesDAO.createSecretSeries("someOtherSecret", "creator", "",
         null, null, now);
-    long contentId = secretContentDAOFactory.readwrite().createSecretContent(other, "blah",
+    long contentId = secretContentDAO.createSecretContent(other, "blah",
         "checksum", "creator", null, 0, now);
 
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
@@ -110,7 +112,7 @@ public class SecretSeriesDAOTest {
     long now = OffsetDateTime.now().toEpochSecond();
     long id = secretSeriesDAO.createSecretSeries("toBeDeleted_deleteSecretSeriesByName", "creator",
         "", null, null, now);
-    long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
+    long contentId = secretContentDAO.createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
     assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeleted_deleteSecretSeriesByName")
@@ -128,7 +130,7 @@ public class SecretSeriesDAOTest {
     long now = OffsetDateTime.now().toEpochSecond();
     long id = secretSeriesDAO.createSecretSeries("toBeDeletedAndReplaced", "creator",
         "", null, null, now);
-    long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
+    long contentId = secretContentDAO.createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
     assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced")
@@ -143,7 +145,7 @@ public class SecretSeriesDAOTest {
 
     id = secretSeriesDAO.createSecretSeries("toBeDeletedAndReplaced", "creator",
         "", null, null, now);
-    contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah2",
+    contentId = secretContentDAO.createSecretContent(id, "blah2",
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
     assertThat(secretSeriesDAO.getSecretSeriesByName("toBeDeletedAndReplaced")
@@ -156,7 +158,7 @@ public class SecretSeriesDAOTest {
     long now = OffsetDateTime.now().toEpochSecond();
     long id = secretSeriesDAO.createSecretSeries("toBeDeleted_deleteSecretSeriesById",
         "creator", "", null, null, now);
-    long contentId = secretContentDAOFactory.readwrite().createSecretContent(id, "blah",
+    long contentId = secretContentDAO.createSecretContent(id, "blah",
         "checksum", "creator", null, 0, now);
     secretSeriesDAO.setCurrentVersion(id, contentId, "creator", now);
     assertThat(secretSeriesDAO.getSecretSeriesById(id).get().currentVersion()).isPresent();
@@ -180,54 +182,65 @@ public class SecretSeriesDAOTest {
     long fourthExpiry = now + 40000;
     long firstId = secretSeriesDAO.createSecretSeries("expiringFirst",
         "creator", "", null, null, now);
-    long firstContentId = secretContentDAOFactory.readwrite().createSecretContent(firstId,
+    long firstContentId = secretContentDAO.createSecretContent(firstId,
         "blah", "checksum", "creator", null, firstExpiry, now);
     secretSeriesDAO.setCurrentVersion(firstId, firstContentId, "creator", now);
 
     long secondId = secretSeriesDAO.createSecretSeries("expiringSecond",
         "creator", "", null, null, now);
-    long secondContentId = secretContentDAOFactory.readwrite().createSecretContent(secondId, "blah",
+    long secondContentId = secretContentDAO.createSecretContent(secondId, "blah",
         "checksum", "creator", null, secondExpiry, now);
     secretSeriesDAO.setCurrentVersion(secondId, secondContentId, "creator", now);
 
     // Make sure the rows aren't ordered by expiry
     long fourthId = secretSeriesDAO.createSecretSeries("expiringFourth",
         "creator", "", null, null, now);
-    long fourthContentId = secretContentDAOFactory.readwrite().createSecretContent(fourthId, "blah",
+    long fourthContentId = secretContentDAO.createSecretContent(fourthId, "blah",
         "checksum", "creator", null, fourthExpiry, now);
     secretSeriesDAO.setCurrentVersion(fourthId, fourthContentId, "creator", now);
 
     long thirdId = secretSeriesDAO.createSecretSeries("expiringThird",
         "creator", "", null, null, now);
-    long thirdContentId = secretContentDAOFactory.readwrite().createSecretContent(thirdId, "blah",
+    long thirdContentId = secretContentDAO.createSecretContent(thirdId, "blah",
         "checksum", "creator", null, thirdExpiry, now);
     secretSeriesDAO.setCurrentVersion(thirdId, thirdContentId, "creator", now);
 
-    // Retrieving secrets with no parameters should retrieve all four secrets (although given
+    long fifthId = secretSeriesDAO.createSecretSeries("laterInAlphabetExpiringFourth",
+        "creator", "", null, null, now);
+    long fifthContentId = secretContentDAO.createSecretContent(fifthId, "blah",
+        "checksum", "creator", null, fourthExpiry, now);
+    secretSeriesDAO.setCurrentVersion(fifthId, fifthContentId, "creator", now);
+
+    // Retrieving secrets with no parameters should retrieve all created secrets (although given
     // the shared database, it's likely to also retrieve others)
     ImmutableList<SecretSeries>
-        retrievedSeries = secretSeriesDAO.getSecretSeries(null, null, null, null, null);
-    assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, secondId, thirdId, fourthId));
+        retrievedSeries = secretSeriesDAO.getSecretSeries(null, null, null, null, null, null);
+    assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, secondId, thirdId, fourthId, fifthId));
 
-    // Restrict expireMaxTime to exclude the fourth secret
-    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, null, null, null);
+    // Restrict expireMaxTime to exclude the last secrets
+    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, null,null, null, null);
     assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, secondId, thirdId));
-    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(fourthId));
+    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(fourthId, fifthId));
 
     // Restrict expireMinTime to exclude the first secret
-    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, firstExpiry + 10, null, null);
+    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, firstExpiry + 10, null,null, null);
     assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(secondId, thirdId));
-    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, fourthId));
+    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, fourthId, fifthId));
 
     // Adjust the limit and offset to exclude the second secret
-    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, firstExpiry + 10, 2, 1);
+    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, firstExpiry + 10, null,2, 1);
     assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(thirdId));
-    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, secondId, fourthId));
+    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, secondId, fourthId, fifthId));
 
     // Adjust the limit and offset without limiting expireMinTime
-    retrievedSeries = secretSeriesDAO.getSecretSeries(null, null, null, 2, 1);
+    retrievedSeries = secretSeriesDAO.getSecretSeries(null, null, null, null, 2, 1);
     assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(secondId, thirdId));
-    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, fourthId));
+    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, fourthId, fifthId));
+
+    // Restrict the minName to exclude the fourth secret
+    retrievedSeries = secretSeriesDAO.getSecretSeries(null, null, fourthExpiry, "laterInAlphabetExpiringFourth", null, null);
+    assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(fifthId));
+    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, secondId, thirdId, fourthId));
   }
 
   private void assertListContainsSecretsWithIds(List<SecretSeries> secrets, List<Long> ids) {


### PR DESCRIPTION
This uses a simpler pagination API compared to the v3
endpoint to retrieve expiring secrets, returning no more
secrets per batch than a limit specified by the client
and managing pagination with a server-managed cursor
(the client does not need to understand how the cursor is
constructed, only return the cursor to the server if it
is provided).