### PR TITLE
WIP upgrading dropwizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <autovalue.version>1.7.3</autovalue.version>
-    <dropwizard.version>1.3.24</dropwizard.version>
+    <dropwizard.version>2.0.11</dropwizard.version>
     <!-- 1.2.0-1 is the last version of dropwizard-raven JAR. The development continues under dropwizard-sentry -->
     <dropwizard-raven.version>1.2.0-1</dropwizard-raven.version>
     <guice.version>4.2.3</guice.version>
@@ -296,7 +296,7 @@
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>5.4.3.Final</version>
+        <version>6.0.13.Final</version>
       </dependency>
       <dependency>
         <groupId>org.jooq</groupId>

--- a/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
@@ -80,8 +80,7 @@ public class ClientAuthFactory {
     this.clientAuthConfig = clientAuthConfig;
   }
 
-  public Client provide(ContainerRequest containerRequest,
-      HttpServletRequest httpServletRequest) {
+  public Client provide(ContainerRequest containerRequest, HttpServletRequest httpServletRequest) {
     // Ports must either always send an x-forwarded-client-cert header, or
     // never send this header. This also throws an error if a single port
     // has multiple configurations.

--- a/server/src/main/java/keywhiz/service/resources/admin/SessionLoginResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SessionLoginResource.java
@@ -87,7 +87,7 @@ public class SessionLoginResource {
       logger.warn("User authenticator threw something weird.", e);
     }
 
-    if (!optionalUser.isPresent()) {
+    if (optionalUser.isEmpty()) {
       logger.info("User authentication failed at login for {}", username);
       throw new NotAuthorizedException("");
     }


### PR DESCRIPTION
Unfortunately, it appears that Jersey's stricter injection
rules (which prevent using @Context for a class registered as an
instance of a class rather than by the class name) are
incompatible with the injections needed by an AbstractValueParamProvider.

The refactor of AuthResolver is based on https://github.com/dropwizard/dropwizard/pull/2395/files and http://hoardingdata.blogspot.com/2019/02/jersey-226-and-injection-changes.html.

The problem with injecting @Context is documented in https://www.dropwizard.io/en/latest/manual/upgrade-notes/upgrade-notes-2_0_x.html#upgrade-notes-dropwizard-2-0-x.

I'm not sure how much longer I'll be able to spend on this in the near future.