### PR TITLE
Move admin api to v2 models

### DIFF
--- a/client/src/main/java/keywhiz/client/KeywhizClient.java
+++ b/client/src/main/java/keywhiz/client/KeywhizClient.java
@@ -24,12 +24,12 @@ import java.util.Base64;
 import java.util.List;
 import javax.ws.rs.core.HttpHeaders;
 import keywhiz.api.ClientDetailResponse;
-import keywhiz.api.CreateClientRequest;
 import keywhiz.api.CreateGroupRequest;
 import keywhiz.api.CreateSecretRequest;
 import keywhiz.api.GroupDetailResponse;
 import keywhiz.api.LoginRequest;
 import keywhiz.api.SecretDetailResponse;
+import keywhiz.api.automation.v2.CreateClientRequestV2;
 import keywhiz.api.automation.v2.PartialUpdateSecretRequestV2;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
@@ -49,7 +49,7 @@ import static java.lang.String.format;
 
 /**
  * Client for interacting with the Keywhiz Server.
- *
+ * <p>
  * Facilitates the manipulation of Clients, Groups, Secrets and the connections between them.
  */
 public class KeywhizClient {
@@ -61,36 +61,42 @@ public class KeywhizClient {
       return "Malformed request syntax from client (400)";
     }
   }
+
   public static class UnauthorizedException extends IOException {
 
     @Override public String getMessage() {
       return "Not allowed to login, password may be incorrect (401)";
     }
   }
+
   public static class ForbiddenException extends IOException {
 
     @Override public String getMessage() {
       return "Resource forbidden (403)";
     }
   }
+
   public static class NotFoundException extends IOException {
 
     @Override public String getMessage() {
       return "Resource not found (404)";
     }
   }
+
   public static class UnsupportedMediaTypeException extends IOException {
 
     @Override public String getMessage() {
       return "Resource media type is incorrect or incompatible (415)";
     }
   }
+
   public static class ConflictException extends IOException {
 
     @Override public String getMessage() {
       return "Conflicting resource (409)";
     }
   }
