### PR TITLE
Share lookup code for regular and automation clients

### DIFF
--- a/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
@@ -17,14 +17,13 @@
 package keywhiz.service.providers;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.security.Principal;
 import java.util.Optional;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.ForbiddenException;
-import javax.ws.rs.NotAuthorizedException;
+import keywhiz.KeywhizConfig;
 import keywhiz.api.model.AutomationClient;
 import keywhiz.api.model.Client;
+import keywhiz.service.config.ClientAuthConfig;
 import keywhiz.service.daos.ClientDAO;
 import keywhiz.service.daos.ClientDAO.ClientDAOFactory;
 import org.glassfish.jersey.server.ContainerRequest;
@@ -38,42 +37,31 @@ import static java.lang.String.format;
  * Modeled similar to io.dropwizard.auth.AuthFactory, however that is not yet usable. See
  * https://github.com/dropwizard/dropwizard/issues/864.
  */
-public class AutomationClientAuthFactory {
-  private final MyAuthenticator authenticator;
-
-  @Inject public AutomationClientAuthFactory(ClientDAOFactory clientDAOFactory) {
-    this.authenticator =
-        new MyAuthenticator(clientDAOFactory.readwrite(), clientDAOFactory.readonly());
+public class AutomationClientAuthFactory extends ClientAuthFactory {
+  @Inject public AutomationClientAuthFactory(ClientDAOFactory clientDAOFactory,
+      KeywhizConfig keywhizConfig) {
+    super(clientDAOFactory, keywhizConfig);
   }
 
-  @VisibleForTesting AutomationClientAuthFactory(ClientDAO clientDAO) {
-    this.authenticator = new MyAuthenticator(clientDAO, clientDAO);
+  @VisibleForTesting AutomationClientAuthFactory(ClientDAO clientDAO,
+      ClientAuthConfig clientAuthConfig) {
+    super(clientDAO, clientAuthConfig);
   }
 
   public AutomationClient provide(ContainerRequest request) {
-    Principal principal = ClientAuthFactory.getPrincipal(request)
-        .orElseThrow(() -> new NotAuthorizedException("Not authorized as a AutomationClient"));
-    String clientName = ClientAuthenticator.getClientName(principal)
-        .orElseThrow(() -> new NotAuthorizedException("Not authorized as a AutomationClient"));
+    // This will throw a NotAuthorizedException if the client does not exist or cannot
+    // be extracted from the request.
+    Client client = super.provide(request);
 
-    return authenticator.authenticate(clientName, principal)
+    // This method returns null if the provided client is not actually an automation client
+    return Optional.ofNullable(AutomationClient.of(client))
         .orElseThrow(() -> new ForbiddenException(
-            format("ClientCert name %s not authorized as a AutomationClient", clientName)));
+            format("Client %s not authorized as a AutomationClient", client.getName())));
   }
 
-  private static class MyAuthenticator {
-    private final ClientDAO clientDAOReadWrite;
-    private final ClientDAO clientDAOReadOnly;
-
-    private MyAuthenticator(ClientDAO clientDAOReadWrite, ClientDAO clientDAOReadOnly) {
-      this.clientDAOReadWrite = clientDAOReadWrite;
-      this.clientDAOReadOnly = clientDAOReadOnly;
-    }
-
-    public Optional<AutomationClient> authenticate(String name, @Nullable Principal principal) {
-      Optional<Client> client = clientDAOReadOnly.getClientByName(name);
-      client.ifPresent(value -> clientDAOReadWrite.sawClient(value, principal));
-      return client.map(AutomationClient::of);
-    }
+  @Override
+  protected boolean createMissingClient() {
+    // Automation clients should not be automatically created if they are missing
+    return false;
   }
 }

--- a/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
@@ -270,9 +270,18 @@ public class ClientAuthFactory {
     return Optional.of(cert);
   }
 
+  /**
+   * Defined as a function so that subclasses can override this behavior
+   *
+   * @return whether to create a client that can't be found, if the client doesn't exist
+   */
+  protected boolean createMissingClient() {
+    return true;
+  }
+
   private Client authorizeClientFromCertificate(Principal clientPrincipal) {
     Optional<Client> possibleClient =
-        authenticator.authenticate(clientPrincipal, true);
+        authenticator.authenticate(clientPrincipal, createMissingClient());
     return possibleClient.orElseThrow(() -> new NotAuthorizedException(
         format("No authorized Client for connection using principal %s",
             clientPrincipal.getName())));


### PR DESCRIPTION
"Automation" clients, which have significant power to manage
secrets in Keywhiz (due to access to additional APIs), are stored
in the same database table and authenticated in the same way as
normal Keywhiz clients. This means that their authentication code
can share logic with the standard client lookup process, except
for the final stage of attempting to use the retrieved client
as an automation client.

Note that although at this point the ClientAuthFactory and
AutomationClientAuthFactory have significant code differences
(because the ClientAuthFactory supports extracting client
information from the x-forwarded-client-cert header and looking
up clients based on their SPIFFE IDs), these differences are
because of recent changes to the ClientAuthFactory. Before the
ClientAuthFactory was updated, the only differences in behavior
between the two factories were the ForbiddenException thrown by
the AutomationClient factory and the AutomationClient factory not
creating a missing client, both of which are preserved in this commit.