### PR TITLE
Add index on creation time for secret contents

### DIFF
--- a/server/src/main/resources/db/mysql/migration/V13__add_index_on_secret_version_creation.sql
+++ b/server/src/main/resources/db/mysql/migration/V13__add_index_on_secret_version_creation.sql
@@ -1,0 +1,1 @@
+CREATE INDEX createdat_idx ON secrets_content (createdat);


### PR DESCRIPTION
Multiple endpoints that work with secrets' versions, notably
the endpoint to list all secret versions and the check for
old versions of a secret when creating or updating a secret,
order secret versions by their creation date.

Without this index, a secret with thousands of versions takes
seconds to update because the attempt to prune old versions of
the secret before updating takes a second or more to list and
order the existing versions.

https://github.com/square/keywhiz/blob/master/server/src/main/java/keywhiz/service/daos/SecretContentDAO.java#L108-L146 is the check when updating a secret that should be improved by this index.