### PR TITLE
Add support for authenticating clients through Envoy-format XFCC header

### DIFF
--- a/server/src/main/java/keywhiz/KeywhizConfig.java
+++ b/server/src/main/java/keywhiz/KeywhizConfig.java
@@ -29,6 +29,7 @@ import javax.validation.constraints.NotNull;
 import keywhiz.api.validation.ValidBase64;
 import keywhiz.auth.UserAuthenticatorFactory;
 import keywhiz.auth.cookie.CookieConfig;
+import keywhiz.service.config.ClientAuthConfig;
 import keywhiz.service.config.KeyStoreConfig;
 import keywhiz.service.config.Templates;
 import org.hibernate.validator.constraints.Length;
@@ -88,9 +89,12 @@ public class KeywhizConfig extends Configuration {
 
   @JsonProperty
   private String rowHmacCheck;
-  
+
   @JsonProperty
   private String flywaySchemaTable;
+
+  @JsonProperty
+  private ClientAuthConfig clientAuthConfig;
 
   public enum RowHmacCheck {
     DISABLED, DISABLED_BUT_LOG, ENFORCED
@@ -200,12 +204,16 @@ public class KeywhizConfig extends Configuration {
         );
     }
   }
-  
+
   public String getFlywaySchemaTable() {
 	  if (flywaySchemaTable == null) {
 		  return "schema_version";
 	  }
 	  return flywaySchemaTable;
+  }
+
+  public ClientAuthConfig getClientAuthConfig() {
+    return clientAuthConfig;
   }
 
   public static class TemplatedDataSourceFactory extends DataSourceFactory {

--- a/server/src/main/java/keywhiz/service/config/ClientAuthConfig.java
+++ b/server/src/main/java/keywhiz/service/config/ClientAuthConfig.java
@@ -32,9 +32,9 @@ public abstract class ClientAuthConfig {
     return new AutoValue_ClientAuthConfig(sourceConfigs, typeConfig);
   }
 
-  // connection sources that can set x-forwarded-client-cert headers
+  /** connection sources that can set x-forwarded-client-cert headers */
   public abstract List<XfccSourceConfig> xfccConfigs();
 
-  // what identifier(s) to use for clients
+  /** what identifier(s) to use for clients */
   public abstract ClientAuthTypeConfig typeConfig();
 }

--- a/server/src/main/java/keywhiz/service/config/ClientAuthConfig.java
+++ b/server/src/main/java/keywhiz/service/config/ClientAuthConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keywhiz.service.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+/** Configuration for how clients should be authenticated. */
+@AutoValue
+public abstract class ClientAuthConfig {
+  @JsonCreator public static ClientAuthConfig of(
+      @JsonProperty("xfcc") XfccSourceConfig sourceConfig,
+      @JsonProperty("type") ClientAuthTypeConfig typeConfig) {
+    return new AutoValue_ClientAuthConfig(sourceConfig, typeConfig);
+  }
+
+  // connection sources that can set x-forwarded-client-cert headers
+  public abstract XfccSourceConfig xfccConfig();
+
+  // what identifier(s) to use for clients
+  public abstract ClientAuthTypeConfig typeConfig();
+}

--- a/server/src/main/java/keywhiz/service/config/ClientAuthConfig.java
+++ b/server/src/main/java/keywhiz/service/config/ClientAuthConfig.java
@@ -19,18 +19,21 @@ package keywhiz.service.config;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import java.util.List;
 
