### PR TITLE
Handle SPIFFE IDs as URIs

### DIFF
--- a/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/ClientsResource.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.params.LongParam;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -148,8 +149,8 @@ public class ClientsResource {
     long clientId;
     try {
       clientId = clientDAO.createClient(createClientRequest.name(), user.getName(),
-          createClientRequest.description(), createClientRequest.spiffeId());
-    } catch (DataAccessException e) {
+          createClientRequest.description(), new URI(createClientRequest.spiffeId()));
+    } catch (DataAccessException | URISyntaxException e) {
       logger.warn("Cannot create client {}: {}", createClientRequest.name(), e);
       throw new ConflictException("Conflict creating client.");
     }

--- a/server/src/test/java/keywhiz/service/daos/ClientDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/ClientDAOTest.java
@@ -16,6 +16,7 @@
 
 package keywhiz.service.daos;
 
+import java.net.URI;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Set;
@@ -60,10 +61,10 @@ public class ClientDAOTest {
     client2 = clientDAO.getClientByName("client2").get();
   }
 
-  @Test public void createClient() {
+  @Test public void createClient() throws Exception {
     int before = tableSize();
     clientDAO.createClient("newClient", "creator", "",
-        "spiffe://test.env.com/newClient");
+        new URI("spiffe://test.env.com/newClient"));
     Client newClient = clientDAO.getClientByName("newClient").orElseThrow(RuntimeException::new);
 
     assertThat(tableSize()).isEqualTo(before + 1);
@@ -80,10 +81,10 @@ public class ClientDAOTest {
     assertThat(clientByName.getId()).isEqualTo(id);
   }
 
-  @Test public void createClientDropsEmptyStringSpiffeId() {
-    clientDAO.createClient("firstWithoutSpiffe", "creator2", "", "");
+  @Test public void createClientDropsEmptyStringSpiffeId() throws Exception {
+    clientDAO.createClient("firstWithoutSpiffe", "creator2", "", new URI(""));
     // This creation should not fail, because an empty SPIFFE ID should be converted to null
-    clientDAO.createClient("secondWithoutSpiffe", "creator2", "", "");
+    clientDAO.createClient("secondWithoutSpiffe", "creator2", "", new URI(""));
   }
 
   @Test public void deleteClient() {

--- a/server/src/test/java/keywhiz/service/providers/ClientAuthenticatorTest.java
+++ b/server/src/test/java/keywhiz/service/providers/ClientAuthenticatorTest.java
@@ -17,6 +17,7 @@
 package keywhiz.service.providers;
 
 import java.io.ByteArrayInputStream;
+import java.net.URI;
 import java.security.Principal;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -52,11 +53,13 @@ public class ClientAuthenticatorTest {
   @Rule public MockitoRule mockito = MockitoJUnit.rule();
 
   private static final String clientName = "principal";
-  private static final String clientSpiffe = "spiffe://example.org/principal";
+  private static final String clientSpiffeStr = "spiffe://example.org/principal";
+  private static URI clientSpiffe;
+
   private static final Principal simplePrincipal =
       SimplePrincipal.of(format("CN=%s,OU=organizational-unit", clientName));
   private static final Client client =
-      new Client(0, clientName, null, clientSpiffe, null, null, null, null,
+      new Client(0, clientName, null, clientSpiffeStr, null, null, null, null,
           null, null, true, false);
 
   private static Principal certPrincipal;
@@ -97,7 +100,7 @@ public class ClientAuthenticatorTest {
   // certstrap request-cert --common-name other-principal --ou organizational-unit
   //     --uri spiffe://example.org/principal,spiffe://example.org/other-principal
   // certstrap sign other-principal --CA KeywhizAuth
-  private static String multipleSpiffePem = "-----BEGIN CERTIFICATE-----\n"
+  private static final String multipleSpiffePem = "-----BEGIN CERTIFICATE-----\n"
       + "MIIEnTCCAoWgAwIBAgIRAJ3eemLVkvReTvZJqcBWWBswDQYJKoZIhvcNAQELBQAw\n"
       + "FjEUMBIGA1UEAxMLS2V5d2hpekF1dGgwHhcNMjAwNjI1MjIxMTQ5WhcNMjExMjE2\n"
       + "MDAzNzAwWjA4MRwwGgYDVQQLExNvcmdhbml6YXRpb25hbC11bml0MRgwFgYDVQQD\n"
@@ -133,6 +136,8 @@ public class ClientAuthenticatorTest {
   ClientAuthenticator authenticator;
 
   @Before public void setUp() throws Exception {
+    clientSpiffe = new URI(clientSpiffeStr);
+
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
     X509Certificate clientCert = (X509Certificate) cf.generateCertificate(
         new ByteArrayInputStream(clientPem.getBytes(UTF_8)));

--- a/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
+++ b/server/src/test/java/keywhiz/service/resources/admin/ClientsResourceTest.java
@@ -19,6 +19,7 @@ package keywhiz.service.resources.admin;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.dropwizard.jersey.params.LongParam;
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -69,10 +70,12 @@ public class ClientsResourceTest {
 
   @Test public void listClients() {
     Client client1 =
-        new Client(1, "client", "1st client", null, now, "test", now, "test", null, null, true, false
+        new Client(1, "client", "1st client", null, now, "test", now, "test", null, null, true,
+            false
         );
     Client client2 =
-        new Client(2, "client2", "2nd client", null, now, "test", now, "test", null, null, true, false
+        new Client(2, "client2", "2nd client", null, now, "test", now, "test", null, null, true,
+            false
         );
 
     when(clientDAO.getClients()).thenReturn(ImmutableSet.of(client1, client2));
@@ -81,14 +84,14 @@ public class ClientsResourceTest {
     assertThat(response).containsOnly(client1, client2);
   }
 
-  @Test public void createsClient() {
+  @Test public void createsClient() throws Exception {
     CreateClientRequestV2 request = CreateClientRequestV2.builder()
         .name("new-client-name")
         .description("description")
         .spiffeId("spiffe//example.org/new-client-name")
         .build();
     when(clientDAO.createClient("new-client-name", "user", "description",
-        "spiffe//example.org/new-client-name")).thenReturn(42L);
+        new URI("spiffe//example.org/new-client-name"))).thenReturn(42L);
     when(clientDAO.getClientById(42L)).thenReturn(Optional.of(client));
     when(aclDAO.getSanitizedSecretsFor(client)).thenReturn(ImmutableSet.of());
 


### PR DESCRIPTION
SPIFFE IDs are defined as URIs, which means that some parts of
the ID (notably the truststore) are case-insensitive, but other
parts (notably the path) are case-sensitive. Handle them as URIs
to make these comparisons match typical URI behavior by default,
rather than comparing strings.