### PR TITLE
Configure whether to create clients when missing

### DIFF
--- a/server/src/main/java/keywhiz/service/config/ClientAuthConfig.java
+++ b/server/src/main/java/keywhiz/service/config/ClientAuthConfig.java
@@ -28,13 +28,23 @@ import java.util.List;
 public abstract class ClientAuthConfig {
   @JsonCreator public static ClientAuthConfig of(
       @JsonProperty("xfcc") List<XfccSourceConfig> sourceConfigs,
-      @JsonProperty("type") ClientAuthTypeConfig typeConfig) {
-    return new AutoValue_ClientAuthConfig(sourceConfigs, typeConfig);
+      @JsonProperty("type") ClientAuthTypeConfig typeConfig,
+      @JsonProperty("createMissingClients") boolean createMissingClients) {
+    return new AutoValue_ClientAuthConfig(sourceConfigs, typeConfig, createMissingClients);
   }
 
-  /** connection sources that can set x-forwarded-client-cert headers */
+  /**
+   * connection sources that can set x-forwarded-client-cert headers
+   */
   public abstract List<XfccSourceConfig> xfccConfigs();
 
-  /** what identifier(s) to use for clients */
+  /**
+   * what identifier(s) to use for clients
+   */
   public abstract ClientAuthTypeConfig typeConfig();
+
+  /**
+   * whether to create missing (non-automation) clients when a new certificate is presented
+   */
+  public abstract boolean createMissingClients();
 }

--- a/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
+++ b/server/src/main/java/keywhiz/service/providers/ClientAuthFactory.java
@@ -293,7 +293,7 @@ public class ClientAuthFactory {
    * @return whether to create a client that can't be found, if the client doesn't exist
    */
   protected boolean createMissingClient() {
-    return true;
+    return clientAuthConfig.createMissingClients();
   }
 
   private Client authenticateClientFromCertificate(Principal clientPrincipal) {

--- a/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
+++ b/server/src/test/java/keywhiz/service/providers/ClientAuthFactoryTest.java
@@ -159,6 +159,7 @@ public class ClientAuthFactoryTest {
 
     when(clientAuthConfig.xfccConfigs()).thenReturn(List.of(xfccSourceConfig));
     when(clientAuthConfig.typeConfig()).thenReturn(clientAuthTypeConfig);
+    when(clientAuthConfig.createMissingClients()).thenReturn(false);
 
     when(xfccSourceConfig.port()).thenReturn(xfccAllowedPort);
     when(xfccSourceConfig.allowedClientNames()).thenReturn(List.of(xfccName));

--- a/server/src/test/resources/keywhiz-test.yaml
+++ b/server/src/test/resources/keywhiz-test.yaml
@@ -160,3 +160,4 @@ clientAuthConfig:
   type:
     useCommonName: true
     useSpiffeId: true
+  createMissingClients: true


### PR DESCRIPTION
Keywhiz supports the ability to automatically create clients
(without assigning them to any groups or secrets) when a new
client certificate is presented. This has previously been
automatic, but is now configurable. WARNING: If the configuration
is not specified, it defaults to "false."