### PR TITLE
Improve handling of empty secret contents on update

### DIFF
--- a/cli/src/main/java/keywhiz/cli/commands/UpdateAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/UpdateAction.java
@@ -58,6 +58,9 @@ public class UpdateAction implements Runnable {
     byte[] content = {};
     if (config.contentProvided) {
       content = readSecretContent();
+      if (content.length == 0) {
+        throw new IllegalArgumentException("Secret content must be provided if --content flag is present; check inputs");
+      }
     }
     partialUpdateSecret(secretName, content, config);
 

--- a/cli/src/test/java/keywhiz/cli/commands/UpdateActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/UpdateActionTest.java
@@ -136,11 +136,19 @@ public class UpdateActionTest {
     updateAction.run();
   }
 
-
   @Test(expected = IllegalArgumentException.class)
-  public void updateValidatesSecretName() throws Exception {
+  public void updateValidatesSecretName() {
     updateActionConfig.name = "Invalid Name";
 
+    updateAction.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void updateThrowsIfNoContentInput() {
+    updateActionConfig.name = secret.getDisplayName();
+    updateActionConfig.contentProvided = true;
+
+    updateAction.stream = new ByteArrayInputStream(new byte[]{});
     updateAction.run();
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -138,6 +138,7 @@ public class SecretDAO {
   public long createOrUpdateSecret(String name, String encryptedSecret, String hmac, String creator,
       Map<String, String> metadata, long expiry, String description, @Nullable String type,
       @Nullable Map<String, String> generationOptions) {
+    // SecretController should have already checked that the contents are not empty
     return dslContext.transactionResult(configuration -> {
       long now = OffsetDateTime.now().toEpochSecond();
 
@@ -193,6 +194,8 @@ public class SecretDAO {
       String hmac = secretContent.hmac();
       // Mirrors hmac-creation in SecretController
       if (request.contentPresent()) {
+        checkArgument(!request.content().isEmpty());
+
         hmac = cryptographer.computeHmac(
             request.content().getBytes(UTF_8), "hmackey"); // Compute HMAC on base64 encoded data
         if (hmac == null) {


### PR DESCRIPTION
When empty secret contents are passed to the keywhiz.cli
command-line tool, it silently does not update the secret's
contents. This updates the command-line tool to error when
empty contents are passed but the --content flag is specified.

This also updates Keywhiz' internal update endpoint to check
for empty contents, since that endpoint is not accessed
through the SecretController's Builder class (unlike the create
and complete-update endpoints, which use SecretController's
validation to ensure that secret contents are present).