### PR TITLE
Do not warn for certificates without a common name

### DIFF
--- a/server/src/main/java/keywhiz/service/providers/ClientAuthenticator.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthenticator.java
@@ -123,7 +123,6 @@ public class ClientAuthenticator {
     X500Name name = new X500Name(principal.getName());
     RDN[] rdns = name.getRDNs(BCStyle.CN);
     if (rdns.length == 0) {
-      logger.warn("Certificate does not contain CN=xxx,...: {}", principal.getName());
       return Optional.empty();
     }
     return Optional.of(IETFUtils.valueToString(rdns[0].getFirst().getValue()));
@@ -151,7 +150,7 @@ public class ClientAuthenticator {
     try {
       sans = cert.getSubjectAlternativeNames();
     } catch (CertificateParsingException e) {
-      logger.warn("Unable to parse SANs from principal", e);
+      logger.warn("Error parsing SANs from principal", e);
       return Optional.empty();
     }
 
@@ -179,7 +178,7 @@ public class ClientAuthenticator {
         return Optional.of(new URI(possibleName.get()));
       } catch (URISyntaxException e) {
         logger.warn(
-            format("Unable to parse SPIFFE URI (%s) from certificate as a URI", possibleName.get()),
+            format("Error parsing SPIFFE URI (%s) from certificate as a URI", possibleName.get()),
             e);
       }
     }


### PR DESCRIPTION
SPIFFE IDs as X509 certificates are not required to provide a
common name, only a URI corresponding to a SPIFFE ID in the SANs.
This means that Keywhiz should not log a warning when the common
name cannot be found, since the CN is no longer expected to always
be present.

This also slightly adjusts the wording on a few other error messages
to clarify that they are thrown when an exception occurs, not just
when a field is not set.