+
   public static class ValidationException extends IOException {
 
     @Override public String getMessage() {
@@ -110,8 +116,9 @@ public class KeywhizClient {
 
   /**
    * Login to the Keywhiz server.
-   *
+   * <p>
    * Future requests made using this client instance will be authenticated.
+   *
    * @param username login username
    * @param password login password
    * @throws IOException if a network IO error occurs
@@ -122,12 +129,15 @@ public class KeywhizClient {
 
   public List<Group> allGroups() throws IOException {
     String response = httpGet(baseUrl.resolve("/admin/groups/"));
-    return mapper.readValue(response, new TypeReference<List<Group>>() {});
+    return mapper.readValue(response, new TypeReference<List<Group>>() {
+    });
   }
 
-  public GroupDetailResponse createGroup(String name, String description, ImmutableMap<String, String> metadata) throws IOException {
+  public GroupDetailResponse createGroup(String name, String description,
+      ImmutableMap<String, String> metadata) throws IOException {
     checkArgument(!name.isEmpty());
-    String response = httpPost(baseUrl.resolve("/admin/groups"), new CreateGroupRequest(name, description, metadata));
+    String response = httpPost(baseUrl.resolve("/admin/groups"),
+        new CreateGroupRequest(name, description, metadata));
     return mapper.readValue(response, GroupDetailResponse.class);
   }
 
@@ -142,12 +152,16 @@ public class KeywhizClient {
 
   public List<SanitizedSecret> allSecrets() throws IOException {
     String response = httpGet(baseUrl.resolve("/admin/secrets?nameOnly=1"));
-    return mapper.readValue(response, new TypeReference<List<SanitizedSecret>>() {});
+    return mapper.readValue(response, new TypeReference<List<SanitizedSecret>>() {
+    });
   }
 
-  public List<SanitizedSecret> allSecretsBatched(int idx, int num, boolean newestFirst) throws IOException {
-    String response = httpGet(baseUrl.resolve(String.format("/admin/secrets?idx=%d&num=%d&newestFirst=%s", idx, num, newestFirst)));
-    return mapper.readValue(response, new TypeReference<List<SanitizedSecret>>() {});
+  public List<SanitizedSecret> allSecretsBatched(int idx, int num, boolean newestFirst)
+      throws IOException {
+    String response = httpGet(baseUrl.resolve(
+        String.format("/admin/secrets?idx=%d&num=%d&newestFirst=%s", idx, num, newestFirst)));
+    return mapper.readValue(response, new TypeReference<List<SanitizedSecret>>() {
+    });
   }
 
   public SecretDetailResponse createSecret(String name, String description, byte[] content,
@@ -156,7 +170,8 @@ public class KeywhizClient {
     checkArgument(content.length > 0, "Content must not be empty");
 
     String b64Content = Base64.getEncoder().encodeToString(content);
-    CreateSecretRequest request = new CreateSecretRequest(name, description, b64Content, metadata, expiry);
+    CreateSecretRequest request =
+        new CreateSecretRequest(name, description, b64Content, metadata, expiry);
     String response = httpPost(baseUrl.resolve("/admin/secrets"), request);
     return mapper.readValue(response, SecretDetailResponse.class);
   }
@@ -188,13 +203,17 @@ public class KeywhizClient {
     return mapper.readValue(response, SecretDetailResponse.class);
   }
 
-  public List<SanitizedSecret> listSecretVersions(String name, int idx, int numVersions) throws IOException {
-    String response = httpGet(baseUrl.resolve(format("/admin/secrets/versions/%s?versionIdx=%d&numVersions=%d", name, idx, numVersions)));
-    return mapper.readValue(response, new TypeReference<List<SanitizedSecret>>() {});
+  public List<SanitizedSecret> listSecretVersions(String name, int idx, int numVersions)
+      throws IOException {
+    String response = httpGet(baseUrl.resolve(
+        format("/admin/secrets/versions/%s?versionIdx=%d&numVersions=%d", name, idx, numVersions)));
+    return mapper.readValue(response, new TypeReference<List<SanitizedSecret>>() {
+    });
   }
 
-  public SecretDetailResponse rollbackSecret (String name, long version) throws IOException {
-    String response = httpPost(baseUrl.resolve(format("/admin/secrets/rollback/%s/%d", name, version)), null);
+  public SecretDetailResponse rollbackSecret(String name, long version) throws IOException {
+    String response =
+        httpPost(baseUrl.resolve(format("/admin/secrets/rollback/%s/%d", name, version)), null);
     return mapper.readValue(response, SecretDetailResponse.class);
   }
 
@@ -204,12 +223,14 @@ public class KeywhizClient {
 
   public List<Client> allClients() throws IOException {
     String httpResponse = httpGet(baseUrl.resolve("/admin/clients/"));
-    return mapper.readValue(httpResponse, new TypeReference<List<Client>>() {});
+    return mapper.readValue(httpResponse, new TypeReference<List<Client>>() {
+    });
   }
 
   public ClientDetailResponse createClient(String name) throws IOException {
     checkArgument(!name.isEmpty());
-    String response = httpPost(baseUrl.resolve("/admin/clients"), new CreateClientRequest(name));
+    String response = httpPost(baseUrl.resolve("/admin/clients"),
+        CreateClientRequestV2.builder().name(name).build());
     return mapper.readValue(response, ClientDetailResponse.class);
   }
 
@@ -227,7 +248,8 @@ public class KeywhizClient {
   }
 
   public void evictClientFromGroupByIds(long clientId, long groupId) throws IOException {
-    httpDelete(baseUrl.resolve(format("/admin/memberships/clients/%d/groups/%d", clientId, groupId)));
+    httpDelete(
+        baseUrl.resolve(format("/admin/memberships/clients/%d/groups/%d", clientId, groupId)));
   }
 
   public void grantSecretToGroupByIds(long secretId, long groupId) throws IOException {
@@ -235,7 +257,8 @@ public class KeywhizClient {
   }
 
   public void revokeSecretFromGroupByIds(long secretId, long groupId) throws IOException {
-    httpDelete(baseUrl.resolve(format("/admin/memberships/secrets/%d/groups/%d", secretId, groupId)));
+    httpDelete(
+        baseUrl.resolve(format("/admin/memberships/secrets/%d/groups/%d", secretId, groupId)));
   }
 
   public Client getClientByName(String name) throws IOException {
@@ -256,12 +279,13 @@ public class KeywhizClient {
 
   public SanitizedSecret getSanitizedSecretByName(String name) throws IOException {
     checkArgument(!name.isEmpty());
-    String response = httpGet(baseUrl.resolve("/admin/secrets").newBuilder().addQueryParameter("name", name)
-        .build());
+    String response =
+        httpGet(baseUrl.resolve("/admin/secrets").newBuilder().addQueryParameter("name", name)
+            .build());
     return mapper.readValue(response, SanitizedSecret.class);
   }
 
-  public boolean isLoggedIn() throws IOException{
+  public boolean isLoggedIn() throws IOException {
     HttpUrl url = baseUrl.resolve("/admin/me");
     Call call = client.newCall(new Request.Builder().get().url(url).build());
     return call.execute().code() != HttpStatus.SC_UNAUTHORIZED;

--- a/client/src/main/java/keywhiz/client/KeywhizClient.java
+++ b/client/src/main/java/keywhiz/client/KeywhizClient.java
@@ -24,12 +24,12 @@ import java.util.Base64;
 import java.util.List;
 import javax.ws.rs.core.HttpHeaders;
 import keywhiz.api.ClientDetailResponse;
-import keywhiz.api.CreateGroupRequest;
 import keywhiz.api.CreateSecretRequest;
 import keywhiz.api.GroupDetailResponse;
 import keywhiz.api.LoginRequest;
 import keywhiz.api.SecretDetailResponse;
 import keywhiz.api.automation.v2.CreateClientRequestV2;
+import keywhiz.api.automation.v2.CreateGroupRequestV2;
 import keywhiz.api.automation.v2.PartialUpdateSecretRequestV2;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
@@ -137,7 +137,11 @@ public class KeywhizClient {
       ImmutableMap<String, String> metadata) throws IOException {
     checkArgument(!name.isEmpty());
     String response = httpPost(baseUrl.resolve("/admin/groups"),
-        new CreateGroupRequest(name, description, metadata));
+        CreateGroupRequestV2.builder()
+            .name(name)
+            .description(description)
+            .metadata(metadata)
+            .build());
     return mapper.readValue(response, GroupDetailResponse.class);
   }
 

--- a/client/src/main/java/keywhiz/client/KeywhizClient.java
+++ b/client/src/main/java/keywhiz/client/KeywhizClient.java
@@ -24,12 +24,12 @@ import java.util.Base64;
 import java.util.List;
 import javax.ws.rs.core.HttpHeaders;
 import keywhiz.api.ClientDetailResponse;
-import keywhiz.api.CreateSecretRequest;
 import keywhiz.api.GroupDetailResponse;
 import keywhiz.api.LoginRequest;
 import keywhiz.api.SecretDetailResponse;
 import keywhiz.api.automation.v2.CreateClientRequestV2;
 import keywhiz.api.automation.v2.CreateGroupRequestV2;
+import keywhiz.api.automation.v2.CreateSecretRequestV2;
 import keywhiz.api.automation.v2.PartialUpdateSecretRequestV2;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
@@ -174,8 +174,14 @@ public class KeywhizClient {
     checkArgument(content.length > 0, "Content must not be empty");
 
     String b64Content = Base64.getEncoder().encodeToString(content);
-    CreateSecretRequest request =
-        new CreateSecretRequest(name, description, b64Content, metadata, expiry);
+    CreateSecretRequestV2 request =
+        CreateSecretRequestV2.builder()
+            .name(name)
+            .description(description)
+            .content(b64Content)
+            .metadata(metadata)
+            .expiry(expiry)
+            .build();
     String response = httpPost(baseUrl.resolve("/admin/secrets"), request);
     return mapper.readValue(response, SecretDetailResponse.class);
   }

--- a/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
@@ -26,7 +26,7 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import keywhiz.api.ApiDate;
 import keywhiz.api.ClientDetailResponse;
-import keywhiz.api.CreateClientRequest;
+import keywhiz.api.automation.v2.CreateClientRequestV2;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
@@ -55,7 +55,8 @@ public class ClientsResourceTest {
 
   User user = User.named("user");
   ApiDate now = ApiDate.now();
-  Client client = new Client(1, "client", "1st client", now, "test", now, "test", null, null, true, false);
+  Client client =
+      new Client(1, "client", "1st client", now, "test", now, "test", null, null, true, false);
   AuditLog auditLog = new SimpleLogger();
 
   ClientsResource resource;
@@ -65,8 +66,10 @@ public class ClientsResourceTest {
   }
 
   @Test public void listClients() {
-    Client client1 = new Client(1, "client", "1st client", now, "test", now, "test", null, null, true, false);
-    Client client2 = new Client(2, "client2", "2nd client", now, "test", now, "test", null, null, true, false);
+    Client client1 =
+        new Client(1, "client", "1st client", now, "test", now, "test", null, null, true, false);
+    Client client2 =
+        new Client(2, "client2", "2nd client", now, "test", now, "test", null, null, true, false);
 
     when(clientDAO.getClients()).thenReturn(ImmutableSet.of(client1, client2));
 
@@ -75,7 +78,7 @@ public class ClientsResourceTest {
   }
 
   @Test public void createsClient() {
-    CreateClientRequest request = new CreateClientRequest("new-client-name");
+    CreateClientRequestV2 request = CreateClientRequestV2.builder().name("new-client-name").build();
     when(clientDAO.createClient("new-client-name", "user", "")).thenReturn(42L);
     when(clientDAO.getClientById(42L)).thenReturn(Optional.of(client));
     when(aclDAO.getSanitizedSecretsFor(client)).thenReturn(ImmutableSet.of());
@@ -113,8 +116,9 @@ public class ClientsResourceTest {
   @Test public void includesAssociations() {
     Group group1 = new Group(0, "group1", null, null, null, null, null, null);
     Group group2 = new Group(0, "group2", null, null, null, null, null, null);
-    Secret secret = new Secret(15, "secret", null, () -> "supersecretdata", "checksum", now, "creator", now,
-        "updater", null, null, null, 0, 1L, now, "updater");
+    Secret secret =
+        new Secret(15, "secret", null, () -> "supersecretdata", "checksum", now, "creator", now,
+            "updater", null, null, null, 0, 1L, now, "updater");
 
     when(clientDAO.getClientById(1)).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(client)).thenReturn(Sets.newHashSet(group1, group2));

--- a/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/GroupsResourceTest.java
@@ -24,8 +24,8 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import keywhiz.api.ApiDate;
-import keywhiz.api.CreateGroupRequest;
 import keywhiz.api.GroupDetailResponse;
+import keywhiz.api.automation.v2.CreateGroupRequestV2;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
@@ -75,8 +75,12 @@ public class GroupsResourceTest {
   }
 
   @Test public void createsGroup() {
-    CreateGroupRequest request =
-        new CreateGroupRequest("newGroup", "description", ImmutableMap.of("app", "app"));
+    CreateGroupRequestV2 request =
+        CreateGroupRequestV2.builder()
+            .name("newGroup")
+            .description("description")
+            .metadata(ImmutableMap.of("app", "app"))
+            .build();
     when(groupDAO.getGroup("newGroup")).thenReturn(Optional.empty());
     when(groupDAO.createGroup("newGroup", "user", "description",
         ImmutableMap.of("app", "app"))).thenReturn(55L);
@@ -89,8 +93,12 @@ public class GroupsResourceTest {
 
   @Test(expected = BadRequestException.class)
   public void rejectsWhenGroupExists() {
-    CreateGroupRequest request =
-        new CreateGroupRequest("newGroup", "description", ImmutableMap.of("app", "app"));
+    CreateGroupRequestV2 request =
+        CreateGroupRequestV2.builder()
+            .name("newGroup")
+            .description("description")
+            .metadata(ImmutableMap.of("app", "app"))
+            .build();
     Group group = new Group(3, "newGroup", "desc", now, "creator", now, "updater",
         ImmutableMap.of("app", "app"));
     when(groupDAO.getGroup("newGroup")).thenReturn(Optional.of(group));
@@ -101,11 +109,13 @@ public class GroupsResourceTest {
   @Test public void getSpecificIncludesAllTheThings() {
     when(groupDAO.getGroupById(4444)).thenReturn(Optional.of(group));
 
-    SanitizedSecret secret = SanitizedSecret.of(1, "name", null, "checksum", now, "creator", now, "creator", null, null, null,
-        1136214245, 125L, now, "creator");
+    SanitizedSecret secret =
+        SanitizedSecret.of(1, "name", null, "checksum", now, "creator", now, "creator", null, null,
+            null, 1136214245, 125L, now, "creator");
     when(aclDAO.getSanitizedSecretsFor(group)).thenReturn(ImmutableSet.of(secret));
 
-    Client client = new Client(1, "client", "desc", now, "creator", now, "creator", null, null, true, false);
+    Client client =
+        new Client(1, "client", "desc", now, "creator", now, "creator", null, null, true, false);
     when(aclDAO.getClientsFor(group)).thenReturn(ImmutableSet.of(client));
 
     GroupDetailResponse response = resource.getGroup(user, new LongParam("4444"));

--- a/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/SecretsResourceTest.java
@@ -29,9 +29,9 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import keywhiz.api.ApiDate;
-import keywhiz.api.CreateSecretRequest;
 import keywhiz.api.SecretDetailResponse;
 import keywhiz.api.automation.v2.CreateOrUpdateSecretRequestV2;
+import keywhiz.api.automation.v2.CreateSecretRequestV2;
 import keywhiz.api.automation.v2.PartialUpdateSecretRequestV2;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
@@ -129,8 +129,12 @@ public class SecretsResourceTest {
         .thenReturn(secretBuilder);
     when(secretBuilder.create()).thenReturn(secret);
 
-    CreateSecretRequest req = new CreateSecretRequest(secret.getName(),
-        secret.getDescription(), secret.getSecret(), emptyMap, 0);
+    CreateSecretRequestV2 req =
+        CreateSecretRequestV2.builder()
+            .name(secret.getName())
+            .description(secret.getDescription())
+            .content(secret.getSecret())
+            .build();
     Response response = resource.createSecret(user, req);
 
     assertThat(response.getStatus()).isEqualTo(201);
@@ -264,7 +268,11 @@ public class SecretsResourceTest {
     DataAccessException exception = new DataAccessException("");
     doThrow(exception).when(secretBuilder).create();
 
-    CreateSecretRequest req = new CreateSecretRequest("name", "desc", "content", emptyMap, 0);
+    CreateSecretRequestV2 req = CreateSecretRequestV2.builder()
+        .name("name")
+        .description("desc")
+        .content("content")
+        .build();
     resource.createSecret(user, req);
   }
 


### PR DESCRIPTION
The currently maintained APIs are "automation/v2" and "admin" (the deprecated "automation" APIs are not typically updated). This migrates the "admin" API to use the same request classes as the "automation/v2" API for object creation, although retrieving details still uses classes customized for the admin API (in particular, looking up a single secret, group, or client also retrieves information about its ACL links to other secrets/groups/clients).