### PR TITLE
Remove unused parameters from expiration-v3 endpoint

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/SecretController.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretController.java
@@ -81,7 +81,7 @@ public class SecretController {
    * @return all existing secrets matching criteria.
    * */
   public List<Secret> getSecretsForGroup(Group group) {
-    return secretDAO.getSecrets(null, group, null, null, null, null).stream()
+    return secretDAO.getSecrets(null, group, null, null, null).stream()
         .map(transformer::transform)
         .collect(toList());
   }
@@ -92,22 +92,18 @@ public class SecretController {
    * @return all existing sanitized secrets matching criteria.
    * */
   public List<SanitizedSecret> getSanitizedSecrets(@Nullable Long expireMaxTime, @Nullable Group group) {
-    return secretDAO.getSecrets(expireMaxTime, group, null, null, null, null).stream()
+    return secretDAO.getSecrets(expireMaxTime, group, null, null, null).stream()
         .map(SanitizedSecret::fromSecretSeriesAndContent)
         .collect(toList());
   }
 
   /**
    * @param expireMaxTime timestamp for farthest expiry to include
-   * @param expireMinTime timestamp for smallest expiry to include
-   * @param limit limit on number of results to return
-   * @param offset offset into the list of results to use; must be specified with "limit"
    * @return all existing sanitized secrets and their groups matching criteria.
    * */
-  public List<SanitizedSecretWithGroups> getSanitizedSecretsWithGroups(@Nullable Long expireMaxTime,
-      @Nullable Long expireMinTime, @Nullable Integer limit, @Nullable Integer offset) {
+  public List<SanitizedSecretWithGroups> getSanitizedSecretsWithGroups(@Nullable Long expireMaxTime) {
     ImmutableList<SecretSeriesAndContent> secrets = secretDAO.getSecrets(expireMaxTime, null,
-        expireMinTime, null, limit, offset);
+        null, null, null);
 
     Map<Long, SecretSeriesAndContent> secretIds = secrets.stream()
         .collect(toMap(s -> s.series().id(), s -> s));
@@ -143,10 +139,10 @@ public class SecretController {
     }
 
     if (cursor == null) {
-      secrets = secretDAO.getSecrets(expireMaxTime, null, null, null, updatedLimit, 0);
+      secrets = secretDAO.getSecrets(expireMaxTime, null, null, null, updatedLimit);
     } else {
       secrets = secretDAO.getSecrets(expireMaxTime, null, cursor.expiry(), cursor.name(),
-          updatedLimit, 0);
+          updatedLimit);
     }
 
     // Set the cursor and strip the final record from the secrets if necessary

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -286,7 +286,7 @@ public class SecretDAO {
   /** @return list of secrets. can limit/sort by expiry, and for group if given */
   public ImmutableList<SecretSeriesAndContent> getSecrets(@Nullable Long expireMaxTime,
       @Nullable Group group, @Nullable Long expireMinTime, @Nullable String minName,
-      @Nullable Integer limit, @Nullable Integer offset) {
+      @Nullable Integer limit) {
     return dslContext.transactionResult(configuration -> {
       SecretContentDAO secretContentDAO = secretContentDAOFactory.using(configuration);
       SecretSeriesDAO secretSeriesDAO = secretSeriesDAOFactory.using(configuration);
@@ -294,7 +294,7 @@ public class SecretDAO {
       ImmutableList.Builder<SecretSeriesAndContent> secretsBuilder = ImmutableList.builder();
 
       for (SecretSeries series : secretSeriesDAO.getSecretSeries(expireMaxTime, group,
-          expireMinTime, minName, limit, offset)) {
+          expireMinTime, minName, limit)) {
         SecretContent content =
             secretContentDAO.getSecretContentById(series.currentVersion().get()).get();
         SecretSeriesAndContent seriesAndContent = SecretSeriesAndContent.of(series, content);

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -187,7 +187,7 @@ public class SecretSeriesDAO {
 
   public ImmutableList<SecretSeries> getSecretSeries(@Nullable Long expireMaxTime,
       @Nullable Group group, @Nullable Long expireMinTime, @Nullable String minName,
-      @Nullable Integer limit, @Nullable Integer offset) {
+      @Nullable Integer limit) {
     SelectQuery<Record> select = dslContext
           .select()
           .from(SECRETS)
@@ -222,11 +222,6 @@ public class SecretSeriesDAO {
 
     if (limit != null && limit >= 0) {
       select.addLimit(limit);
-
-      // The offset syntax requires a limit to be specified
-      if (offset != null && offset >= 0) {
-        select.addOffset(offset);
-      }
     }
 
     List<SecretSeries> r = select.fetchInto(SECRETS).map(secretSeriesMapper);

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -340,22 +340,16 @@ public class SecretResource {
    *
    * @excludeParams automationClient
    * @param maxTime timestamp for farthest expiry to include (exclusive)
-   * @param minTime timestamp for nearest expiry to include (inclusive)
-   * @param limit maximum number of secrets and groups to return
-   * @param offset offset to use into the list of secrets and groups; ignored if "limit" is not
-   *               specified
    *
    * @responseMessage 200 List of secrets expiring soon
    */
   @Timed @ExceptionMetered
-  @Path("expiring/v3/{maxtime}")
+  @Path("expiring/v3/{time}")
   @GET
   @Produces(APPLICATION_JSON)
   public Iterable<SanitizedSecretWithGroups> secretListingExpiringV3(@Auth AutomationClient automationClient,
-      @PathParam("maxtime") Long maxTime, @QueryParam("mintime") Long minTime,
-      @QueryParam("limit") Integer limit, @QueryParam("offset") Integer offset) {
-    List<SanitizedSecretWithGroups> secrets = secretControllerReadOnly.getSanitizedSecretsWithGroups(maxTime, minTime, limit, offset);
-    return secrets;
+      @PathParam("time") Long maxTime) {
+    return secretControllerReadOnly.getSanitizedSecretsWithGroups(maxTime);
   }
 
   /**

--- a/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretDAOTest.java
@@ -222,7 +222,7 @@ public class SecretDAOTest {
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore + 1);
 
     newSecret = secretDAO.getSecretByName(newSecret.series().name()).get();
-    assertThat(secretDAO.getSecrets(null, null, null,null, null, null)).containsOnly(secret1, secret2b, newSecret);
+    assertThat(secretDAO.getSecrets(null, null, null,null, null)).containsOnly(secret1, secret2b, newSecret);
   }
 
   @Test(expected = DataAccessException.class)
@@ -288,7 +288,7 @@ public class SecretDAOTest {
     assertThat(tableSize(SECRETS_CONTENT)).isEqualTo(secretContentsBefore + 1);
 
     newSecret = secretDAO.getSecretByName(newSecret.series().name()).get();
-    assertThat(secretDAO.getSecrets(null, null, null, null, null, null)).containsOnly(secret1, secret2b, newSecret);
+    assertThat(secretDAO.getSecrets(null, null, null, null, null)).containsOnly(secret1, secret2b, newSecret);
   }
 
   @Test public void createOrUpdateSecretWhenSecretExists() {
@@ -464,7 +464,7 @@ public class SecretDAOTest {
   }
 
   @Test public void getSecrets() {
-    assertThat(secretDAO.getSecrets(null, null, null, null, null, null)).containsOnly(secret1, secret2b);
+    assertThat(secretDAO.getSecrets(null, null, null, null, null)).containsOnly(secret1, secret2b);
   }
 
   @Test public void getSecretsByNameOnly() {

--- a/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretSeriesDAOTest.java
@@ -214,31 +214,26 @@ public class SecretSeriesDAOTest {
     // Retrieving secrets with no parameters should retrieve all created secrets (although given
     // the shared database, it's likely to also retrieve others)
     ImmutableList<SecretSeries>
-        retrievedSeries = secretSeriesDAO.getSecretSeries(null, null, null, null, null, null);
+        retrievedSeries = secretSeriesDAO.getSecretSeries(null, null, null, null, null);
     assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, secondId, thirdId, fourthId, fifthId));
 
     // Restrict expireMaxTime to exclude the last secrets
-    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, null,null, null, null);
+    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, null,null, null);
     assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, secondId, thirdId));
     assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(fourthId, fifthId));
 
     // Restrict expireMinTime to exclude the first secret
-    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, firstExpiry + 10, null,null, null);
+    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, firstExpiry + 10, null,null);
     assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(secondId, thirdId));
     assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, fourthId, fifthId));
 
-    // Adjust the limit and offset to exclude the second secret
-    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, firstExpiry + 10, null,2, 1);
-    assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(thirdId));
-    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, secondId, fourthId, fifthId));
-
-    // Adjust the limit and offset without limiting expireMinTime
-    retrievedSeries = secretSeriesDAO.getSecretSeries(null, null, null, null, 2, 1);
-    assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(secondId, thirdId));
-    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, fourthId, fifthId));
+    // Adjust the limit to exclude the third secret
+    retrievedSeries = secretSeriesDAO.getSecretSeries(fourthExpiry - 100, null, firstExpiry + 10, null,1);
+    assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(secondId));
+    assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, thirdId, fourthId, fifthId));
 
     // Restrict the minName to exclude the fourth secret
-    retrievedSeries = secretSeriesDAO.getSecretSeries(null, null, fourthExpiry, "laterInAlphabetExpiringFourth", null, null);
+    retrievedSeries = secretSeriesDAO.getSecretSeries(null, null, fourthExpiry, "laterInAlphabetExpiringFourth", null);
     assertListContainsSecretsWithIds(retrievedSeries, ImmutableList.of(fifthId));
     assertListDoesNotContainSecretsWithIds(retrievedSeries, ImmutableList.of(firstId, secondId, thirdId, fourthId));
   }

--- a/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/v2/SecretResourceTest.java
@@ -582,25 +582,10 @@ public class SecretResourceTest {
     assertListContainsSecretsWithNames(s4Names, ImmutableList.of("secret18", "secret19"));
     assertListDoesNotContainSecretsWithNames(s4Names, ImmutableList.of("secret17"));
 
-    List<SanitizedSecretWithGroups> s5 = listExpiringV3(now + 86400 * 3, null, null, null, null);
+    List<SanitizedSecretWithGroups> s5 = listExpiringV3(now + 86400 * 3);
     List<String> s5Names = s5.stream().map(s -> s.secret().name()).collect(toList());
     assertListContainsSecretsWithNames(s5Names, ImmutableList.of("secret18", "secret19"));
     assertListDoesNotContainSecretsWithNames(s5Names, ImmutableList.of("secret17"));
-
-    List<SanitizedSecretWithGroups> s6 = listExpiringV3(now + 86400 * 4, null, now + 86400 + 1, null, null);
-    List<String> s6Names = s6.stream().map(s -> s.secret().name()).collect(toList());
-    assertListContainsSecretsWithNames(s6Names, ImmutableList.of("secret19", "secret17"));
-    assertListDoesNotContainSecretsWithNames(s6Names, ImmutableList.of("secret18"));
-
-    List<SanitizedSecretWithGroups> s7 = listExpiringV3(now + 86400 * 4, null, now + 86400 + 1, 3, 1);
-    List<String> s7Names = s7.stream().map(s -> s.secret().name()).collect(toList());
-    assertListContainsSecretsWithNames(s7Names, ImmutableList.of("secret17"));
-    assertListDoesNotContainSecretsWithNames(s7Names, ImmutableList.of("secret18", "secret19"));
-
-    List<SanitizedSecretWithGroups> s8 = listExpiringV3(now + 86400 * 4, null, now + 86400 + 1, 1, 0);
-    List<String> s8Names = s8.stream().map(s -> s.secret().name()).collect(toList());
-    assertListContainsSecretsWithNames(s8Names, ImmutableList.of("secret19"));
-    assertListDoesNotContainSecretsWithNames(s8Names, ImmutableList.of("secret17", "secret18"));
  }
 
   @Test public void secretListingExpiry_successWithCursor() throws Exception {
@@ -1039,45 +1024,11 @@ public class SecretResourceTest {
     });
   }
 
-  List<SanitizedSecretWithGroups> listExpiringV3(Long maxTime, String groupName, Long minTime,
-      Integer limit, Integer offset) throws IOException {
+  List<SanitizedSecretWithGroups> listExpiringV3(Long maxTime) throws IOException {
     String requestURL = "/automation/v2/secrets/expiring/v3/";
     if (maxTime != null && maxTime > 0) {
       requestURL += maxTime.toString() + '/';
     }
-    if (groupName != null && groupName.length() > 0) {
-      requestURL += groupName;
-    }
-
-    // This should probably be replaced with a proper query library
-    if (minTime != null || limit != null || offset != null) {
-      requestURL += "?";
-
-      boolean firstQueryParam = true;
-      if (minTime != null) {
-        requestURL += "mintime=";
-        requestURL += minTime.toString();
-        firstQueryParam = false;
-      }
-
-      if (limit != null) {
-        if(!firstQueryParam) {
-          requestURL += "&";
-        }
-        requestURL += "limit=";
-        requestURL += limit.toString();
-        firstQueryParam = false;
-      }
-
-      if (offset != null) {
-        if(!firstQueryParam) {
-          requestURL += "&";
-        }
-        requestURL += "offset=";
-        requestURL += offset.toString();
-      }
-    }
-
     Request get = clientRequest(requestURL).get().build();
     Response httpResponse = mutualSslClient.newCall(get).execute();
     assertThat(httpResponse.code()).isEqualTo(200);


### PR DESCRIPTION
The pagination implementation in the v4 expiration retrieval
endpoint for automation clients is significantly easier to work
with than the implementation in v3.  Since the v3 implementation
has not been released, this removes its extra parameters (which
allows some simplifications to the internal secrets-management
code).