### PR TITLE
Fix admin client to handle negative secret IDs correctly

### DIFF
--- a/cli/src/main/java/keywhiz/cli/commands/ListVersionsAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/ListVersionsAction.java
@@ -37,8 +37,7 @@ public class ListVersionsAction implements Runnable {
       List<SanitizedSecret> versions =
           keywhizClient.listSecretVersions(sanitizedSecret.name(),
               listVersionsActionConfig.idx, listVersionsActionConfig.number);
-      // The current version can never be negative
-      printing.printSecretVersions(versions, sanitizedSecret.version().orElse(-1L));
+      printing.printSecretVersions(versions, sanitizedSecret.version());
     } catch (NotFoundException e) {
       throw new AssertionError("Secret does not exist: " + listVersionsActionConfig.name);
     } catch (IOException e) {

--- a/cli/src/main/java/keywhiz/cli/commands/RollbackAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/RollbackAction.java
@@ -23,7 +23,7 @@ public class RollbackAction implements Runnable {
 
   private final RollbackActionConfig rollbackActionConfig;
   private final KeywhizClient keywhizClient;
-  
+
   @VisibleForTesting
   InputStream inputStream = System.in;
 
@@ -39,9 +39,9 @@ public class RollbackAction implements Runnable {
             format("Invalid name, must match %s", VALID_NAME_PATTERN));
       }
 
-      if (rollbackActionConfig.id == null || rollbackActionConfig.id < 0) {
+      if (rollbackActionConfig.id == null) {
         throw new IllegalArgumentException(
-            "Version ID must be specified and non-negative for rollback.  List the secret's versions to view IDs.");
+            "Version ID must be specified for rollback.  List the secret's versions to view IDs.");
       }
 
       SanitizedSecret sanitizedSecret =

--- a/cli/src/test/java/keywhiz/cli/commands/ListVersionsActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/ListVersionsActionTest.java
@@ -1,6 +1,9 @@
 package keywhiz.cli.commands;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Optional;
 import keywhiz.api.ApiDate;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.api.model.Secret;
@@ -14,6 +17,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,9 +32,15 @@ public class ListVersionsActionTest {
   ListVersionsAction listVersionsAction;
 
   private static final ApiDate NOW = ApiDate.now();
-  Secret secret = new Secret(0, "secret", null, () -> "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
-      ImmutableMap.of(), 0, 1L, NOW, null);
-  SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
+  Secret secretV2 =
+      new Secret(0, "secret", null, () -> "c2VjcmV0MQ==", "checksum2", NOW, null, NOW, null, null,
+          null, ImmutableMap.of(), 0, 1L, NOW, "creator2");
+  Secret secretV1 =
+      new Secret(0, "secret", null, () -> "c2VjcmV0MQ==", "checksum1", NOW, null, NOW, null, null,
+          null, ImmutableMap.of(), 0, -1L, NOW, "creator1");
+  SanitizedSecret sanitizedSecretV2 = SanitizedSecret.fromSecret(secretV2);
+  SanitizedSecret sanitizedSecretV1 = SanitizedSecret.fromSecret(secretV1);
+  List<SanitizedSecret> secretVersions = ImmutableList.of(sanitizedSecretV2, sanitizedSecretV1);
 
   @Before
   public void setUp() {
@@ -39,46 +50,54 @@ public class ListVersionsActionTest {
 
   @Test
   public void listVersionsCallsPrint() throws Exception {
-    listVersionsActionConfig.name = secret.getDisplayName();
+    listVersionsActionConfig.name = secretV2.getDisplayName();
     listVersionsActionConfig.idx = 5;
     listVersionsActionConfig.number = 15;
 
-    when(keywhizClient.getSanitizedSecretByName(secret.getDisplayName())).thenReturn(sanitizedSecret);
+    when(keywhizClient.getSanitizedSecretByName(secretV2.getDisplayName())).thenReturn(
+        sanitizedSecretV2);
+    when(keywhizClient.listSecretVersions(eq(secretV2.getName()), anyInt(), anyInt())).thenReturn(
+        secretVersions);
 
     listVersionsAction.run();
 
-    verify(printing).printSecretVersions(keywhizClient.listSecretVersions("test-secret", 5, 15),
-        1L);
+    verify(keywhizClient).listSecretVersions(secretV2.getName(), 5, 15);
+    verify(printing).printSecretVersions(secretVersions, Optional.of(1L));
   }
 
   @Test
   public void listVersionsUsesDefaults() throws Exception {
-    listVersionsActionConfig.name = secret.getDisplayName();
+    listVersionsActionConfig.name = secretV2.getDisplayName();
 
-    when(keywhizClient.getSanitizedSecretByName(secret.getDisplayName())).thenReturn(sanitizedSecret);
+    when(keywhizClient.getSanitizedSecretByName(secretV2.getDisplayName())).thenReturn(
+        sanitizedSecretV2);
+    when(keywhizClient.listSecretVersions(eq(secretV2.getName()), anyInt(), anyInt())).thenReturn(
+        secretVersions);
+
     listVersionsAction.run();
 
-    verify(printing).printSecretVersions(keywhizClient.listSecretVersions("test-secret", 0, 10),
-        1L);
+    verify(keywhizClient).listSecretVersions(secretV2.getName(), 0, 10);
+    verify(printing).printSecretVersions(secretVersions, Optional.of(1L));
   }
 
   @Test(expected = AssertionError.class)
   public void listVersionsThrowsIfSecretDoesNotExist() throws Exception {
-    listVersionsActionConfig.name = secret.getDisplayName();
+    listVersionsActionConfig.name = secretV2.getDisplayName();
 
-    when(keywhizClient.getSanitizedSecretByName(secret.getDisplayName())).thenThrow(new KeywhizClient.NotFoundException());
+    when(keywhizClient.getSanitizedSecretByName(secretV2.getDisplayName())).thenThrow(
+        new KeywhizClient.NotFoundException());
 
     listVersionsAction.run();
   }
 
-  @Test (expected = IllegalArgumentException.class)
-  public void listVersionsThrowsIfNoSecretSpecified() throws Exception {
+  @Test(expected = IllegalArgumentException.class)
+  public void listVersionsThrowsIfNoSecretSpecified() {
     listVersionsActionConfig.name = null;
     listVersionsAction.run();
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void listVersionsValidatesSecretName() throws Exception {
+  public void listVersionsValidatesSecretName() {
     listVersionsActionConfig.name = "Invalid Name";
     listVersionsAction.run();
   }

--- a/cli/src/test/java/keywhiz/cli/commands/RollbackActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/RollbackActionTest.java
@@ -78,6 +78,18 @@ public class RollbackActionTest {
   }
 
   @Test
+  public void rollbackCallsRollbackWithNegativeId() throws Exception {
+    rollbackAction.inputStream = yes;
+    rollbackActionConfig.name = secret.getDisplayName();
+    rollbackActionConfig.id = -1L;
+
+    when(keywhizClient.getSanitizedSecretByName(secret.getName())).thenReturn(sanitizedSecret);
+
+    rollbackAction.run();
+    verify(keywhizClient).rollbackSecret(sanitizedSecret.name(), rollbackActionConfig.id);
+  }
+
+  @Test
   public void rollbackSkipsWithoutConfirmation() throws Exception {
     rollbackAction.inputStream = no;
     rollbackActionConfig.name = secret.getDisplayName();


### PR DESCRIPTION
The version-listing and rollback admin client endpoints initially
assumed that negative secret IDs were impossible.  However, since
secret IDs are now randomly generated, the endpoints must handle
negative values properly.

This also fixes a bug in the display of secret creators, adds a display of metadata, and improves the test for listing secret versions.

A manual test which included rolling back to a previous (negative) version ID:
<img width="684" alt="Screen Shot 2019-11-14 at 11 22 24 AM" src="https://user-images.githubusercontent.com/13395970/68889762-6411ac00-06d2-11ea-9cdc-374aa990d9f3.png">
