### PR TITLE
Use HttpServletRequest to check XFCC port

### DIFF
--- a/server/src/main/java/keywhiz/service/providers/AuthResolver.java
+++ b/server/src/main/java/keywhiz/service/providers/AuthResolver.java
@@ -19,6 +19,8 @@ package keywhiz.service.providers;
 import io.dropwizard.auth.Auth;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
 import keywhiz.api.model.AutomationClient;
 import keywhiz.api.model.Client;
 import keywhiz.auth.User;
@@ -74,16 +76,22 @@ public class AuthResolver {
 
       if (classType.equals(Client.class)) {
         return new AbstractContainerRequestValueFactory<Client>() {
+          @Context
+          private HttpServletRequest httpRequest;
+
           @Override public Client provide() {
-            return clientAuthFactory.provide(getContainerRequest());
+            return clientAuthFactory.provide(getContainerRequest(), httpRequest);
           }
         };
       }
 
       if (classType.equals(AutomationClient.class)) {
         return new AbstractContainerRequestValueFactory<AutomationClient>() {
+          @Context
+          private HttpServletRequest httpRequest;
+
           @Override public AutomationClient provide() {
-            return automationClientAuthFactory.provide(getContainerRequest());
+            return automationClientAuthFactory.provide(getContainerRequest(), httpRequest);
           }
         };
       }

--- a/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/AutomationClientAuthFactory.java
@@ -19,6 +19,7 @@ package keywhiz.service.providers;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.ForbiddenException;
 import keywhiz.KeywhizConfig;
 import keywhiz.api.model.AutomationClient;
@@ -48,10 +49,11 @@ public class AutomationClientAuthFactory extends ClientAuthFactory {
     super(clientDAO, clientAuthConfig);
   }
 
-  public AutomationClient provide(ContainerRequest request) {
+  public AutomationClient provide(ContainerRequest containerRequest,
+      HttpServletRequest httpServletRequest) {
     // This will throw a NotAuthorizedException if the client does not exist or cannot
     // be extracted from the request.
-    Client client = super.provide(request);
+    Client client = super.provide(containerRequest, httpServletRequest);
 
     // This method returns null if the provided client is not actually an automation client
     return Optional.ofNullable(AutomationClient.of(client))


### PR DESCRIPTION
The ContainerRequest constructed by Jersey does not include information
about where the request was received by Keywhiz; the port in its URI
is derived from the port (if any) specified by the original requestor.
The HttpServletRequest, however, identifies which Keywhiz port traffic
came to, which allows us to enforce controls--notably whether certificates
are allowed to be set by the x-forwarded-client-cert header--based on
the port associated with incoming traffic.

There's a merge conflict between this change and https://github.com/square/keywhiz/pull/686, since the AutomationClientAuthFactory creation and use will need to be updated to include the ServletRequest as well. However, the fix will be straightforward (I'll rebase and update whichever PR is merged second to address it).