### PR TITLE
Allow clients to be created with empty groups

### DIFF
--- a/api/src/main/java/keywhiz/api/automation/v2/CreateClientRequestV2.java
+++ b/api/src/main/java/keywhiz/api/automation/v2/CreateClientRequestV2.java
@@ -51,12 +51,12 @@ import static com.google.common.base.Strings.nullToEmpty;
   @SuppressWarnings("unused")
   @JsonCreator public static CreateClientRequestV2 fromParts(
       @JsonProperty("name") String name,
-      @JsonProperty("groups") Iterable<String> groups,
+      @JsonProperty("groups") @Nullable Iterable<String> groups,
       @JsonProperty("description") @Nullable String description,
       @JsonProperty("spiffeId") @Nullable String spiffeId) {
     return builder()
         .name(name)
-        .groups(ImmutableSet.copyOf(groups))
+        .groups(groups == null ? ImmutableSet.of() : ImmutableSet.copyOf(groups))
         .description(nullToEmpty(description))
         .spiffeId(nullToEmpty(spiffeId))
         .build();

--- a/api/src/main/java/keywhiz/api/automation/v2/CreateGroupRequestV2.java
+++ b/api/src/main/java/keywhiz/api/automation/v2/CreateGroupRequestV2.java
@@ -43,7 +43,7 @@ import static com.google.common.base.Strings.nullToEmpty;
     return builder()
         .name(name)
         .description(nullToEmpty(description))
-        .metadata(ImmutableMap.copyOf(metadata == null ? ImmutableMap.of() : metadata))
+        .metadata(metadata == null ? ImmutableMap.of() : ImmutableMap.copyOf(metadata))
         .build();
   }
 

--- a/api/src/main/java/keywhiz/api/automation/v2/CreateSecretRequestV2.java
+++ b/api/src/main/java/keywhiz/api/automation/v2/CreateSecretRequestV2.java
@@ -79,7 +79,7 @@ import keywhiz.api.validation.ValidBase64;
         .metadata(metadata == null ? ImmutableMap.of() : ImmutableMap.copyOf(metadata))
         .expiry(expiry)
         .type(Strings.nullToEmpty(type))
-        .groups(groups == null ? ImmutableSet.of() : groups)
+        .groups(groups == null ? ImmutableSet.of() : ImmutableSet.copyOf(groups))
         .build();
   }
 

--- a/api/src/main/java/keywhiz/api/automation/v2/GroupDetailResponseV2.java
+++ b/api/src/main/java/keywhiz/api/automation/v2/GroupDetailResponseV2.java
@@ -73,7 +73,7 @@ import keywhiz.api.model.Group;
         .updatedBy(updatedBy)
         .secrets(secrets)
         .clients(clients)
-        .metadata(ImmutableMap.copyOf(metadata == null ? ImmutableMap.of() : metadata))
+        .metadata(metadata == null ? ImmutableMap.of() : ImmutableMap.copyOf(metadata))
         .build();
   }
 


### PR DESCRIPTION
Most optional fields when creating objects (such as a group's
or secret's metadata) are allowed to be missing. This updates
client creation through the automation/v2 API to allow omitting
the groups field. It also slightly standardizes how these optional
fields are handled in other classes.