-/** Configuration for how clients should be authenticated. */
+/**
+ * Configuration for how clients should be authenticated.
+ */
 @AutoValue
 public abstract class ClientAuthConfig {
   @JsonCreator public static ClientAuthConfig of(
-      @JsonProperty("xfcc") XfccSourceConfig sourceConfig,
+      @JsonProperty("xfcc") List<XfccSourceConfig> sourceConfigs,
       @JsonProperty("type") ClientAuthTypeConfig typeConfig) {
-    return new AutoValue_ClientAuthConfig(sourceConfig, typeConfig);
+    return new AutoValue_ClientAuthConfig(sourceConfigs, typeConfig);
   }
 
   // connection sources that can set x-forwarded-client-cert headers
-  public abstract XfccSourceConfig xfccConfig();
+  public abstract List<XfccSourceConfig> xfccConfigs();
 
   // what identifier(s) to use for clients
   public abstract ClientAuthTypeConfig typeConfig();

--- a/server/src/main/java/keywhiz/service/config/ClientAuthTypeConfig.java
+++ b/server/src/main/java/keywhiz/service/config/ClientAuthTypeConfig.java
@@ -27,14 +27,14 @@ import org.slf4j.LoggerFactory;
 @AutoValue
 public abstract class ClientAuthTypeConfig {
   @JsonCreator public static ClientAuthTypeConfig of(
-      @JsonProperty("useClientName") boolean useClientName,
+      @JsonProperty("useCommonName") boolean useCommonName,
       @JsonProperty("useSpiffeId") boolean useSpiffeId) {
-    return new AutoValue_ClientAuthTypeConfig(useClientName, useSpiffeId);
+    return new AutoValue_ClientAuthTypeConfig(useCommonName, useSpiffeId);
   }
 
-  // whether to use the client name to identify clients
-  public abstract boolean useClientName();
+  /** whether to use the client name/common name on the client certificate to identify clients */
+  public abstract boolean useCommonName();
 
-  // whether to use the spiffe ID to identify clients
+  /** whether to use the spiffe ID to identify clients */
   public abstract boolean useSpiffeId();
 }

--- a/server/src/main/java/keywhiz/service/config/ClientAuthTypeConfig.java
+++ b/server/src/main/java/keywhiz/service/config/ClientAuthTypeConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keywhiz.service.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Configuration for how clients should be authenticated. */
+@AutoValue
+public abstract class ClientAuthTypeConfig {
+  @JsonCreator public static ClientAuthTypeConfig of(
+      @JsonProperty("useClientName") boolean useClientName,
+      @JsonProperty("useSpiffeId") boolean useSpiffeId) {
+    return new AutoValue_ClientAuthTypeConfig(useClientName, useSpiffeId);
+  }
+
+  // whether to use the client name to identify clients
+  public abstract boolean useClientName();
+
+  // whether to use the spiffe ID to identify clients
+  public abstract boolean useSpiffeId();
+}

--- a/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
+++ b/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
@@ -28,18 +28,9 @@ import java.util.List;
 @AutoValue
 public abstract class XfccSourceConfig {
   @JsonCreator public static XfccSourceConfig of(
-      @JsonProperty("allowedPorts") List<Integer> allowedPorts,
       @JsonProperty("allowedClientNames") List<String> allowedClientNames) {
-    return new AutoValue_XfccSourceConfig(allowedPorts, allowedClientNames);
+    return new AutoValue_XfccSourceConfig(allowedClientNames);
   }
-
-  // Only traffic from these ports will be allowed to include an x-forwarded-client-cert header;
-  // traffic which includes an XFCC header and is _not_ sent to these ports will be rejected,
-  // since it is likely that the provided certificate belongs to a proxy rather than the original
-  // requestor.
-  // Access to these ports MUST be highly restricted, since otherwise clients can set the XFCC
-  // header to steal other clients' secrets.
-  public abstract List<Integer> allowedPorts();
 
   // Only traffic from these clients will be allowed to include an x-forwarded-client-cert header;
   // traffic which includes an XFCC header and is _not_ sent from these clients will be rejected,

--- a/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
+++ b/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
@@ -28,8 +28,9 @@ import java.util.List;
 @AutoValue
 public abstract class XfccSourceConfig {
   @JsonCreator public static XfccSourceConfig of(
-      @JsonProperty("allowedClientNames") List<String> allowedClientNames) {
-    return new AutoValue_XfccSourceConfig(allowedClientNames);
+      @JsonProperty("allowedClientNames") List<String> allowedClientNames,
+      @JsonProperty("allowedSpiffeIds") List<String> allowedSpiffeIds) {
+    return new AutoValue_XfccSourceConfig(allowedClientNames, allowedSpiffeIds);
   }
 
   // Only traffic from these clients will be allowed to include an x-forwarded-client-cert header;
@@ -37,4 +38,5 @@ public abstract class XfccSourceConfig {
   // since most clients should only access their own secrets rather than potentially accessing other
   // secrets using the XFCC header.
   public abstract List<String> allowedClientNames();
+  public abstract List<String> allowedSpiffeIds();
 }

--- a/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
+++ b/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
@@ -28,8 +28,9 @@ import java.util.List;
 @AutoValue
 public abstract class XfccSourceConfig {
   @JsonCreator public static XfccSourceConfig of(
-      @JsonProperty("allowedPorts") List<Integer> allowedPorts) {
-    return new AutoValue_XfccSourceConfig(allowedPorts);
+      @JsonProperty("allowedPorts") List<Integer> allowedPorts,
+      @JsonProperty("allowedClientNames") List<String> allowedClientNames) {
+    return new AutoValue_XfccSourceConfig(allowedPorts, allowedClientNames);
   }
 
   // Only traffic from these ports will be allowed to include an x-forwarded-client-cert header;
@@ -39,4 +40,10 @@ public abstract class XfccSourceConfig {
   // Access to these ports MUST be highly restricted, since otherwise clients can set the XFCC
   // header to steal other clients' secrets.
   public abstract List<Integer> allowedPorts();
+
+  // Only traffic from these clients will be allowed to include an x-forwarded-client-cert header;
+  // traffic which includes an XFCC header and is _not_ sent from these clients will be rejected,
+  // since most clients should only access their own secrets rather than potentially accessing other
+  // secrets using the XFCC header.
+  public abstract List<String> allowedClientNames();
 }

--- a/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
+++ b/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
@@ -28,15 +28,25 @@ import java.util.List;
 @AutoValue
 public abstract class XfccSourceConfig {
   @JsonCreator public static XfccSourceConfig of(
+      @JsonProperty("port") Integer port,
       @JsonProperty("allowedClientNames") List<String> allowedClientNames,
       @JsonProperty("allowedSpiffeIds") List<String> allowedSpiffeIds) {
-    return new AutoValue_XfccSourceConfig(allowedClientNames, allowedSpiffeIds);
+    return new AutoValue_XfccSourceConfig(port, allowedClientNames, allowedSpiffeIds);
   }
 
-  // Only traffic from these clients will be allowed to include an x-forwarded-client-cert header;
-  // traffic which includes an XFCC header and is _not_ sent from these clients will be rejected,
-  // since most clients should only access their own secrets rather than potentially accessing other
-  // secrets using the XFCC header.
+  /**
+   * The port that this configuration applies to. All traffic sent through this port
+   * must use an XFCC header to identify the Keywhiz client.
+   */
+  public abstract Integer port();
+
+  /**
+   * Only traffic from these clients will be allowed to include an x-forwarded-client-cert header;
+   * traffic which includes an XFCC header and is not sent from these clients will be rejected,
+   * since most clients should only access their own secrets rather than potentially accessing other
+   * secrets using the XFCC header.
+   */
   public abstract List<String> allowedClientNames();
+
   public abstract List<String> allowedSpiffeIds();
 }

--- a/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
+++ b/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keywhiz.service.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import java.util.List;
+
+/**
+ * Configuration for x-forwarded-client-cert header support, as set by the Envoy proxy
+ * https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert
+ */
+@AutoValue
+public abstract class XfccSourceConfig {
+  @JsonCreator public static XfccSourceConfig of(
+      @JsonProperty("allowedPorts") List<Integer> allowedPorts) {
+    return new AutoValue_XfccSourceConfig(allowedPorts);
+  }
+
+  // Only traffic from these ports will be allowed to include an x-forwarded-client-cert header;
+  // traffic which includes an XFCC header and is _not_ sent to these ports will be rejected,
+  // since it is likely that the provided certificate belongs to a proxy rather than the original
+  // requestor.
+  // Access to these ports MUST be highly restricted, since otherwise clients can set the XFCC
+  // header to steal other clients' secrets.
+  public abstract List<Integer> allowedPorts();
+}

--- a/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
@@ -52,7 +52,7 @@ public class AutomationClientAuthFactory {
   public AutomationClient provide(ContainerRequest request) {
     Optional<Principal> principal = ClientAuthFactory.getPrincipal(request);
     Optional<String> possibleClientName = ClientAuthFactory.getClientName(principal);
-    if (!principal.isPresent() || !possibleClientName.isPresent()) {
+    if (principal.isEmpty() || possibleClientName.isEmpty()) {
       throw new NotAuthorizedException("Not authorized as a AutomationClient");
     }
     String clientName = possibleClientName.get();

--- a/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
@@ -17,12 +17,20 @@
 package keywhiz.service.providers;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.io.ByteArrayInputStream;
+import java.net.URLDecoder;
 import java.security.Principal;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.NotAuthorizedException;
+import keywhiz.KeywhizConfig;
 import keywhiz.api.model.Client;
+import keywhiz.service.config.ClientAuthConfig;
 import keywhiz.service.daos.ClientDAO;
 import keywhiz.service.daos.ClientDAO.ClientDAOFactory;
 import org.bouncycastle.asn1.x500.RDN;
@@ -34,31 +42,75 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * Authenticates {@link Client}s from requests based on the principal present in a
- * {@link javax.ws.rs.core.SecurityContext} and by querying the database.
- *
- * Modeled similar to io.dropwizard.auth.AuthFactory, however that is not yet usable.
- * See https://github.com/dropwizard/dropwizard/issues/864.
+ * Authenticates {@link Client}s from requests based on the principal present in a {@link
+ * javax.ws.rs.core.SecurityContext} and by querying the database.
+ * <p>
+ * Modeled similar to io.dropwizard.auth.AuthFactory, however that is not yet usable. See
+ * https://github.com/dropwizard/dropwizard/issues/864.
  */
 public class ClientAuthFactory {
   private static final Logger logger = LoggerFactory.getLogger(ClientAuthFactory.class);
 
-  private final MyAuthenticator authenticator;
+  @VisibleForTesting
+  protected static final String XFCC_HEADER_NAME = "X-Forwarded-Client-Cert";
 
-  @Inject public ClientAuthFactory(ClientDAOFactory clientDAOFactory) {
-    this.authenticator = new MyAuthenticator(clientDAOFactory.readwrite(), clientDAOFactory.readonly());
+  // The key that will be searched for in the XFCC header. Eventually, this should be made
+  // configurable, with different parsing depending on the key being searched for.
+  @VisibleForTesting
+  protected static final String CERT_KEY = "Cert";
+
+  private final MyAuthenticator authenticator;
+  private final ClientAuthConfig clientAuthConfig;
+
+  @Inject
+  public ClientAuthFactory(ClientDAOFactory clientDAOFactory, KeywhizConfig keywhizConfig) {
+    this.authenticator =
+        new MyAuthenticator(clientDAOFactory.readwrite(), clientDAOFactory.readonly());
+    this.clientAuthConfig = keywhizConfig.getClientAuthConfig();
   }
 
-  @VisibleForTesting ClientAuthFactory(ClientDAO clientDAO) {
+  @VisibleForTesting ClientAuthFactory(ClientDAO clientDAO, ClientAuthConfig clientAuthConfig) {
     this.authenticator = new MyAuthenticator(clientDAO, clientDAO);
+    this.clientAuthConfig = clientAuthConfig;
   }
 
   public Client provide(ContainerRequest request) {
-    Optional<Principal> principal = getPrincipal(request);
-    Optional<String> possibleClientName = getClientName(principal);
-    if (!principal.isPresent() || !possibleClientName.isPresent()) {
+    Optional<Principal> principal;
+    Optional<String> possibleClientName;
+
+    // Extract client information based on the x-forwarded-client-cert header (if set) or
+    // on the security context of this request
+    if (request.getRequestHeader(XFCC_HEADER_NAME) == null ||
+        request.getRequestHeader(XFCC_HEADER_NAME).isEmpty()) {
+      // The XFCC header was not set; use the security context of this request to identify the client
+      principal = getPrincipal(request);
+    } else {
+      if (clientAuthConfig == null) {
+        throw new NotAuthorizedException(
+            format(
+                "not configured to handle requests with %s header set; see 'xfcc' field in client config",
+                XFCC_HEADER_NAME));
+      }
+
+      // Do not allow the XFCC header to be set by all incoming traffic. The allowed ports MUST
+      // be a restricted list to prevent clients from setting the header and accessing other
+      // clients' secrets.
+      if (!clientAuthConfig.xfccConfig().allowedPorts().contains(request.getBaseUri().getPort())) {
+        throw new NotAuthorizedException(
+            format("requests with %s header set not allowed from port %d; check configuration",
+                XFCC_HEADER_NAME, request.getBaseUri().getPort()));
+      }
+
+      // Extract client information from the XFCC header
+      principal = getClientPrincipalFromXfccHeaderEnvoyFormatted(request);
+    }
+
+    possibleClientName = getClientName(principal);
+
+    if (principal.isEmpty() || possibleClientName.isEmpty()) {
       throw new NotAuthorizedException("ClientCert not authorized as a Client");
     }
     String clientName = possibleClientName.get();
@@ -73,7 +125,7 @@ public class ClientAuthFactory {
   }
 
   static Optional<String> getClientName(Optional<Principal> principal) {
-    if (!principal.isPresent()) {
+    if (principal.isEmpty()) {
       return Optional.empty();
     }
 
@@ -84,6 +136,80 @@ public class ClientAuthFactory {
       return Optional.empty();
     }
     return Optional.of(IETFUtils.valueToString(rdns[0].getFirst().getValue()));
+  }
+
+  private Optional<Principal> getClientPrincipalFromXfccHeaderEnvoyFormatted(
+      ContainerRequest request) {
+    List<String> headerValues = request.getRequestHeader(XFCC_HEADER_NAME);
+
+    // Keywhiz currently supports only one certificate set in the XFCC header,
+    // since otherwise it is more difficult to distinguish which certificate should have
+    // access to secrets
+    if (headerValues.size() == 0) {
+      return Optional.empty();
+    } else if (headerValues.size() > 1) {
+      logger.warn("Keywhiz only supports one certificate set in the {} header", XFCC_HEADER_NAME);
+      return Optional.empty();
+    }
+
+    // From https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert:
+    // The XFCC header value is a comma (“,”) separated string. Each substring is an XFCC element,
+    // which holds information added by a single proxy. A proxy can append the current client
+    // certificate information as an XFCC element, to the end of the request’s XFCC header
+    // after a comma.
+    //
+    // Each XFCC element is a semicolon “;” separated string. Each substring is a key-value pair,
+    // grouped together by an equals (“=”) sign. The keys are case-insensitive, the values are
+    // case-sensitive. If “,”, “;” or “=” appear in a value, the value should be double-quoted.
+    // Double-quotes in the value should be replaced by backslash-double-quote (“).
+    String[] keyValuePairs = headerValues.get(0).split(";");
+
+    for (String pair : keyValuePairs) {
+      String[] keyValue = pair.split("=");
+      if (keyValue.length != 2) {
+        logger.warn("Got entry in {} header that wasn't a key/value pair: {}", XFCC_HEADER_NAME,
+            pair);
+        continue;
+      }
+
+      if (!CERT_KEY.equals(keyValue[0])) {
+        continue;
+      }
+
+      return clientPrincipalFromCertField(keyValue[1]);
+    }
+
+    logger.warn("Unable to find {} in {} header; no client ID parsed from header", CERT_KEY,
+        XFCC_HEADER_NAME);
+    return Optional.empty();
+  }
+
+  private Optional<Principal> clientPrincipalFromCertField(String xfccEncodedCert) {
+    // remove outer quotes
+    String encodedPem = xfccEncodedCert.replace("\"", "");
+
+    // decode and parse the certificate
+    String certPem = URLDecoder.decode(encodedPem, UTF_8);
+
+    CertificateFactory cf;
+    try {
+      cf = CertificateFactory.getInstance("X.509");
+    } catch (CertificateException e) {
+      // Should never happen (X.509 supported by default)
+      logger.error("Unexpected error: Unable to get X.509 certificate factory");
+      return Optional.empty();
+    }
+
+    X509Certificate cert;
+    try {
+      cert = (X509Certificate) cf.generateCertificate(
+          new ByteArrayInputStream(certPem.getBytes(UTF_8)));
+    } catch (CertificateException e) {
+      // Certificate must have been invalid
+      logger.warn("Failed to parse client certificate", e);
+      return Optional.empty();
+    }
+    return Optional.of(cert.getSubjectX500Principal());
   }
 
   private static class MyAuthenticator {

--- a/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
@@ -191,7 +191,7 @@ public class ClientAuthFactory {
               XFCC_HEADER_NAME, requestName.get()));
     }
 
-    if (requestSpiffeId.isPresent() && !containsIgnoreCase(xfccConfig.allowedSpiffeIds(),
+    if (requestSpiffeId.isPresent() && !xfccConfig.allowedSpiffeIds().contains(
         requestSpiffeId.get())) {
       throw new NotAuthorizedException(
           format(
@@ -316,15 +316,6 @@ public class ClientAuthFactory {
     throw new NotAuthorizedException(
         format("No authorized Client for connection using principal %s",
             clientPrincipal.getName()));
-  }
-
-  private static boolean containsIgnoreCase(List<String> strings, String target) {
-    for (String string : strings) {
-      if (string.equalsIgnoreCase(target)) {
-        return true;
-      }
-    }
-    return false;
   }
 
   private static class MyAuthenticator {

--- a/server/src/main/java/keywhiz/service/providers/XfccHeader.java
+++ b/server/src/main/java/keywhiz/service/providers/XfccHeader.java
@@ -1,0 +1,325 @@
+package keywhiz.service.providers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Structured representation of Envoy's {@code X-Forwarded-Client-Cert} (XFCC) header.
+ *
+ * @see <a href="https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert">Envoy
+ * XFCC spec</a>
+ */
+public class XfccHeader {
+  /**
+   * Elements contained in this header.
+   */
+  public final Element[] elements;
+
+  /**
+   * Element of the XFCC header. Contains information about one certificate as a list of key-value
+   * pairs.
+   */
+  public static class Element {
+    /**
+     * Key-value pairs contained in this header element.
+     */
+    public final Pair[] pairs;
+
+    /**
+     * Constructs a new instance of {@code Element} with the provided key-value pairs.
+     */
+    public Element(Pair... pairs) {
+      this.pairs = pairs;
+    }
+
+    @Override
+    public String toString() {
+      return "Element{" + Arrays.toString(pairs) + "}";
+    }
+
+    /**
+     * Key-value pair contained in the XFCC header element.
+     */
+    public static class Pair {
+      /**
+       * Name/key of the pair.
+       */
+      public final String key;
+
+      /**
+       * Value of the pair.
+       */
+      public final String value;
+
+      /**
+       * Constructs a new {@code Pair} with the specified key and value.
+       */
+      public Pair(String key, String value) {
+        this.key = key;
+        this.value = value;
+      }
+
+      @Override
+      public String toString() {
+        return "(" + key + ", " + value + ")";
+      }
+    }
+  }
+
+  /**
+   * Constructs a new instance of {@code XfccHeader} with the provided elements.
+   */
+  public XfccHeader(Element... elements) {
+    this.elements = elements;
+  }
+
+  @Override
+  public String toString() {
+    return "XfccHeader{" + Arrays.toString(elements) + "}";
+  }
+
+  /**
+   * Parses the provided XFCC header value and returns its contents in a structured form.
+   *
+   * @throws ParseException if an error occurred while parsing the header.
+   */
+  public static XfccHeader parse(String headerValue) throws ParseException {
+    //   All rules:
+    // HEADER  := ELEMENT [',' ELEMENT]*
+    // ELEMENT := [PAIR [';' PAIR]]*
+    // PAIR    := KEY '=' VALUE
+    // KEY     := [^=;,"]*
+    // VALUE   := QUOTED_VALUE | UNQUOTED_VALUE
+    // QUOTED_VALUE   := '"' [^"]* '"'
+    // UNQUOTED_VALUE := [^=;,"]*
+    //    Double-quotes in values should be replaced by \"
+    List<Element> elements = new ArrayList<>();
+    int pos = 0;
+    pos = parseElement(headerValue, pos, elements);
+    while (pos < headerValue.length()) {
+      char c = headerValue.charAt(pos);
+      if (c != ',') {
+        throw new ParseException("Invalid character '" + c
+            + "' instead of element delimiter at position " + pos);
+      }
+      pos++;
+      pos = parseElement(headerValue, pos, elements);
+    }
+    return new XfccHeader(elements.toArray(new Element[elements.size()]));
+  }
+
+  /**
+   * Consumes a single element located at the provided position in the header.
+   *
+   * @param headerValue XFCC header contents to parse.
+   * @param pos         {@code 0}-based offset at which to start parsing.
+   * @param elements    List into which to add the resulting parsed element.
+   * @return {@code 0}-based offset in the header at which this element ends. The offset is one past
+   * the last character of the element.
+   */
+  private static int parseElement(String headerValue, int pos, List<Element> elements)
+      throws ParseException {
+    //   Rules relevant to this method:
+    // HEADER  := ELEMENT [',' ELEMENT]*
+    // ELEMENT := [PAIR [';' PAIR]]
+    List<Element.Pair> pairs = new ArrayList<>();
+    while (pos < headerValue.length()) {
+      char c = headerValue.charAt(pos);
+      if (c == ',') {
+        // End of element
+        break;
+      }
+      if ((!pairs.isEmpty()) && (c == ';')) {
+        // Consume pair delimiter
+        pos++;
+      }
+      pos = parsePair(headerValue, pos, pairs);
+    }
+
+    elements.add(new Element(pairs.toArray(new Element.Pair[pairs.size()])));
+    return pos;
+  }
+
+  /**
+   * Consumes a single key-value pair located at the provided position in the header.
+   *
+   * @param headerValue XFCC header contents to parse.
+   * @param pos         {@code 0}-based offset at which to start parsing.
+   * @param pairs       List into which to add the resulting parsed pair.
+   * @return {@code 0}-based offset in the header at which this pair ends. The offset is one past
+   * the last character of the pair.
+   */
+  private static int parsePair(String headerValue, int pos, List<Element.Pair> pairs)
+      throws ParseException {
+    //   Rules relevant to this method:
+    // ELEMENT := [PAIR [';' PAIR]]
+    // PAIR    := KEY '=' VALUE
+    // KEY     := [^;,="]*
+    // VALUE   := QUOTED_VALUE | UNQUOTED_VALUE
+    // QUOTED_VALUE   := '"' [^"]* '"'
+    // UNQUOTED_VALUE := [^;,="]*
+    //    Double-quotes in values should be replaced by \"
+
+    int keyStartPosition = pos;
+
+    // Consume key and the terminating =
+    String key;
+    while (true) {
+      if (pos >= headerValue.length()) {
+        throw new ParseException("Unterminated key starts at position " + keyStartPosition
+            + ", current position: " + pos);
+      }
+      char c = headerValue.charAt(pos);
+      if (c == '=') {
+        // End of key
+        key = headerValue.substring(keyStartPosition, pos);
+        pos++;
+        break;
+      }
+
+      if ((c == ',') || (c == ';') || (c == '"')) {
+        // The "spec" is vague about whether these characters are permitted in a key. Err
+        // on the side of rejecting.
+        throw new ParseException("Invalid character '" + c
+            + "' inside key which starts at position " + keyStartPosition);
+      }
+
+      pos++;
+    }
+
+    // Consume value
+    if (pos > headerValue.length()) {
+      throw new ParseException("Missing value for key which starts at position "
+          + keyStartPosition + ", current position: " + pos);
+    }
+    StringBuilder value = new StringBuilder();
+    if (pos < headerValue.length()) {
+      if (headerValue.charAt(pos) == '"') {
+        // Consume quoted value
+        pos = parseQuotedValue(headerValue, pos, value);
+      } else {
+        // Consume unquoted value
+        pos = parseUnquotedValue(headerValue, pos, value);
+      }
+    }
+
+    pairs.add(new Element.Pair(key, value.toString()));
+    return pos;
+  }
+
+  /**
+   * Consumes a single unquoted value of a key-value pair, located at the provided position in the
+   * header.
+   *
+   * @param headerValue XFCC header contents to parse.
+   * @param pos         {@code 0}-based offset at which to start parsing.
+   * @param value       {@code StringBuilder} into which to output the value.
+   * @return {@code 0}-based offset in the header at which this value ends. The offset is one past
+   * the last character of the value.
+   */
+  private static int parseUnquotedValue(String headerValue, int pos, StringBuilder value)
+      throws ParseException {
+    // UNQUOTED_VALUE := [^;,="]*
+    //     Double-quotes in values should be replaced by \"
+    int startPosition = pos;
+    while (pos < headerValue.length()) {
+      char c = headerValue.charAt(pos);
+
+      if ((c == ';') || (c == ',')) {
+        // End of key-value pair
+        break;
+      } else if (c == '"') {
+        if ((pos == 0) || (headerValue.charAt(pos - 1) != '\\')) {
+          throw new ParseException("Invalid character '" + c
+              + "' inside unquoted value which starts at position " + startPosition
+              + ", current position: " + pos);
+        } else {
+          // Escaped double quote
+          value.setCharAt(value.length() - 1, '"');
+          pos++;
+          continue;
+        }
+      } else if (c == '=') {
+        throw new ParseException("Invalid character '" + c
+            + "' inside unquoted value which starts at position " + startPosition
+            + ", current position: " + pos);
+      }
+
+      // Consume valid character
+      value.append(c);
+      pos++;
+    }
+    return pos;
+  }
+
+  /**
+   * Consumes a single quoted value of a key-value pair, located at the provided position in the
+   * header.
+   *
+   * @param headerValue XFCC header contents to parse.
+   * @param pos         {@code 0}-based offset at which to start parsing.
+   * @param value       {@code StringBuilder} into which to output the value.
+   * @return {@code 0}-based offset in the header at which this value ends. The offset is one past
+   * the last character (terminating quote) of the value.
+   */
+  private static int parseQuotedValue(String headerValue, int pos, StringBuilder value)
+      throws ParseException {
+    // QUOTED_VALUE := '"' [^"]* '"'
+    //     Double-quotes in values should be replaced by \"
+    if (pos >= headerValue.length()) {
+      throw new ParseException("Missing value at position " + pos);
+    }
+    if (headerValue.charAt(pos) != '"') {
+      throw new IllegalArgumentException("Not a quoted value");
+    }
+    int startPosition = pos;
+    pos++;
+    while (true) {
+      if (pos >= headerValue.length()) {
+        throw new ParseException("Unterminated quoted value starts at position "
+            + startPosition + ", current position: " + pos);
+      }
+      char c = headerValue.charAt(pos);
+
+      if (c == '"') {
+        if (headerValue.charAt(pos - 1) != '\\') {
+          // End of quoted value
+          pos++;
+          break;
+        } else {
+          // Escaped double quote
+          value.setCharAt(value.length() - 1, '"');
+          pos++;
+          continue;
+        }
+      }
+
+      // Consume valid character
+      value.append(c);
+      pos++;
+    }
+    return pos;
+  }
+
+  /**
+   * Indicates that an error occurred during the parsing of an XFCC header.
+   */
+  public static class ParseException extends Exception {
+    private static final long serialVersionUID = 1;
+
+    /**
+     * Constructs a new instance of {@code ParseException} with the specified message.
+     */
+    public ParseException(String message) {
+      super(message);
+    }
+
+    /**
+     * Constructs a new instance of {@code ParseException} with the specified message and cause.
+     */
+    public ParseException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
+++ b/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
@@ -16,14 +16,20 @@
 
 package keywhiz.service.providers;
 
+import java.net.URI;
 import java.security.Principal;
+import java.util.List;
 import java.util.Optional;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.SecurityContext;
 import keywhiz.api.ApiDate;
 import keywhiz.api.model.Client;
 import keywhiz.auth.mutualssl.SimplePrincipal;
+import keywhiz.service.config.ClientAuthConfig;
+import keywhiz.service.config.ClientAuthTypeConfig;
+import keywhiz.service.config.XfccSourceConfig;
 import keywhiz.service.daos.ClientDAO;
+import org.eclipse.jetty.util.UrlEncoded;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,6 +38,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,16 +55,57 @@ public class ClientAuthFactoryTest {
   private static final Client client =
       new Client(0, "principal", null, null, null, null, null, null, null, null, true, false);
 
+  // certstrap init --common-name "KeywhizAuth"
+  // certstrap request-cert --common-name principal --ou organizational-unit --uri spiffe://example.org/principal
+  // certstrap sign principal --CA KeywhizAuth
+  private static final String clientPem =
+      "-----BEGIN CERTIFICATE-----\n\n"
+          + "MIIEcTCCAlmgAwIBAgIRALryCWgCxplmVoNtywrAfR0wDQYJKoZIhvcNAQELBQAw\n"
+          + "FjEUMBIGA1UEAxMLS2V5d2hpekF1dGgwHhcNMjAwNjE2MDAzODI0WhcNMjExMjE2\n"
+          + "MDAzNzAwWjAyMRwwGgYDVQQLExNvcmdhbml6YXRpb25hbC11bml0MRIwEAYDVQQD\n"
+          + "EwlwcmluY2lwYWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDz9ex2\n"
+          + "HQ7YA9nyOigFjeOqSpkDVReSG2IWSDHnugkO3TVY7NqfgMx1I+KESAj5w/PXIv1I\n"
+          + "Aa4qUnLYQ2IqgYUYvJqTt6DtlFLC6dWdgV0x/zRIbtybPR9Ww0eObShzy4od97w4\n"
+          + "zMN1/xXwpIrTNhn9wwzi4l7vtOYwxtoss/B6MBKyxB8R6iEUupINcFANFzcKdniG\n"
+          + "40HcEW8aUS6aRC8bCc4e6ACJp3VR5wnHpHXUlnkeOyTX5yWD8MKni9eY2t0Ra5OX\n"
+          + "tV1NEwOPJz8fTp8aRnoe8+Rq8Lm7W59PO7cJ45srlQ5kKnagha6KB8TTzvNOtYqj\n"
+          + "SgQNkb/OhS8R7Z/9AgMBAAGjgZ0wgZowDgYDVR0PAQH/BAQDAgO4MB0GA1UdJQQW\n"
+          + "MBQGCCsGAQUFBwMBBggrBgEFBQcDAjAdBgNVHQ4EFgQUj35sbmMzi/R/rrdMJHnj\n"
+          + "n1TLhMwwHwYDVR0jBBgwFoAUUtVdMwHcbWdRZ/VypTBlpCbxgDIwKQYDVR0RBCIw\n"
+          + "IIYec3BpZmZlOi8vZXhhbXBsZS5vcmcvcHJpbmNpcGFsMA0GCSqGSIb3DQEBCwUA\n"
+          + "A4ICAQCXPUPcv9ADJACy5D4Z8bQlGyDj131+vthj95eyO8ftPzTrJANGwpl93oO1\n"
+          + "d7lNh1h2exj/e+gtxdYE/I+DYyvHb2Op+SRNN/ZeZntaoqt22p8CGYIpsPQHttLw\n"
+          + "KJ91ekZhyQhphzgceMrhcnSc/RH7L373ZkFi5FC9EAixKsaDftz+NVTk7vhc+cLV\n"
+          + "Mhkhc3L3dA/Ffqpq6iRVs9eefFlN5Oot3PIihvCrbtl0tur02PjLVWQr5Y/nyVG0\n"
+          + "kN0LU7+w3GNddqB0gsLkwBPZ+UtmbyjHaVQN50jZxA7ysr+EjNhTyZ3lliPX4bGE\n"
+          + "TS/jTexOAObS3tC+e157k2UXbFMNZrE/pQb3juOJHcBgwpZ8FnYlwqe8VIJ6513K\n"
+          + "sOTS2lqAXYCaCOC0X6grRuL+s2JTzhzfgz2xuOSQVtvGYK5FijQVpGBR5BlfgpMM\n"
+          + "/W45PGdkvZGI4281VZUfTSSYK/OstnBAD3BgZXhnQg28dj8BD4jNd5JP7cKHb+ID\n"
+          + "33dh8mAGmSmiSPbxkVwq1AKwa5y6hbfvPIQGaUKveQe0JLTFlU4KmYIRv/nl8N83\n"
+          + "st5hq3sW1qoqXZZ71A/T/BYPODcKgeEBzJ64l7jHtPN91SE8U8vhcrpEWZb/D/PI\n"
+          + "vZTiHaxVIvRRokUPFie1drkj5I7Q7qXqHOCy22rgccR64wkNVg==\n"
+          + "-----END CERTIFICATE-----";
+  private static final String xfccHeader =
+      format("Cert=\"%s\"", UrlEncoded.encodeString(clientPem, UTF_8));
+
+  private static final int xfccAllowedPort = 4445;
+  private static final int xfccDisallowedPort = 4446;
+  private static final ClientAuthConfig clientAuthConfig = ClientAuthConfig.of(
+      XfccSourceConfig.of(List.of(xfccAllowedPort)),
+      ClientAuthTypeConfig.of(true, false)
+  );
+
   @Mock ContainerRequest request;
   @Mock SecurityContext securityContext;
   @Mock ClientDAO clientDAO;
 
   ClientAuthFactory factory;
 
-  @Before public void setUp() {
-    factory = new ClientAuthFactory(clientDAO);
+  @Before public void setUp() throws Exception {
+    factory = new ClientAuthFactory(clientDAO, clientAuthConfig);
 
     when(request.getSecurityContext()).thenReturn(securityContext);
+    when(request.getBaseUri()).thenReturn(new URI(format("https://localhost:%d", xfccAllowedPort)));
     when(clientDAO.getClient("principal")).thenReturn(Optional.of(client));
   }
 
@@ -75,9 +124,10 @@ public class ClientAuthFactoryTest {
 
   @Test(expected = NotAuthorizedException.class)
   public void rejectsDisabledClients() {
-    Client disabledClient = new Client(1, "disabled", null, null, null, null, null, null, null, null,
-        false, false
-        /* disabled */);
+    Client disabledClient =
+        new Client(1, "disabled", null, null, null, null, null, null, null, null,
+            false, false
+            /* disabled */);
 
     when(securityContext.getUserPrincipal()).thenReturn(SimplePrincipal.of("CN=disabled"));
     when(clientDAO.getClient("disabled")).thenReturn(Optional.of(disabledClient));
@@ -85,11 +135,12 @@ public class ClientAuthFactoryTest {
     factory.provide(request);
   }
 
-  @Test public void createsDbRecordForNewClient() throws Exception {
+  @Test public void createsDbRecordForNewClient() {
     ApiDate now = ApiDate.now();
-    Client newClient = new Client(2345L, "new-client", "desc", null, now, "automatic", now, "automatic",
-        null, null, true, false
-    );
+    Client newClient =
+        new Client(2345L, "new-client", "desc", null, now, "automatic", now, "automatic",
+            null, null, true, false
+        );
 
     // lookup doesn't find client
     when(securityContext.getUserPrincipal()).thenReturn(SimplePrincipal.of("CN=new-client"));
@@ -106,5 +157,38 @@ public class ClientAuthFactoryTest {
     when(securityContext.getUserPrincipal()).thenReturn(principal);
     factory.provide(request);
     verify(clientDAO, times(1)).sawClient(any(), eq(principal));
+  }
+
+  @Test public void clientWhenClientPresent_fromXfccHeader() {
+    when(request.getRequestHeader(ClientAuthFactory.XFCC_HEADER_NAME)).thenReturn(
+        List.of(xfccHeader));
+
+    assertThat(factory.provide(request)).isEqualTo(client);
+  }
+
+  @Test(expected = NotAuthorizedException.class)
+  public void rejectsUnauthorizedXfccPort() throws Exception {
+    when(request.getBaseUri()).thenReturn(
+        new URI(format("https://localhost:%d", xfccDisallowedPort)));
+    when(request.getRequestHeader(ClientAuthFactory.XFCC_HEADER_NAME)).thenReturn(
+        List.of(xfccHeader));
+
+    factory.provide(request);
+  }
+
+  @Test(expected = NotAuthorizedException.class)
+  public void rejectsMultipleXfccEntries() {
+    when(request.getRequestHeader(ClientAuthFactory.XFCC_HEADER_NAME)).thenReturn(
+        List.of(xfccHeader, xfccHeader));
+
+    factory.provide(request);
+  }
+
+  @Test(expected = NotAuthorizedException.class)
+  public void rejectsMissingXfccClient() {
+    when(request.getRequestHeader(ClientAuthFactory.XFCC_HEADER_NAME)).thenReturn(
+        List.of("By=principal"));
+
+    factory.provide(request);
   }
 }

--- a/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
+++ b/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
@@ -110,8 +110,12 @@ public class ClientAuthFactoryTest {
     when(clientDAO.getClient("principal")).thenReturn(Optional.of(client));
 
     when(clientAuthConfig.xfccConfig()).thenReturn(xfccSourceConfig);
-    when(xfccSourceConfig.allowedClientNames()).thenReturn(List.of(xfccClient.getName()));
     when(clientAuthConfig.typeConfig()).thenReturn(clientAuthTypeConfig);
+
+    when(xfccSourceConfig.allowedClientNames()).thenReturn(List.of(xfccClient.getName()));
+
+    when(clientAuthTypeConfig.useClientName()).thenReturn(true);
+    when(clientAuthTypeConfig.useSpiffeId()).thenReturn(false);
   }
 
   @Test public void returnsClientWhenClientPresent() {

--- a/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
+++ b/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
@@ -267,7 +267,7 @@ public class ClientAuthFactoryTest {
         new URI(format("https://localhost:%d", xfccAllowedPort)));
     when(securityContext.getUserPrincipal()).thenReturn(xfccPrincipal);
 
-    // Simulate multiple XFCC headers
+    // multiple XFCC headers
     when(request.getRequestHeader(ClientAuthFactory.XFCC_HEADER_NAME)).thenReturn(
         List.of(xfccHeader, xfccHeader));
 
@@ -280,9 +280,23 @@ public class ClientAuthFactoryTest {
         new URI(format("https://localhost:%d", xfccAllowedPort)));
     when(securityContext.getUserPrincipal()).thenReturn(xfccPrincipal);
 
-    // Simulate a single header with multiple certs added to it
+    // a single header with multiple client elements in to it
     when(request.getRequestHeader(ClientAuthFactory.XFCC_HEADER_NAME)).thenReturn(
         List.of(xfccHeader + "," + xfccHeader));
+
+    factory.provide(request);
+  }
+
+  @Test(expected = NotAuthorizedException.class)
+  public void rejectsXfcc_multipleCertKeysInHeader() throws Exception {
+    when(request.getBaseUri()).thenReturn(
+        new URI(format("https://localhost:%d", xfccAllowedPort)));
+    when(securityContext.getUserPrincipal()).thenReturn(xfccPrincipal);
+
+    // a single header with multiple cert tags in it for the same client
+    when(request.getRequestHeader(ClientAuthFactory.XFCC_HEADER_NAME)).thenReturn(
+        List.of(format("Cert=\"%s\";cert=\"%s\"", UrlEncoded.encodeString(clientPem, UTF_8),
+            UrlEncoded.encodeString(clientPem, UTF_8))));
 
     factory.provide(request);
   }

--- a/server/src/test/java/keywhiz/service/providers/XfccHeaderTest.java
+++ b/server/src/test/java/keywhiz/service/providers/XfccHeaderTest.java
@@ -1,0 +1,197 @@
+package keywhiz.service.providers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for {@link XfccHeader}
+ */
+public class XfccHeaderTest {
+
+  /**
+   * Tests the test vectors from Envoy's "spec".
+   *
+   * @see <a href="https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert">Envoy
+   * XFCC spec</a>
+   */
+  @Test
+  public void testSpec() {
+    assertParseSucceeds(
+        "By=http://frontend.lyft.com;Hash=468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688;Subject=\"/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test Client\";URI=http://testclient.lyft.com",
+        new XfccHeader(
+            new XfccHeader.Element(
+                new XfccHeader.Element.Pair("By", "http://frontend.lyft.com"),
+                new XfccHeader.Element.Pair("Hash",
+                    "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688"),
+                new XfccHeader.Element.Pair("Subject",
+                    "/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test Client"),
+                new XfccHeader.Element.Pair("URI", "http://testclient.lyft.com")
+            )));
+    assertParseSucceeds(
+        "By=http://frontend.lyft.com;Hash=468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688;URI=http://testclient.lyft.com,By=http://backend.lyft.com;Hash=9ba61d6425303443c0748a02dd8de688468ed33be74eee6556d90c0149c1309e;URI=http://frontend.lyft.com",
+        new XfccHeader(
+            new XfccHeader.Element(
+                new XfccHeader.Element.Pair("By", "http://frontend.lyft.com"),
+                new XfccHeader.Element.Pair("Hash",
+                    "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688"),
+                new XfccHeader.Element.Pair("URI", "http://testclient.lyft.com")
+            ),
+            new XfccHeader.Element(
+                new XfccHeader.Element.Pair("By", "http://backend.lyft.com"),
+                new XfccHeader.Element.Pair("Hash",
+                    "9ba61d6425303443c0748a02dd8de688468ed33be74eee6556d90c0149c1309e"),
+                new XfccHeader.Element.Pair("URI", "http://frontend.lyft.com")
+            )));
+    assertParseSucceeds(
+        "By=http://frontend.lyft.com;Hash=468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688;Subject=\"/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test Client\";URI=http://testclient.lyft.com;DNS=lyft.com;DNS=www.lyft.com",
+        new XfccHeader(
+            new XfccHeader.Element(
+                new XfccHeader.Element.Pair("By", "http://frontend.lyft.com"),
+                new XfccHeader.Element.Pair("Hash",
+                    "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688"),
+                new XfccHeader.Element.Pair("Subject",
+                    "/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test Client"),
+                new XfccHeader.Element.Pair("URI", "http://testclient.lyft.com"),
+                new XfccHeader.Element.Pair("DNS", "lyft.com"),
+                new XfccHeader.Element.Pair("DNS", "www.lyft.com")
+            )));
+  }
+
+  @Test
+  public void testEmptyElements() {
+    assertParseSucceeds("", new XfccHeader(new XfccHeader.Element()));
+    assertParseSucceeds(",", new XfccHeader(new XfccHeader.Element(), new XfccHeader.Element()));
+    assertParseSucceeds(
+        ",,",
+        new XfccHeader(new XfccHeader.Element(), new XfccHeader.Element(),
+            new XfccHeader.Element()));
+  }
+
+  @Test
+  public void testEmptyPairs() {
+    assertParseFails(";");
+  }
+
+  @Test
+  public void testSpaces() {
+    assertParseFails(" ");
+    assertParseFails(", ");
+    assertParseFails(" ,");
+    assertParseFails(", ,");
+
+    assertParseSucceeds(" a=b", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair(" a", "b"))));
+    assertParseSucceeds("a =b", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("a ", "b"))));
+    assertParseSucceeds("a= b", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("a", " b"))));
+    assertParseSucceeds("a=b ", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("a", "b "))));
+  }
+
+  @Test
+  public void testEmptyKeyOrValue() {
+    assertParseSucceeds("=", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("", ""))));
+    assertParseSucceeds("=\"\"", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("", ""))));
+    assertParseSucceeds("a=", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("a", ""))));
+    assertParseSucceeds("=b", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("", "b"))));
+  }
+
+  @Test
+  public void testPairKeyInvalidCharacters() {
+    assertParseFails("a\"=b");
+    assertParseFails("a\\\"=");
+    assertParseFails("a\"\"=b");
+    assertParseFails("\"a\"=b");
+    assertParseFails("a;=b");
+    assertParseFails("a,=b");
+  }
+
+  @Test
+  public void testPairValueInvalidCharacters() {
+    assertParseFails("a=b\"");
+    assertParseFails("a=b\"\"");
+    assertParseFails("a=b;c");
+    assertParseFails("a=b,c");
+    assertParseFails("a=b=c");
+  }
+
+  @Test
+  public void testPairValueQuotes() {
+    assertParseSucceeds("a=\"\"", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("a", ""))));
+    assertParseSucceeds("a=\"\\\",b=\\\"\"", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("a", "\",b=\""))));
+    assertParseSucceeds("a=\",\"", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("a", ","))));
+    assertParseSucceeds("a=\";\"", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("a", ";"))));
+    assertParseSucceeds("a=\"=\"", new XfccHeader(new XfccHeader.Element(
+        new XfccHeader.Element.Pair("a", "="))));
+  }
+
+  private static void assertParseFails(String headerValue) {
+    XfccHeader header;
+    try {
+      header = XfccHeader.parse(headerValue);
+    } catch (XfccHeader.ParseException e) {
+      // expected
+      return;
+    }
+    fail("Expected to fail, but got " + header);
+  }
+
+  private static void assertParseSucceeds(String actualHeaderValue, XfccHeader expectedResult) {
+    XfccHeader actual;
+    try {
+      actual = XfccHeader.parse(actualHeaderValue);
+    } catch (XfccHeader.ParseException e) {
+      throw new AssertionError("Parsing failed instead of succeeding", e);
+    }
+    assertHeaderEquals(expectedResult, actual);
+  }
+
+  private static void assertHeaderEquals(XfccHeader expected, XfccHeader actual) {
+    if (expected.elements.length != actual.elements.length) {
+      fail("Expected<" + expected + ">, actual: <" + actual + ">. Different number of"
+          + " elements. Expected:<" + expected.elements.length + ">, actual: <"
+          + actual.elements.length + ">");
+    }
+    for (int i = 0; i < expected.elements.length; i++) {
+      try {
+        assertElementEquals(
+            "Expected<" + expected + ">, actual: <" + actual + ">. Element #" + i
+                + " differs",
+            expected.elements[i],
+            actual.elements[i]);
+      } catch (AssertionError e) {
+        fail("Expected<" + expected + ">, actual: <" + actual + ">. Element #" + i
+            + " differs. " + e.getMessage());
+      }
+    }
+  }
+
+  private static void assertElementEquals(
+      String message, XfccHeader.Element expected, XfccHeader.Element actual) {
+    if (actual.pairs.length != expected.pairs.length) {
+      fail(message + ": Different number of pairs. Expected <" + expected.pairs.length
+          + ">, actual: <" + actual.pairs.length + ">");
+    }
+    for (int i = 0; i < expected.pairs.length; i++) {
+      assertPairEquals(
+          message + ": Pair #" + i + " differs", expected.pairs[i], actual.pairs[i]);
+    }
+  }
+
+  private static void assertPairEquals(
+      String message, XfccHeader.Element.Pair expected, XfccHeader.Element.Pair actual) {
+    assertEquals(message + ": Key", expected.key, actual.key);
+    assertEquals(message + ": Value", expected.value, actual.value);
+  }
+}

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -154,8 +154,9 @@ flywaySchemaTable: schema_version
 
 clientAuthConfig:
   xfcc:
-    allowedClientNames: []
-    allowedSpiffeIds: []
+    - port: 4446
+      allowedClientNames: []
+      allowedSpiffeIds: []
   type:
     useClientName: true
     useSpiffeId: true

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -158,5 +158,5 @@ clientAuthConfig:
       allowedClientNames: []
       allowedSpiffeIds: []
   type:
-    useClientName: true
+    useCommonName: true
     useSpiffeId: true

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -155,6 +155,7 @@ flywaySchemaTable: schema_version
 clientAuthConfig:
   xfcc:
     allowedClientNames: []
+    allowedSpiffeIds: []
   type:
     useClientName: true
     useSpiffeId: true

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -154,8 +154,6 @@ flywaySchemaTable: schema_version
 
 clientAuthConfig:
   xfcc:
-    allowedPorts:
-      - 4445 # in practice, set up a separate connector for XFCC traffic
     allowedClientNames: []
   type:
     useClientName: true

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -156,6 +156,7 @@ clientAuthConfig:
   xfcc:
     allowedPorts:
       - 4445 # in practice, set up a separate connector for XFCC traffic
+    allowedClientNames: []
   type:
     useClientName: true
     useSpiffeId: true

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -151,3 +151,11 @@ contentKeyStore:
 rowHmacCheck: enforced
 
 flywaySchemaTable: schema_version
+
+clientAuthConfig:
+  xfcc:
+    allowedPorts:
+      - 4445 # in practice, set up a separate connector for XFCC traffic
+  type:
+    useClientName: true
+    useSpiffeId: true


### PR DESCRIPTION
Envoy, a widely used L7 proxy, sets the x-forwarded-client-cert
header to contain the certificate for clients connecting to
the proxy. It then can connect directly to its server (such as
Keywhiz) using TLS.

This updates Keywhiz to parse client certificates out of the
XFCC header if they are provided. If the XFCC header was provided,
Keywhiz ignores any certificates from the direct connection; this
is necessary to avoid using the proxy (if it is also a Keywhiz
client) as the client when taking action rather than the real
client which connected to the proxy.

This still has some limitations, which may be addressed in future
commits:
* the XFCC header must be formatted as defined by Envoy
8 the XFCC header must have only one certificate in it, which corresponds
to the certificate for the real Keywhiz client
* only the "Cert" field from the XFCC header is parsed for client
data, although other fields (such as "Subject" and "URI") could carry
client data without the need for parsing a certificate
* traffic with the XFCC header set is blocked based on a port, but
not based on client identity; Keywhiz could instead require traffic
to come from a fixed port and from an allowed, verified proxy client,
to further reduce the risk of a client setting the XFCC
header to steal another client's secrets.

This commit also introduces a configuration option to control
whether SPIFFE URIs are used to authenticate clients, but the
option is not yet in use.