### PR TITLE
Customize MySQL port with KEYWHIZ_CUSTOM_MYSQL_PORT environment variable

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -11,10 +13,47 @@
   <artifactId>keywhiz-model</artifactId>
   <name>Keywhiz Model</name>
 
+  <profiles>
+    <profile>
+      <id>
+        no-custom-mysql-port
+      </id>
+      <activation>
+        <property>
+          <name>!env.KEYWHIZ_CUSTOM_MYSQL_PORT</name>
+        </property>
+      </activation>
+      <properties>
+        <db.create-url>
+          jdbc:mysql://(host=localhost,useUnicode=true,characterEncoding=utf8)
+        </db.create-url>
+        <db.migrate-url>
+          jdbc:mysql://(host=localhost,useUnicode=true,characterEncoding=utf8)/keywhizdb_test
+        </db.migrate-url>
+      </properties>
+    </profile>
+    <profile>
+      <id>
+        custom-mysql-port
+      </id>
+      <activation>
+        <property>
+          <name>env.KEYWHIZ_CUSTOM_MYSQL_PORT</name>
+        </property>
+      </activation>
+      <properties>
+        <db.create-url>
+          jdbc:mysql://(host=localhost,port=${env.KEYWHIZ_CUSTOM_MYSQL_PORT},useUnicode=true,characterEncoding=utf8)
+        </db.create-url>
+        <db.migrate-url>
+          jdbc:mysql://(host=localhost,port=${env.KEYWHIZ_CUSTOM_MYSQL_PORT},useUnicode=true,characterEncoding=utf8)/keywhizdb_test
+        </db.migrate-url>
+      </properties>
+    </profile>
+  </profiles>
+
   <properties>
     <db.driver>com.mysql.cj.jdbc.Driver</db.driver>
-    <db.create-url>jdbc:mysql://localhost/?useUnicode=true&amp;characterEncoding=utf8</db.create-url>
-    <db.migrate-url>jdbc:mysql://localhost/keywhizdb_test?useUnicode=true&amp;characterEncoding=utf8</db.migrate-url>
     <db.username>root</db.username>
     <db.migrations-path>mysql/migration</db.migrations-path>
     <db.schema-table>schema_version</db.schema-table>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <jackson.version>2.11.1</jackson.version>
     <jackson.databind.version>2.10.0.pr1</jackson.databind.version>
     <jooq.version>3.13.2</jooq.version>
-    <powermock.version>1.7.4</powermock.version>
+    <powermock.version>2.0.2</powermock.version>
     <slf4j.version>1.7.30</slf4j.version>
     <mysql.version>8.0.21</mysql.version>
     <logback.version>1.2.3</logback.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -163,6 +163,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-easymock</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-testlib</artifactId>
       <scope>test</scope>

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -48,7 +48,7 @@ environment: testing
 
 database:
   driverClass: com.mysql.cj.jdbc.Driver
-  url: jdbc:mysql://localhost/keywhizdb_test?useUnicode=true&characterEncoding=utf8
+  url: jdbc:mysql://address=(host=localhost)(%custom_mysql_port%)(useUnicode=true)(characterEncoding=utf8)/keywhizdb_test
   user: root
   properties:
     charSet: UTF-8
@@ -60,7 +60,7 @@ database:
 
 readonlyDatabase:
   driverClass: com.mysql.cj.jdbc.Driver
-  url: jdbc:mysql://localhost/keywhizdb_test?useUnicode=true&characterEncoding=utf8
+  url: jdbc:mysql://address=(host=localhost)(%custom_mysql_port%)(useUnicode=true)(characterEncoding=utf8)/keywhizdb_test
   user: root
   properties:
     charSet: UTF-8


### PR DESCRIPTION
This updates Keywhiz' model and tests to allow customizing what
port is used for its connection to MySQL by setting the
KEYWHIZ_CUSTOM_MYSQL_PORT environment variable. This is useful
when the default MySQL instance is unsuitable for building and
testing Keywhiz (for instance, if the MySQL server installed
on the default port 3306 runs MySQL 5.6, since Keywhiz now uses
MySQL 5.7).

If the environment variable is not set, Keywhiz will use the
default MySQL port as specified in the "mysql-connector"
documentation (currently 3306, or 33060 for a connection using
the X protocol).

See https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html#connector-j-url-single-host-without-props for the new format for JDBC connections and https://maven.apache.org/guides/introduction/introduction-to-profiles.html for the custom profiles used in keywhiz-model.