### PR TITLE
Update Flyway to 6.0.4

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -17,6 +17,7 @@
     <db.migrate-url>jdbc:mysql://localhost/keywhizdb_test?useUnicode=true&amp;characterEncoding=utf8</db.migrate-url>
     <db.username>root</db.username>
     <db.migrations-path>mysql/migration</db.migrations-path>
+    <db.schema-table>schema_version</db.schema-table>
     <jooq.dialect>org.jooq.meta.mysql.MySQLDatabase</jooq.dialect>
     <jooq.excludes>mysql.*</jooq.excludes>
     <jooq.input-schema>keywhizdb_test</jooq.input-schema>
@@ -98,6 +99,7 @@
           <driver>${db.driver}</driver>
           <url>${db.migrate-url}</url>
           <user>${db.username}</user>
+          <table>${db.schema-table}</table>
           <locations>
             <location>filesystem:../server/src/main/resources/db/${db.migrations-path}</location>
           </locations>

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
       <dependency>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-core</artifactId>
-        <version>5.2.4</version>
+        <version>6.0.4</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
@@ -612,7 +612,7 @@
         <plugin>
           <groupId>org.flywaydb</groupId>
           <artifactId>flyway-maven-plugin</artifactId>
-          <version>5.2.4</version>
+          <version>6.0.4</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/server/src/main/java/keywhiz/KeywhizConfig.java
+++ b/server/src/main/java/keywhiz/KeywhizConfig.java
@@ -88,6 +88,9 @@ public class KeywhizConfig extends Configuration {
 
   @JsonProperty
   private String rowHmacCheck;
+  
+  @JsonProperty
+  private String flywaySchemaTable;
 
   public enum RowHmacCheck {
     DISABLED, DISABLED_BUT_LOG, ENFORCED
@@ -196,6 +199,13 @@ public class KeywhizConfig extends Configuration {
             String.format("%s is an invalid rowHmacCheck parameter", rowHmacCheck)
         );
     }
+  }
+  
+  public String getFlywaySchemaTable() {
+	  if (flywaySchemaTable == null) {
+		  return "schema_version";
+	  }
+	  return flywaySchemaTable;
   }
 
   public static class TemplatedDataSourceFactory extends DataSourceFactory {

--- a/server/src/main/java/keywhiz/KeywhizService.java
+++ b/server/src/main/java/keywhiz/KeywhizService.java
@@ -165,9 +165,7 @@ public class KeywhizService extends Application<KeywhizConfig> {
     logger.debug("Validating database state");
     DataSource dataSource = config.getDataSourceFactory()
         .build(new MetricRegistry(), "flyway-validation-datasource");
-    Flyway flyway = new Flyway();
-    flyway.setDataSource(dataSource);
-    flyway.setLocations(config.getMigrationsDir());
+    Flyway flyway = Flyway.configure().dataSource(dataSource).locations(config.getMigrationsDir()).table(config.getFlywaySchemaTable()).load();
     flyway.validate();
   }
 

--- a/server/src/main/java/keywhiz/commands/MigrateCommand.java
+++ b/server/src/main/java/keywhiz/commands/MigrateCommand.java
@@ -33,9 +33,7 @@ public class MigrateCommand extends ConfiguredCommand<KeywhizConfig> {
     DataSource dataSource = config.getDataSourceFactory()
         .build(new MetricRegistry(), "migration-datasource");
 
-    Flyway flyway = new Flyway();
-    flyway.setDataSource(dataSource);
-    flyway.setLocations(config.getMigrationsDir());
+    Flyway flyway = Flyway.configure().dataSource(dataSource).locations(config.getMigrationsDir()).table(config.getFlywaySchemaTable()).load();
     flyway.migrate();
   }
 }

--- a/server/src/main/java/keywhiz/commands/PreviewMigrateCommand.java
+++ b/server/src/main/java/keywhiz/commands/PreviewMigrateCommand.java
@@ -39,9 +39,7 @@ public class PreviewMigrateCommand extends ConfiguredCommand<KeywhizConfig> {
     DataSource dataSource = config.getDataSourceFactory()
         .build(new MetricRegistry(), "migration-preview-datasource");
 
-    Flyway flyway = new Flyway();
-    flyway.setDataSource(dataSource);
-    flyway.setLocations(config.getMigrationsDir());
+    Flyway flyway = Flyway.configure().dataSource(dataSource).locations(config.getMigrationsDir()).table(config.getFlywaySchemaTable()).load();
     MigrationInfoService info = flyway.info();
 
     MigrationInfo current = info.current();

--- a/server/src/main/resources/keywhiz-development.yaml
+++ b/server/src/main/resources/keywhiz-development.yaml
@@ -110,3 +110,5 @@ contentKeyStore:
   alias: basekey
 
 rowHmacCheck: logging
+
+flywaySchemaTable: schema_version

--- a/server/src/test/java/keywhiz/MigrationsRule.java
+++ b/server/src/test/java/keywhiz/MigrationsRule.java
@@ -46,9 +46,7 @@ public class MigrationsRule implements TestRule {
         DataSource dataSource = config.getDataSourceFactory()
             .build(new MetricRegistry(), "db-migrations");
 
-        Flyway flyway = new Flyway();
-        flyway.setDataSource(dataSource);
-        flyway.setLocations(config.getMigrationsDir());
+        Flyway flyway = Flyway.configure().dataSource(dataSource).locations(config.getMigrationsDir()).table(config.getFlywaySchemaTable()).load();
         flyway.clean();
         flyway.migrate();
 

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -149,3 +149,5 @@ contentKeyStore:
   alias: basekey
 
 rowHmacCheck: enforced
+
+flywaySchemaTable: schema_version


### PR DESCRIPTION
This PR updates Flyway to 6.0.4 and changes the programatical
initialization to the fluent api provided by flyway.

I also set the table name for the schema versioning explicitly because the default name changed.

Closes https://github.com/square/keywhiz/issues/464