### PR TITLE
Retrieve clients based on their SPIFFE IDs

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/ClientDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/ClientDAO.java
@@ -136,8 +136,13 @@ public class ClientDAO {
     }
   }
 
-  public Optional<Client> getClient(String name) {
+  public Optional<Client> getClientByName(String name) {
     ClientsRecord r = dslContext.fetchOne(CLIENTS, CLIENTS.NAME.eq(name));
+    return Optional.ofNullable(r).map(clientMapper::map);
+  }
+
+  public Optional<Client> getClientBySpiffeId(String spiffeId) {
+    ClientsRecord r = dslContext.fetchOne(CLIENTS, CLIENTS.SPIFFE_ID.eq(spiffeId));
     return Optional.ofNullable(r).map(clientMapper::map);
   }
 

--- a/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
@@ -53,7 +53,7 @@ public class AutomationClientAuthFactory {
   public AutomationClient provide(ContainerRequest request) {
     Principal principal = ClientAuthFactory.getPrincipal(request)
         .orElseThrow(() -> new NotAuthorizedException("Not authorized as a AutomationClient"));
-    String clientName = ClientAuthFactory.getClientName(principal)
+    String clientName = ClientAuthenticator.getClientName(principal)
         .orElseThrow(() -> new NotAuthorizedException("Not authorized as a AutomationClient"));
 
     return authenticator.authenticate(clientName, principal)
@@ -71,7 +71,7 @@ public class AutomationClientAuthFactory {
     }
 
     public Optional<AutomationClient> authenticate(String name, @Nullable Principal principal) {
-      Optional<Client> client = clientDAOReadOnly.getClient(name);
+      Optional<Client> client = clientDAOReadOnly.getClientByName(name);
       client.ifPresent(value -> clientDAOReadWrite.sawClient(value, principal));
       return client.map(AutomationClient::of);
     }

--- a/server/src/main/java/keywhiz/service/providers/ClientAuthenticator.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthenticator.java
@@ -1,0 +1,172 @@
+package keywhiz.service.providers;
+
+import java.security.Principal;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.ws.rs.NotAuthorizedException;
+import keywhiz.api.model.Client;
+import keywhiz.auth.mutualssl.CertificatePrincipal;
+import keywhiz.service.config.ClientAuthConfig;
+import keywhiz.service.daos.ClientDAO;
+import org.bouncycastle.asn1.x500.RDN;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x500.style.IETFUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClientAuthenticator {
+  private static final Logger logger = LoggerFactory.getLogger(ClientAuthenticator.class);
+
+  // The integer representation of the URIName SAN for a certificate.
+  // 6 is hardcoded via RFC:
+  // uniformResourceIdentifier       [6]     IA5String,
+  // E.g. see BouncyCastle documentation:
+  // http://people.eecs.berkeley.edu/~jonah/bc/org/bouncycastle/asn1/x509/GeneralName.html
+  private static final Integer URINAME_SAN = 6;
+
+  // The expected prefix for SPIFFE URIs
+  private static final String SPIFFE_SCHEME = "spiffe://";
+
+  private final ClientDAO clientDAOReadWrite;
+  private final ClientDAO clientDAOReadOnly;
+  private final ClientAuthConfig clientAuthConfig;
+
+  public ClientAuthenticator(
+      ClientDAO clientDAOReadWrite,
+      ClientDAO clientDAOReadOnly,
+      ClientAuthConfig clientAuthConfig) {
+    this.clientDAOReadWrite = clientDAOReadWrite;
+    this.clientDAOReadOnly = clientDAOReadOnly;
+    this.clientAuthConfig = clientAuthConfig;
+  }
+
+  public Optional<Client> authenticate(Principal principal, boolean createMissingClient) {
+    // Try to retrieve clients based on the client name and SPIFFE ID
+    Optional<String> possibleClientName = getClientName(principal);
+    Optional<String> possibleClientSpiffeId = getSpiffeId(principal);
+
+    Optional<Client> possibleClientFromName = possibleClientName.flatMap((name) -> {
+      if (clientAuthConfig.typeConfig().useCommonName()) {
+        return clientDAOReadOnly.getClientByName(name);
+      } else {
+        return Optional.empty();
+      }
+    });
+
+    Optional<Client> possibleClientFromSpiffeId = possibleClientSpiffeId.flatMap((name) -> {
+      if (clientAuthConfig.typeConfig().useSpiffeId()) {
+        return clientDAOReadOnly.getClientBySpiffeId(name);
+      } else {
+        return Optional.empty();
+      }
+    });
+
+    // If the name and SPIFFE id both defined a client, make sure that they defined the same
+    // client! (Note that if retrieving clients by common name or SPIFFE ID is disabled, this
+    // check will not reject a certificate with a mismatched CN and SPIFFE URI.)
+    if (possibleClientFromName.isPresent() && possibleClientFromSpiffeId.isPresent()) {
+      if (!possibleClientFromName.get().equals(possibleClientFromSpiffeId.get())) {
+        throw new NotAuthorizedException(String.format(
+            "Input principal's CN and SPIFFE ID correspond to different clients! (cn = %s, spiffe = %s)",
+            possibleClientFromName.get().getName(), possibleClientFromSpiffeId.get().getName()));
+      }
+    } else if (possibleClientFromName.isEmpty() && possibleClientFromSpiffeId.isEmpty()) {
+      // Create missing clients if configured to do so (client name must be present)
+      return handleMissingClient(createMissingClient, possibleClientName.orElse(""),
+          possibleClientSpiffeId.orElse(""));
+    }
+
+    // Retrieve whichever of the clients is set (if both are present, the earlier check guarantees
+    // that they contain the same client).
+    Client client = possibleClientFromName
+        .or(() -> possibleClientFromSpiffeId)
+        .orElseThrow(() -> new IllegalStateException(
+            "Unable to identify client, and fallback code in server did not handle this case"));
+
+    // Record that this client has been retrieved
+    clientDAOReadWrite.sawClient(client, principal);
+    if (client.isEnabled()) {
+      return Optional.of(client);
+    } else {
+      logger.warn("Client {} authenticated but disabled via DB", client);
+      return Optional.empty();
+    }
+  }
+
+  private Optional<Client> handleMissingClient(boolean createMissingClient, String name,
+      String spiffeId) {
+    if (createMissingClient && !name.isEmpty()) {
+      /*
+       * If a client is seen for the first time, authenticated by certificate, and has no DB entry,
+       * then a DB entry is created here. The client can be disabled in the future by flipping the
+       * 'enabled' field.
+       */
+      long clientId = clientDAOReadWrite.createClient(name, "automatic",
+          "Client created automatically from valid certificate authentication", spiffeId);
+      return clientDAOReadWrite.getClientById(clientId);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  static Optional<String> getClientName(Principal principal) {
+    X500Name name = new X500Name(principal.getName());
+    RDN[] rdns = name.getRDNs(BCStyle.CN);
+    if (rdns.length == 0) {
+      logger.warn("Certificate does not contain CN=xxx,...: {}", principal.getName());
+      return Optional.empty();
+    }
+    return Optional.of(IETFUtils.valueToString(rdns[0].getFirst().getValue()));
+  }
+
+  static Optional<String> getSpiffeId(Principal principal) {
+    if (!(principal instanceof CertificatePrincipal)) {
+      // A SPIFFE ID can only be parsed from a principal with a certificate
+      return Optional.empty();
+    }
+
+    // This chain is either from the XFCC header's "Cert" field, which includes only the
+    // client certificate rather than the chain, or from the CertificateSecurityContext
+    // configured by Keywhiz' ClientCertificateFilter, which sets it based on
+    // X509Certificate[] chain =
+    //        (X509Certificate[]) context.getProperty("javax.servlet.request.X509Certificate");
+    // which appears to place the leaf as the zero-index entry in the chain.
+    X509Certificate cert = ((CertificatePrincipal) principal).getCertificateChain()
+        .get(0);
+    return getSpiffeIdFromCertificate(cert);
+  }
+
+  static Optional<String> getSpiffeIdFromCertificate(X509Certificate cert) {
+    Collection<List<?>> sans;
+    try {
+      sans = cert.getSubjectAlternativeNames();
+    } catch (CertificateParsingException e) {
+      logger.warn("Unable to parse SANs from principal", e);
+      return Optional.empty();
+    }
+
+    if (sans == null || sans.isEmpty()) {
+      return Optional.empty();
+    }
+
+    // The sub-lists returned by getSubjectAlternativeNames have an integer for the first
+    // entry, representing a field, and the value as a string as the second entry.
+    List<String> spiffeUriNames = sans.stream()
+        .filter(sanPair -> sanPair.get(0).equals(URINAME_SAN))
+        .map(sanPair -> (String) sanPair.get(1))
+        .filter(uri -> uri.startsWith(SPIFFE_SCHEME))
+        .collect(Collectors.toUnmodifiableList());
+
+    if (spiffeUriNames.size() > 1) {
+      logger.warn("Got multiple SPIFFE URIs from certificate: {}", spiffeUriNames);
+      return Optional.empty();
+    }
+
+    return spiffeUriNames.stream().findFirst();
+  }
+}

--- a/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
+++ b/server/src/main/java/keywhiz/service/resources/SecretDeliveryResource.java
@@ -94,7 +94,7 @@ public class SecretDeliveryResource {
     Optional<Secret> secret = secretController.getSecretByName(secretName);
 
     if (!sanitizedSecret.isPresent()) {
-      boolean clientExists = clientDAO.getClient(client.getName()).isPresent();
+      boolean clientExists = clientDAO.getClientByName(client.getName()).isPresent();
       boolean secretExists = secret.isPresent();
 
       if (clientExists && secretExists) {

--- a/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
@@ -235,7 +235,7 @@ public class ClientsResource {
   }
 
   private Client clientFromName(String clientName) {
-    Optional<Client> optionalClient = clientDAO.getClient(clientName);
+    Optional<Client> optionalClient = clientDAO.getClientByName(clientName);
     if (!optionalClient.isPresent()) {
       throw new NotFoundException("Client not found.");
     }

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
@@ -138,7 +138,7 @@ public class AutomationClientResource {
     logger.info("Automation ({}) - Looking up a name {}", automationClient.getName(), name);
 
     if (name.isPresent()) {
-      Client client = clientDAO.getClient(name.get()).orElseThrow(NotFoundException::new);
+      Client client = clientDAO.getClientByName(name.get()).orElseThrow(NotFoundException::new);
       ImmutableList<Group> groups = ImmutableList.copyOf(aclDAO.getGroupsFor(client));
       return Response.ok()
           .entity(ClientDetailResponse.fromClient(client, groups, ImmutableList.of()))
@@ -170,7 +170,7 @@ public class AutomationClientResource {
       @Auth AutomationClient automationClient,
       @Valid CreateClientRequest clientRequest) {
 
-    Optional<Client> client = clientDAO.getClient(clientRequest.name);
+    Optional<Client> client = clientDAO.getClientByName(clientRequest.name);
     if (client.isPresent()) {
       logger.info("Automation ({}) - Client {} already exists", automationClient.getName(),
           clientRequest.name);

--- a/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/AutomationClientResource.java
@@ -177,7 +177,7 @@ public class AutomationClientResource {
       throw new ConflictException("Client name already exists.");
     }
 
-    long id = clientDAO.createClient(clientRequest.name, automationClient.getName(), "", "");
+    long id = clientDAO.createClient(clientRequest.name, automationClient.getName(), "", null);
     client = clientDAO.getClientById(id);
 
     if (client.isPresent()) {

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/ClientResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/ClientResource.java
@@ -93,7 +93,7 @@ public class ClientResource {
     String creator = automationClient.getName();
     String client = request.name();
 
-    clientDAOReadWrite.getClient(client).ifPresent((c) -> {
+    clientDAOReadWrite.getClientByName(client).ifPresent((c) -> {
       logger.info("Automation ({}) - Client {} already exists", creator, client);
       throw new ConflictException("Client name already exists.");
     });
@@ -143,7 +143,7 @@ public class ClientResource {
   @Produces(APPLICATION_JSON)
   public ClientDetailResponseV2 clientInfo(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
-    Client client = clientDAOReadOnly.getClient(name)
+    Client client = clientDAOReadOnly.getClientByName(name)
         .orElseThrow(NotFoundException::new);
 
     return ClientDetailResponseV2.fromClient(client);
@@ -165,7 +165,7 @@ public class ClientResource {
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientGroupsListing(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
-    Client client = clientDAOReadOnly.getClient(name)
+    Client client = clientDAOReadOnly.getClientByName(name)
         .orElseThrow(NotFoundException::new);
     return aclDAOReadOnly.getGroupsFor(client).stream()
         .map(Group::getName)
@@ -189,7 +189,7 @@ public class ClientResource {
   @Produces(APPLICATION_JSON)
   public Iterable<String> modifyClientGroups(@Auth AutomationClient automationClient,
       @PathParam("name") String name, @Valid ModifyGroupsRequestV2 request) {
-    Client client = clientDAOReadWrite.getClient(name)
+    Client client = clientDAOReadWrite.getClientByName(name)
         .orElseThrow(NotFoundException::new);
     String user = automationClient.getName();
 
@@ -234,7 +234,7 @@ public class ClientResource {
   @Produces(APPLICATION_JSON)
   public Iterable<String> clientSecretsListing(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
-    Client client = clientDAOReadOnly.getClient(name)
+    Client client = clientDAOReadOnly.getClientByName(name)
         .orElseThrow(NotFoundException::new);
     return aclDAOReadOnly.getSanitizedSecretsFor(client).stream()
         .map(SanitizedSecret::name)
@@ -256,7 +256,7 @@ public class ClientResource {
   @Path("{name}")
   public Response deleteClient(@Auth AutomationClient automationClient,
       @PathParam("name") String name) {
-    Client client = clientDAOReadWrite.getClient(name)
+    Client client = clientDAOReadWrite.getClientByName(name)
         .orElseThrow(NotFoundException::new);
 
     // Group memberships are deleted automatically by DB cascading.
@@ -285,7 +285,7 @@ public class ClientResource {
   @Produces(APPLICATION_JSON)
   public ClientDetailResponseV2 modifyClient(@Auth AutomationClient automationClient,
       @PathParam("name") String currentName, @Valid ModifyClientRequestV2 request) {
-    Client client = clientDAOReadWrite.getClient(currentName)
+    Client client = clientDAOReadWrite.getClientByName(currentName)
         .orElseThrow(NotFoundException::new);
     String newName = request.name();
 

--- a/server/src/main/resources/db/mysql/migration/V12__make_spiffe_id_unique.sql
+++ b/server/src/main/resources/db/mysql/migration/V12__make_spiffe_id_unique.sql
@@ -1,0 +1,8 @@
+# Keywhiz does not currently support an entity acting on behalf of other clients without being
+# a full-fledged automation client. This would be the primary use case for sharing SPIFFE IDs
+# between clients. Since this would be a significant change to Keywhiz' security model,
+# require SPIFFE IDs to be unique for now.
+# SPIFFE IDs, like all URIs, are ASCII because RFC 3986 permits only ASCII characters.
+# Using the ASCII character set allows indexing on this value (utf8-mb4 is too large).
+ALTER TABLE clients MODIFY spiffe_id varchar(2048) character set ascii default null;
+CREATE UNIQUE INDEX spiffe_id_unique on clients (`spiffe_id`);

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -398,7 +398,7 @@ public class AclDAOTest {
         .where(CLIENTS.ID.eq(client2.getId()))
         .execute();
 
-    Client maliciousClient = clientDAO.getClient(client2.getName()).orElseThrow();
+    Client maliciousClient = clientDAO.getClientByName(client2.getName()).orElseThrow();
 
     String errorMessage = String.format(
         "Client HMAC verification failed for client: %s", client2.getName());

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -70,10 +70,10 @@ public class AclDAOTest {
     groupDAO = groupDAOFactory.readwrite();
     aclDAO = aclDAOFactory.readwrite();
 
-    long id = clientDAO.createClient("client1", "creator", "", "");
+    long id = clientDAO.createClient("client1", "creator", "", null);
     client1 = clientDAO.getClientById(id).get();
 
-    id = clientDAO.createClient("client2", "creator", "", "");
+    id = clientDAO.createClient("client2", "creator", "", null);
     client2 = clientDAO.getClientById(id).get();
 
     id = groupDAO.createGroup("group1", "creator", "", ImmutableMap.of());

--- a/server/src/test/java/keywhiz/service/daos/ClientDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/ClientDAOTest.java
@@ -45,7 +45,7 @@ public class ClientDAOTest {
   Client client1, client2;
   ClientDAO clientDAO;
 
-  @Before public void setUp() throws Exception {
+  @Before public void setUp() {
 
     clientDAO = clientDAOFactory.readwrite();
     long now = OffsetDateTime.now().toEpochSecond();
@@ -74,10 +74,16 @@ public class ClientDAOTest {
   }
 
   @Test public void createClientReturnsId() {
-    long id = clientDAO.createClient("newClientWithSameId", "creator2", "", "");
+    long id = clientDAO.createClient("newClientWithSameId", "creator2", "", null);
     Client clientById = clientDAO.getClient("newClientWithSameId")
         .orElseThrow(RuntimeException::new);
     assertThat(clientById.getId()).isEqualTo(id);
+  }
+
+  @Test public void createClientDropsEmptyStringSpiffeId() {
+    clientDAO.createClient("firstWithoutSpiffe", "creator2", "", "");
+    // This creation should not fail, because an empty SPIFFE ID should be converted to null
+    clientDAO.createClient("secondWithoutSpiffe", "creator2", "", "");
   }
 
   @Test public void deleteClient() {

--- a/server/src/test/java/keywhiz/service/daos/ClientDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/ClientDAOTest.java
@@ -56,15 +56,15 @@ public class ClientDAOTest {
         .values("client2", "desc2", "creator", "updater", false, now, now)
         .execute();
 
-    client1 = clientDAO.getClient("client1").get();
-    client2 = clientDAO.getClient("client2").get();
+    client1 = clientDAO.getClientByName("client1").get();
+    client2 = clientDAO.getClientByName("client2").get();
   }
 
   @Test public void createClient() {
     int before = tableSize();
     clientDAO.createClient("newClient", "creator", "",
         "spiffe://test.env.com/newClient");
-    Client newClient = clientDAO.getClient("newClient").orElseThrow(RuntimeException::new);
+    Client newClient = clientDAO.getClientByName("newClient").orElseThrow(RuntimeException::new);
 
     assertThat(tableSize()).isEqualTo(before + 1);
     assertThat(clientDAO.getClients()).containsOnly(client1, client2, newClient);
@@ -75,9 +75,9 @@ public class ClientDAOTest {
 
   @Test public void createClientReturnsId() {
     long id = clientDAO.createClient("newClientWithSameId", "creator2", "", null);
-    Client clientById = clientDAO.getClient("newClientWithSameId")
+    Client clientByName = clientDAO.getClientByName("newClientWithSameId")
         .orElseThrow(RuntimeException::new);
-    assertThat(clientById.getId()).isEqualTo(id);
+    assertThat(clientByName.getId()).isEqualTo(id);
   }
 
   @Test public void createClientDropsEmptyStringSpiffeId() {
@@ -94,11 +94,11 @@ public class ClientDAOTest {
   }
 
   @Test public void getClientByName() {
-    assertThat(clientDAO.getClient("client1")).contains(client1);
+    assertThat(clientDAO.getClientByName("client1")).contains(client1);
   }
 
   @Test public void getNonExistentClientByName() {
-    assertThat(clientDAO.getClient("non-existent")).isEmpty();
+    assertThat(clientDAO.getClientByName("non-existent")).isEmpty();
   }
 
   @Test public void getClientById() {
@@ -131,8 +131,8 @@ public class ClientDAOTest {
     clientDAO.sawClient(client1, principal);
 
     // reload clients from db, as sawClient doesn't update in-memory object
-    Client client1v2 = clientDAO.getClient(client1.getName()).get();
-    Client client2v2 = clientDAO.getClient(client2.getName()).get();
+    Client client1v2 = clientDAO.getClientByName(client1.getName()).get();
+    Client client2v2 = clientDAO.getClientByName(client2.getName()).get();
 
     // verify client1 from db has updated lastSeen, and client2 hasn't changed
     assertThat(client1v2.getLastSeen()).isNotNull();

--- a/server/src/test/java/keywhiz/service/providers/AutomationClientAuthFactoryTest.java
+++ b/server/src/test/java/keywhiz/service/providers/AutomationClientAuthFactoryTest.java
@@ -54,7 +54,7 @@ public class AutomationClientAuthFactoryTest {
     factory = new AutomationClientAuthFactory(clientDAO);
 
     when(request.getSecurityContext()).thenReturn(securityContext);
-    when(clientDAO.getClient("principal")).thenReturn(Optional.of(client));
+    when(clientDAO.getClientByName("principal")).thenReturn(Optional.of(client));
   }
 
   @Test public void automationClientWhenClientPresent() {
@@ -72,7 +72,7 @@ public class AutomationClientAuthFactoryTest {
 
     when(securityContext.getUserPrincipal()).thenReturn(
         SimplePrincipal.of("CN=clientWithoutAutomation"));
-    when(clientDAO.getClient("clientWithoutAutomation"))
+    when(clientDAO.getClientByName("clientWithoutAutomation"))
         .thenReturn(Optional.of(clientWithoutAutomation));
 
     factory.provide(request);
@@ -82,7 +82,7 @@ public class AutomationClientAuthFactoryTest {
   public void automationClientRejectsClientsWithoutDBEntries() {
     when(securityContext.getUserPrincipal()).thenReturn(
         SimplePrincipal.of("CN=clientWithoutDBEntry"));
-    when(clientDAO.getClient("clientWithoutDBEntry")).thenReturn(Optional.empty());
+    when(clientDAO.getClientByName("clientWithoutDBEntry")).thenReturn(Optional.empty());
 
     factory.provide(request);
   }

--- a/server/src/test/java/keywhiz/service/providers/ClientAuthenticatorTest.java
+++ b/server/src/test/java/keywhiz/service/providers/ClientAuthenticatorTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keywhiz.service.providers;
+
+import java.io.ByteArrayInputStream;
+import java.security.Principal;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Optional;
+import javax.ws.rs.NotAuthorizedException;
+import keywhiz.api.ApiDate;
+import keywhiz.api.model.Client;
+import keywhiz.auth.mutualssl.CertificatePrincipal;
+import keywhiz.auth.mutualssl.SimplePrincipal;
+import keywhiz.service.config.ClientAuthConfig;
+import keywhiz.service.config.ClientAuthTypeConfig;
+import keywhiz.service.daos.ClientDAO;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class ClientAuthenticatorTest {
+  @Rule public MockitoRule mockito = MockitoJUnit.rule();
+
+  private static final String clientName = "principal";
+  private static final String clientSpiffe = "spiffe://example.org/principal";
+  private static final Principal simplePrincipal =
+      SimplePrincipal.of(format("CN=%s,OU=organizational-unit", clientName));
+  private static final Client client =
+      new Client(0, clientName, null, clientSpiffe, null, null, null, null,
+          null, null, true, false);
+
+  private static Principal certPrincipal;
+
+  // certstrap init --common-name "KeywhizAuth"
+  // certstrap request-cert --common-name principal --ou organizational-unit
+  //     --uri spiffe://example.org/principal
+  // certstrap sign principal --CA KeywhizAuth
+  private static final String clientPem =
+      "-----BEGIN CERTIFICATE-----\n\n"
+          + "MIIEcTCCAlmgAwIBAgIRALryCWgCxplmVoNtywrAfR0wDQYJKoZIhvcNAQELBQAw\n"
+          + "FjEUMBIGA1UEAxMLS2V5d2hpekF1dGgwHhcNMjAwNjE2MDAzODI0WhcNMjExMjE2\n"
+          + "MDAzNzAwWjAyMRwwGgYDVQQLExNvcmdhbml6YXRpb25hbC11bml0MRIwEAYDVQQD\n"
+          + "EwlwcmluY2lwYWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDz9ex2\n"
+          + "HQ7YA9nyOigFjeOqSpkDVReSG2IWSDHnugkO3TVY7NqfgMx1I+KESAj5w/PXIv1I\n"
+          + "Aa4qUnLYQ2IqgYUYvJqTt6DtlFLC6dWdgV0x/zRIbtybPR9Ww0eObShzy4od97w4\n"
+          + "zMN1/xXwpIrTNhn9wwzi4l7vtOYwxtoss/B6MBKyxB8R6iEUupINcFANFzcKdniG\n"
+          + "40HcEW8aUS6aRC8bCc4e6ACJp3VR5wnHpHXUlnkeOyTX5yWD8MKni9eY2t0Ra5OX\n"
+          + "tV1NEwOPJz8fTp8aRnoe8+Rq8Lm7W59PO7cJ45srlQ5kKnagha6KB8TTzvNOtYqj\n"
+          + "SgQNkb/OhS8R7Z/9AgMBAAGjgZ0wgZowDgYDVR0PAQH/BAQDAgO4MB0GA1UdJQQW\n"
+          + "MBQGCCsGAQUFBwMBBggrBgEFBQcDAjAdBgNVHQ4EFgQUj35sbmMzi/R/rrdMJHnj\n"
+          + "n1TLhMwwHwYDVR0jBBgwFoAUUtVdMwHcbWdRZ/VypTBlpCbxgDIwKQYDVR0RBCIw\n"
+          + "IIYec3BpZmZlOi8vZXhhbXBsZS5vcmcvcHJpbmNpcGFsMA0GCSqGSIb3DQEBCwUA\n"
+          + "A4ICAQCXPUPcv9ADJACy5D4Z8bQlGyDj131+vthj95eyO8ftPzTrJANGwpl93oO1\n"
+          + "d7lNh1h2exj/e+gtxdYE/I+DYyvHb2Op+SRNN/ZeZntaoqt22p8CGYIpsPQHttLw\n"
+          + "KJ91ekZhyQhphzgceMrhcnSc/RH7L373ZkFi5FC9EAixKsaDftz+NVTk7vhc+cLV\n"
+          + "Mhkhc3L3dA/Ffqpq6iRVs9eefFlN5Oot3PIihvCrbtl0tur02PjLVWQr5Y/nyVG0\n"
+          + "kN0LU7+w3GNddqB0gsLkwBPZ+UtmbyjHaVQN50jZxA7ysr+EjNhTyZ3lliPX4bGE\n"
+          + "TS/jTexOAObS3tC+e157k2UXbFMNZrE/pQb3juOJHcBgwpZ8FnYlwqe8VIJ6513K\n"
+          + "sOTS2lqAXYCaCOC0X6grRuL+s2JTzhzfgz2xuOSQVtvGYK5FijQVpGBR5BlfgpMM\n"
+          + "/W45PGdkvZGI4281VZUfTSSYK/OstnBAD3BgZXhnQg28dj8BD4jNd5JP7cKHb+ID\n"
+          + "33dh8mAGmSmiSPbxkVwq1AKwa5y6hbfvPIQGaUKveQe0JLTFlU4KmYIRv/nl8N83\n"
+          + "st5hq3sW1qoqXZZ71A/T/BYPODcKgeEBzJ64l7jHtPN91SE8U8vhcrpEWZb/D/PI\n"
+          + "vZTiHaxVIvRRokUPFie1drkj5I7Q7qXqHOCy22rgccR64wkNVg==\n"
+          + "-----END CERTIFICATE-----";
+
+  // certstrap init --common-name "KeywhizAuth"
+  // certstrap request-cert --common-name other-principal --ou organizational-unit
+  //     --uri spiffe://example.org/principal,spiffe://example.org/other-principal
+  // certstrap sign other-principal --CA KeywhizAuth
+  private static String multipleSpiffePem = "-----BEGIN CERTIFICATE-----\n"
+      + "MIIEnTCCAoWgAwIBAgIRAJ3eemLVkvReTvZJqcBWWBswDQYJKoZIhvcNAQELBQAw\n"
+      + "FjEUMBIGA1UEAxMLS2V5d2hpekF1dGgwHhcNMjAwNjI1MjIxMTQ5WhcNMjExMjE2\n"
+      + "MDAzNzAwWjA4MRwwGgYDVQQLExNvcmdhbml6YXRpb25hbC11bml0MRgwFgYDVQQD\n"
+      + "Ew9vdGhlci1wcmluY2lwYWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\n"
+      + "AQC5ImUMp17F38Wyyph/rUIL4qJE86pZLIrv2lyZd8qzHXxw1o9TawBu3fNtFx0Y\n"
+      + "+96lAb7A50uNMfuzibb2U+w2mDEikFGtchrzDHC6jNPCq7eXL06adcnIEyK2w0Mq\n"
+      + "qvlzuHGJxLNSRsmiuV4SQS3K96t4vCHF30WrboQKD8xsdeqdT2cspkr3WD3nHJih\n"
+      + "ZMg1YdekoV7+qogXrPawnJ7kKK37hBFAF3OnHsxJMS5UMWR6SHYpYU+V8yifp24H\n"
+      + "erJpL9lwJ2BXpMKHsewCLC+VclQVxArCcbmQsXmZhzKTikff/ZngiSfnSnDm9LQL\n"
+      + "vG+HCzr36xwCEmlWnusbcTozAgMBAAGjgcMwgcAwDgYDVR0PAQH/BAQDAgO4MB0G\n"
+      + "A1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAdBgNVHQ4EFgQUpGY0z/FVU+y/\n"
+      + "ZlAFIdnoHzj25JEwHwYDVR0jBBgwFoAUUtVdMwHcbWdRZ/VypTBlpCbxgDIwTwYD\n"
+      + "VR0RBEgwRoYec3BpZmZlOi8vZXhhbXBsZS5vcmcvcHJpbmNpcGFshiRzcGlmZmU6\n"
+      + "Ly9leGFtcGxlLm9yZy9vdGhlci1wcmluY2lwYWwwDQYJKoZIhvcNAQELBQADggIB\n"
+      + "AFjQdKh/mETvX82ltdxzsCmu+2WQXkw0Q7L2toseAxrAEdH/3teHfFlm/E4ozv3d\n"
+      + "D46DR6SnWY5qsPqlucMQlxGnLQd291JEFeRd2pr5avV7F4K85UhslyM27DrihTpT\n"
+      + "Lex5muGECm9oaJz02QanHOiJU9I5i3ggnJQnfiu9cSlbi/puLb9WR/2Q+kldMQ5A\n"
+      + "m3WaP1eKGug022n/bM+OFGgaoAJHH7l2MBfwAvIltgJZLHsRLAP16G3OotmDt2Eh\n"
+      + "/A3WJt0EbD3PIPkUdt643qdfQGHgw+3ATGARVPypSYG9iOeo9oGUily4irGk5Iss\n"
+      + "wgU10lViC6BHcLs3YY+D8oB7Ik0p2l9JZmJmBuArRMqztSnRiVKIteHUMN0cAfrP\n"
+      + "3VrKlKjJn9amdWk0feiUwb7uWO2CunQewM26MGzM0RntdxyQZ8lsqq5e8zTsHDol\n"
+      + "CrD7eyfBv+98TURnNcLDAXMqd3amAhgmedUDVTrNootKuS6fyg+AmmRjcKOZ4t4g\n"
+      + "16cNALu0koCWdETGGsaeu/NX7RA/ztNme+i6ZCIFaS1Fp2ucTfWyWRMkQ9+DM3vC\n"
+      + "jNPreGsiWrjoReHqRxO+dtOuQf5gSGDTKMTvlESD6xilmmE5n58MCl1bSamEY7rv\n"
+      + "Lz9DeXBJLBSOaXNO+/wdJY/Ix8ADwQYc+jLhdyVOKW7k\n"
+      + "-----END CERTIFICATE-----";
+
+  @Mock ClientAuthTypeConfig clientAuthTypeConfig;
+  @Mock ClientAuthConfig clientAuthConfig;
+
+  @Mock ClientDAO clientDAO;
+
+  ClientAuthenticator authenticator;
+
+  @Before public void setUp() throws Exception {
+    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    X509Certificate clientCert = (X509Certificate) cf.generateCertificate(
+        new ByteArrayInputStream(clientPem.getBytes(UTF_8)));
+    certPrincipal = new CertificatePrincipal(clientCert.getSubjectDN().toString(),
+        new X509Certificate[] {clientCert});
+
+    authenticator = new ClientAuthenticator(clientDAO, clientDAO, clientAuthConfig);
+
+    when(clientDAO.getClientByName(clientName)).thenReturn(Optional.of(client));
+    when(clientDAO.getClientBySpiffeId(clientSpiffe)).thenReturn(Optional.of(client));
+
+    when(clientAuthConfig.typeConfig()).thenReturn(clientAuthTypeConfig);
+
+    when(clientAuthTypeConfig.useCommonName()).thenReturn(true);
+    when(clientAuthTypeConfig.useSpiffeId()).thenReturn(true);
+  }
+
+  @Test public void returnsClientWhenClientPresent_simplePrincipal() {
+    assertThat(authenticator.authenticate(simplePrincipal, true)).isEqualTo(Optional.of(client));
+  }
+
+  @Test public void retrievesClientIfPresent_certPrincipal() {
+    assertThat(authenticator.authenticate(certPrincipal, false)).isEqualTo(Optional.of(client));
+  }
+
+  @Test public void rejectsDisabledClients() {
+    Client disabledClient =
+        new Client(1, "disabled", null, null, null, null, null, null, null, null,
+            false, false
+            /* disabled */);
+    when(clientDAO.getClientByName("disabled")).thenReturn(Optional.of(disabledClient));
+
+    assertThat(authenticator.authenticate(SimplePrincipal.of("CN=disabled"), true)).isEmpty();
+  }
+
+  @Test public void createsDbRecordForNewClient_whenConfigured() {
+    ApiDate now = ApiDate.now();
+    Client newClient =
+        new Client(2345L, "new-client", "desc", null, now, "automatic", now, "automatic",
+            null, null, true, false
+        );
+
+    // lookup doesn't find client
+    when(clientDAO.getClientByName("new-client")).thenReturn(Optional.empty());
+
+    // a new DB record is created
+    when(clientDAO.createClient(eq("new-client"), eq("automatic"), any(), any())).thenReturn(2345L);
+    when(clientDAO.getClientById(2345L)).thenReturn(Optional.of(newClient));
+
+    assertThat(authenticator.authenticate(SimplePrincipal.of("CN=new-client"), true)).isEqualTo(
+        Optional.of(newClient));
+  }
+
+  @Test public void doesNotCreateDbRecordForNewClient_whenNotConfigured() {
+    ApiDate now = ApiDate.now();
+    Client newClient =
+        new Client(2345L, "new-client", "desc", null, now, "automatic", now, "automatic",
+            null, null, true, false
+        );
+
+    // lookup doesn't find client
+    when(clientDAO.getClientByName("new-client")).thenReturn(Optional.empty());
+
+    // a new DB record should not be created, but mock the DAO to create a client if called
+    when(clientDAO.createClient(eq("new-client"), eq("automatic"), any(), any())).thenReturn(2345L);
+    when(clientDAO.getClientById(2345L)).thenReturn(Optional.of(newClient));
+
+    assertThat(authenticator.authenticate(SimplePrincipal.of("CN=new-client"), false)).isEmpty();
+
+    // the authenticator should not have tried to create the new client
+    verify(clientDAO, never()).createClient(anyString(), anyString(), anyString(), any());
+  }
+
+  @Test public void updatesClientLastSeen() {
+    assertThat(authenticator.authenticate(simplePrincipal, true)).isPresent();
+    verify(clientDAO, times(1)).sawClient(any(), eq(simplePrincipal));
+  }
+
+  @Test(expected = NotAuthorizedException.class)
+  public void rejectsCertMatchingMultipleClients() {
+    ApiDate now = ApiDate.now();
+    Client otherClient =
+        new Client(2345L, "other-client", "desc", null, now, "automatic", now, "automatic",
+            null, null, true, false
+        );
+
+    when(clientDAO.getClientByName(clientName)).thenReturn(Optional.of(client));
+    when(clientDAO.getClientBySpiffeId(clientSpiffe)).thenReturn(Optional.of(otherClient));
+
+    authenticator.authenticate(certPrincipal, true);
+  }
+
+  @Test
+  public void respectsClientAuthConfig() {
+    ApiDate now = ApiDate.now();
+    Client otherClient =
+        new Client(2345L, "other-client", "desc", null, now, "automatic", now, "automatic",
+            null, null, true, false
+        );
+
+    when(clientDAO.getClientByName(clientName)).thenReturn(Optional.of(client));
+    when(clientDAO.getClientBySpiffeId(clientSpiffe)).thenReturn(
+        Optional.of(otherClient));
+
+    // Retrieve the client using the client name only
+    when(clientAuthTypeConfig.useCommonName()).thenReturn(true);
+    when(clientAuthTypeConfig.useSpiffeId()).thenReturn(false);
+
+    assertThat(authenticator.authenticate(certPrincipal, false)).isEqualTo(Optional.of(client));
+
+    // Retrieve the client using the SPIFFE ID only
+    when(clientAuthTypeConfig.useCommonName()).thenReturn(false);
+    when(clientAuthTypeConfig.useSpiffeId()).thenReturn(true);
+
+    assertThat(authenticator.authenticate(certPrincipal, false)).isEqualTo(
+        Optional.of(otherClient));
+  }
+
+  @Test public void ignoresMultipleSpiffeIds() throws Exception {
+    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    X509Certificate multipleSpiffeClientCert = (X509Certificate) cf.generateCertificate(
+        new ByteArrayInputStream(multipleSpiffePem.getBytes(UTF_8)));
+    Principal multipleSpiffePrincipal =
+        new CertificatePrincipal(multipleSpiffeClientCert.getSubjectDN().toString(),
+            new X509Certificate[] {multipleSpiffeClientCert});
+
+    // Use only the (malformatted) SPIFFE IDs to retrieve a client (which should fail)
+    when(clientAuthTypeConfig.useCommonName()).thenReturn(false);
+    when(clientAuthTypeConfig.useSpiffeId()).thenReturn(true);
+
+    assertThat(authenticator.authenticate(multipleSpiffePrincipal, false)).isEmpty();
+    verifyNoInteractions(clientDAO);
+  }
+}

--- a/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/SecretDeliveryResourceTest.java
@@ -90,7 +90,7 @@ public class SecretDeliveryResourceTest {
   @Test(expected = NotFoundException.class)
   public void returnsNotFoundWhenClientDoesNotExist() throws Exception {
     when(aclDAO.getSanitizedSecretFor(client, secret.getName())).thenReturn(Optional.empty());
-    when(clientDAO.getClient(client.getName())).thenReturn(Optional.empty());
+    when(clientDAO.getClientByName(client.getName())).thenReturn(Optional.empty());
     when(secretController.getSecretByName(secret.getName()))
         .thenReturn(Optional.of(secret));
 
@@ -100,7 +100,7 @@ public class SecretDeliveryResourceTest {
   @Test(expected = NotFoundException.class)
   public void returnsNotFoundWhenSecretDoesNotExist() throws Exception {
     when(aclDAO.getSanitizedSecretFor(client, "secret_name")).thenReturn(Optional.empty());
-    when(clientDAO.getClient(client.getName())).thenReturn(Optional.of(client));
+    when(clientDAO.getClientByName(client.getName())).thenReturn(Optional.of(client));
     when(secretController.getSecretByName("secret_name"))
         .thenReturn(Optional.empty());
 
@@ -110,7 +110,7 @@ public class SecretDeliveryResourceTest {
   @Test(expected = ForbiddenException.class)
   public void returnsUnauthorizedWhenDenied() throws Exception {
     when(aclDAO.getSanitizedSecretFor(client, secret.getName())).thenReturn(Optional.empty());
-    when(clientDAO.getClient(client.getName())).thenReturn(Optional.of(client));
+    when(clientDAO.getClientByName(client.getName())).thenReturn(Optional.of(client));
     when(secretController.getSecretByName(secret.getName()))
         .thenReturn(Optional.of(secret));
 

--- a/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
@@ -140,7 +140,7 @@ public class ClientsResourceTest {
   }
 
   @Test public void findClientByName() {
-    when(clientDAO.getClient(client.getName())).thenReturn(Optional.of(client));
+    when(clientDAO.getClientByName(client.getName())).thenReturn(Optional.of(client));
     assertThat(resource.getClientByName(user, "client")).isEqualTo(client);
   }
 
@@ -152,7 +152,7 @@ public class ClientsResourceTest {
 
   @Test(expected = NotFoundException.class)
   public void notFoundWhenRetrievingBadName() {
-    when(clientDAO.getClient("non-existent-client")).thenReturn(Optional.empty());
+    when(clientDAO.getClientByName("non-existent-client")).thenReturn(Optional.empty());
     resource.getClientByName(user, "non-existent-client");
   }
 

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationClientResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationClientResourceTest.java
@@ -90,7 +90,7 @@ public class AutomationClientResourceTest {
     CreateClientRequest request = new CreateClientRequest("client");
 
     when(clientDAO.getClient("client")).thenReturn(Optional.empty());
-    when(clientDAO.createClient("client", automation.getName(), "", "")).thenReturn(543L);
+    when(clientDAO.createClient("client", automation.getName(), "", null)).thenReturn(543L);
     when(clientDAO.getClientById(543L)).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(client)).thenReturn(ImmutableSet.of());
 
@@ -108,7 +108,7 @@ public class AutomationClientResourceTest {
     CreateClientRequest request = new CreateClientRequest("client");
 
     when(clientDAO.getClient("client")).thenReturn(Optional.empty());
-    when(clientDAO.createClient("client", automation.getName(), "", "")).thenReturn(543L);
+    when(clientDAO.createClient("client", automation.getName(), "", null)).thenReturn(543L);
     when(clientDAO.getClientById(543L)).thenReturn(Optional.of(client));
 
     ClientDetailResponse response = ClientDetailResponse.fromClient(client, ImmutableList.of(),

--- a/server/src/test/java/keywhiz/service/resources/automation/AutomationClientResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/automation/AutomationClientResourceTest.java
@@ -68,7 +68,7 @@ public class AutomationClientResourceTest {
     ClientDetailResponse expectedClient = ClientDetailResponse.fromClient(client,
         ImmutableList.of(firstGroup, secondGroup), ImmutableList.of());
 
-    when(clientDAO.getClient("client")).thenReturn(Optional.of(client));
+    when(clientDAO.getClientByName("client")).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(client)).thenReturn(ImmutableSet.of(firstGroup, secondGroup));
 
     Response response = resource.findClient(automation, Optional.of("client"));
@@ -79,7 +79,7 @@ public class AutomationClientResourceTest {
 
   @Test(expected = NotFoundException.class)
   public void findClientByNameNotFound() {
-    when(clientDAO.getClient("client")).thenReturn(Optional.empty());
+    when(clientDAO.getClientByName("client")).thenReturn(Optional.empty());
     resource.findClient(automation, Optional.of("client"));
   }
 
@@ -89,7 +89,7 @@ public class AutomationClientResourceTest {
 
     CreateClientRequest request = new CreateClientRequest("client");
 
-    when(clientDAO.getClient("client")).thenReturn(Optional.empty());
+    when(clientDAO.getClientByName("client")).thenReturn(Optional.empty());
     when(clientDAO.createClient("client", automation.getName(), "", null)).thenReturn(543L);
     when(clientDAO.getClientById(543L)).thenReturn(Optional.of(client));
     when(aclDAO.getGroupsFor(client)).thenReturn(ImmutableSet.of());
@@ -107,7 +107,7 @@ public class AutomationClientResourceTest {
 
     CreateClientRequest request = new CreateClientRequest("client");
 
-    when(clientDAO.getClient("client")).thenReturn(Optional.empty());
+    when(clientDAO.getClientByName("client")).thenReturn(Optional.empty());
     when(clientDAO.createClient("client", automation.getName(), "", null)).thenReturn(543L);
     when(clientDAO.getClientById(543L)).thenReturn(Optional.of(client));
 


### PR DESCRIPTION
This adds the constraint that SPIFFE IDs are unique per-client, since supporting non-unique SPIFFE IDs requires a significant redesign of Keywhiz' trust model. It also refactors client authorization to separate extracting information about the client from a request (either from the security context or the XFCC header) and retrieving a client based on that information into separate classes.

Note that none of these changes affect automation clients. A later PR will update the automation client factory to share code with the client creation factory, since the logic is almost entirely identical.