### PR TITLE
Fix handling of SPIFFE SVIDs with multiple URIs, other adjustments

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/ClientDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/ClientDAO.java
@@ -113,7 +113,6 @@ public class ClientDAO {
 
     final Instant expiration;
     if (principal instanceof CertificatePrincipal) {
-      // instanceof returns false for a null principal
       expiration = ((CertificatePrincipal) principal).getCertificateExpiration();
     } else {
       expiration = EPOCH;

--- a/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
@@ -107,7 +107,7 @@ public class ClientAuthFactory {
     // on the security context of this request
     if (possibleXfccConfig.isEmpty()) {
       // The XFCC header is not used; use the security context of this request to identify the client
-      return authorizeClientFromCertificate(requestPrincipal);
+      return authenticateClientFromCertificate(requestPrincipal);
     } else {
       return authorizeClientFromXfccHeader(possibleXfccConfig.get(), xfccHeaderValues,
           requestPrincipal);
@@ -151,7 +151,7 @@ public class ClientAuthFactory {
         new CertificatePrincipal(clientCert.getSubjectDN().toString(),
             new X509Certificate[] {clientCert});
 
-    return authorizeClientFromCertificate(certificatePrincipal);
+    return authenticateClientFromCertificate(certificatePrincipal);
   }
 
   private void validateXfccHeaderAllowed(XfccSourceConfig xfccConfig, Principal requestPrincipal) {
@@ -296,7 +296,7 @@ public class ClientAuthFactory {
     return true;
   }
 
-  private Client authorizeClientFromCertificate(Principal clientPrincipal) {
+  private Client authenticateClientFromCertificate(Principal clientPrincipal) {
     Optional<Client> possibleClient =
         authenticator.authenticate(clientPrincipal, createMissingClient());
     return possibleClient.orElseThrow(() -> new NotAuthorizedException(


### PR DESCRIPTION
Removes an unnecessary comment, renames some variables, and (most
importantly) updates the handling of certificates that look like
SPIFFE SVIDs to reject certificates with a SPIFFE-format URI but
other URIs present as well.