### PR TITLE
Remove unused dependency

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -22,10 +22,6 @@
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Hello, I noticed that dependency `com.google.auto.value:auto-value` in module `keywhiz-api` is declared but not used. Hence, this dependency can be removed to make the `pom` clearer.