### PR TITLE
Remove comparisons of serialized JSON in tests

### DIFF
--- a/api/src/main/java/keywhiz/api/AutomationSecretResponse.java
+++ b/api/src/main/java/keywhiz/api/AutomationSecretResponse.java
@@ -17,11 +17,13 @@
 package keywhiz.api;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.Secret;
 
@@ -30,17 +32,24 @@ import static keywhiz.api.model.Secret.decodedLength;
 
 /**
  * JSON Serialization class for a REST response {@link Secret}.
- *
+ * <p>
  * Automation View, does not include secret contents.
  */
 @AutoValue
 public abstract class AutomationSecretResponse {
 
-  public static AutomationSecretResponse create(long id, String name, String secret,
-      ApiDate creationDate,
-      ImmutableMap<String, String> metadata, ImmutableList<Group> groups, long expiry) {
+  @JsonCreator
+  public static AutomationSecretResponse create(
+      @JsonProperty("id") long id,
+      @JsonProperty("name") String name,
+      @JsonProperty("secret") String secret,
+      @JsonProperty("creationDate") ApiDate creationDate,
+      @JsonProperty("metadata") @Nullable ImmutableMap<String, String> metadata,
+      @JsonProperty("groups") ImmutableList<Group> groups,
+      @JsonProperty("expiry") long expiry) {
     return new AutoValue_AutomationSecretResponse(id, name, secret, decodedLength(secret),
-        creationDate, groups, metadata, expiry);
+        creationDate, groups, metadata == null ? ImmutableMap.of() : ImmutableMap.copyOf(metadata),
+        expiry);
   }
 
   public static AutomationSecretResponse fromSecret(Secret secret, ImmutableList<Group> groups) {
@@ -56,11 +65,18 @@ public abstract class AutomationSecretResponse {
   }
 
   @JsonProperty("id") public abstract long id();
+
   @JsonProperty("name") public abstract String name();
+
   @JsonProperty("secret") public abstract String secret();
+
   @JsonProperty("secretLength") public abstract long secretLength();
+
   @JsonProperty("creationDate") public abstract ApiDate creationDate();
+
   @JsonProperty("groups") public abstract ImmutableList<Group> groups();
+
   @JsonAnyGetter @JsonProperty("metadata") public abstract Map<String, String> metadata();
+
   @JsonProperty("expiry") public abstract long expiry();
 }

--- a/api/src/main/java/keywhiz/api/ClientDetailResponse.java
+++ b/api/src/main/java/keywhiz/api/ClientDetailResponse.java
@@ -17,6 +17,7 @@
 package keywhiz.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
 import keywhiz.api.model.Client;
@@ -97,5 +98,29 @@ public class ClientDetailResponse {
         client.getLastSeen(),
         groups,
         secrets);
+  }
+
+  public int hashCode() {
+    return Objects.hashCode(id, name, description, spiffeId, creationDate, updateDate, createdBy,
+        updatedBy, lastSeen, groups, secrets);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof ClientDetailResponse) {
+      ClientDetailResponse that = (ClientDetailResponse) o;
+      return Objects.equal(this.id, that.id) &&
+          Objects.equal(this.name, that.name) &&
+          Objects.equal(this.description, that.description) &&
+          Objects.equal(this.spiffeId, that.spiffeId) &&
+          Objects.equal(this.creationDate, that.creationDate) &&
+          Objects.equal(this.updateDate, that.updateDate) &&
+          Objects.equal(this.createdBy, that.createdBy) &&
+          Objects.equal(this.updatedBy, that.updatedBy) &&
+          Objects.equal(this.lastSeen, that.lastSeen) &&
+          Objects.equal(this.groups, that.groups) &&
+          Objects.equal(this.secrets, that.secrets);
+    }
+    return false;
   }
 }

--- a/api/src/main/java/keywhiz/api/GroupDetailResponse.java
+++ b/api/src/main/java/keywhiz/api/GroupDetailResponse.java
@@ -120,9 +120,13 @@ public class GroupDetailResponse {
     return updatedBy;
   }
 
-  public ImmutableMap<String, String> getMetadata() { return metadata; }
+  public ImmutableMap<String, String> getMetadata() {
+    return metadata;
+  }
 
-  /** @return List of secrets the group has access to. The secrets do not contain content. */
+  /**
+   * @return List of secrets the group has access to. The secrets do not contain content.
+   */
   public ImmutableList<SanitizedSecret> getSecrets() {
     return secrets;
   }
@@ -133,14 +137,15 @@ public class GroupDetailResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(id, name, description, creationDate, updateDate, createdBy, updatedBy, metadata, secrets, clients);
+    return Objects.hashCode(id, name, description, creationDate, updateDate, createdBy, updatedBy,
+        metadata, secrets, clients);
   }
 
   @Override
   public boolean equals(Object o) {
     if (o instanceof GroupDetailResponse) {
       GroupDetailResponse that = (GroupDetailResponse) o;
-      if (Objects.equal(this.id, that.id) &&
+      return Objects.equal(this.id, that.id) &&
           Objects.equal(this.name, that.name) &&
           Objects.equal(this.description, that.description) &&
           Objects.equal(this.creationDate, that.creationDate) &&
@@ -149,9 +154,7 @@ public class GroupDetailResponse {
           Objects.equal(this.updatedBy, that.updatedBy) &&
           Objects.equal(this.metadata, that.metadata) &&
           Objects.equal(this.secrets, that.secrets) &&
-          Objects.equal(this.clients, that.clients)) {
-        return true;
-      }
+          Objects.equal(this.clients, that.clients);
     }
     return false;
   }

--- a/api/src/test/java/keywhiz/api/ClientDetailResponseTest.java
+++ b/api/src/test/java/keywhiz/api/ClientDetailResponseTest.java
@@ -20,29 +20,35 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClientDetailResponseTest {
-  @Test public void serializesCorrectly() throws Exception {
-    ClientDetailResponse clientDetailResponse = new ClientDetailResponse(
-        9875,
-        "Client Name",
-        "Client Description",
-        "spiffe//example.org/client-name",
-        ApiDate.parse("2012-08-01T13:15:30.001Z"),
-        ApiDate.parse("2012-09-10T03:15:30.001Z"),
-        "creator-user",
-        "updater-user",
-        ApiDate.parse("2012-09-10T03:15:30.001Z"),
-        ImmutableList.of(),
-        ImmutableList.of());
+  private ClientDetailResponse clientDetailResponse = new ClientDetailResponse(
+      9875,
+      "Client Name",
+      "Client Description",
+      "spiffe//example.org/client-name",
+      ApiDate.parse("2012-08-01T13:15:30.001Z"),
+      ApiDate.parse("2012-09-10T03:15:30.001Z"),
+      "creator-user",
+      "updater-user",
+      ApiDate.parse("2012-09-10T03:15:30.001Z"),
+      ImmutableList.of(),
+      ImmutableList.of());
 
-    assertThat(asJson(clientDetailResponse))
-        .isEqualTo(jsonFixture("fixtures/clientDetailResponse.json"));
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(clientDetailResponse), ClientDetailResponse.class)).isEqualTo(
+        clientDetailResponse);
   }
 
-  @Test public void serializesNullLastSeenCorrectly() throws Exception {
+  @Test public void deserializesCorrectly() throws Exception {
+    assertThat(fromJson(jsonFixture("fixtures/clientDetailResponse.json"),
+        ClientDetailResponse.class)).isEqualTo(clientDetailResponse);
+  }
+
+  @Test public void handlesNullLastSeenCorrectly() throws Exception {
     ClientDetailResponse clientDetailResponse = new ClientDetailResponse(
         9875,
         "Client Name",
@@ -56,7 +62,10 @@ public class ClientDetailResponseTest {
         ImmutableList.of(),
         ImmutableList.of());
 
-    assertThat(asJson(clientDetailResponse))
-        .isEqualTo(jsonFixture("fixtures/clientDetailResponse_NullLastSeen.json"));
+    assertThat(fromJson(jsonFixture("fixtures/clientDetailResponse_NullLastSeen.json"),
+        ClientDetailResponse.class)).isEqualTo(clientDetailResponse);
+
+    assertThat(fromJson(asJson(clientDetailResponse), ClientDetailResponse.class)).isEqualTo(
+        clientDetailResponse);
   }
 }

--- a/api/src/test/java/keywhiz/api/CreateClientRequestTest.java
+++ b/api/src/test/java/keywhiz/api/CreateClientRequestTest.java
@@ -28,6 +28,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import static javax.ws.rs.client.Entity.entity;
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +38,12 @@ public class CreateClientRequestTest {
   @ClassRule public static final ResourceTestRule resources = ResourceTestRule.builder()
       .addResource(new Resource())
       .build();
+
+  @Test public void roundTripSerialization() throws Exception {
+    CreateClientRequest createClientRequest = new CreateClientRequest("client-name");
+    assertThat(fromJson(asJson(createClientRequest), CreateClientRequest.class))
+        .isEqualTo(createClientRequest);
+  }
 
   @Test public void deserializesCorrectly() throws Exception {
     CreateClientRequest createClientRequest = new CreateClientRequest("client-name");

--- a/api/src/test/java/keywhiz/api/CreateGroupRequestTest.java
+++ b/api/src/test/java/keywhiz/api/CreateGroupRequestTest.java
@@ -19,14 +19,21 @@ package keywhiz.api;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CreateGroupRequestTest {
+  private CreateGroupRequest createGroupRequest =
+      new CreateGroupRequest("groupName", "groupDesc", ImmutableMap.of("app", "groupApp"));
+
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(createGroupRequest), CreateGroupRequest.class))
+        .isEqualTo(createGroupRequest);
+  }
+
   @Test public void deserializesCorrectly() throws Exception {
-    CreateGroupRequest createGroupRequest =
-        new CreateGroupRequest("groupName", "groupDesc", ImmutableMap.of("app", "groupApp"));
     assertThat(fromJson(
         jsonFixture("fixtures/createGroupRequest.json"), CreateGroupRequest.class))
         .isEqualTo(createGroupRequest);

--- a/api/src/test/java/keywhiz/api/CreateSecretRequestTest.java
+++ b/api/src/test/java/keywhiz/api/CreateSecretRequestTest.java
@@ -19,19 +19,25 @@ package keywhiz.api;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CreateSecretRequestTest {
-  @Test public void deserializesCorrectly() throws Exception {
-    CreateSecretRequest createSecretRequest = new CreateSecretRequest(
-        "secretName",
-        "secretDesc",
-        "YXNkZGFz",
-        ImmutableMap.of("owner", "root"),
-        0);
+  private CreateSecretRequest createSecretRequest = new CreateSecretRequest(
+      "secretName",
+      "secretDesc",
+      "YXNkZGFz",
+      ImmutableMap.of("owner", "root"),
+      0);
 
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(createSecretRequest), CreateSecretRequest.class))
+        .isEqualTo(createSecretRequest);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
     assertThat(fromJson(
         jsonFixture("fixtures/createSecretRequest.json"), CreateSecretRequest.class))
         .isEqualTo(createSecretRequest);

--- a/api/src/test/java/keywhiz/api/GroupDetailResponseTest.java
+++ b/api/src/test/java/keywhiz/api/GroupDetailResponseTest.java
@@ -21,24 +21,30 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
 import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GroupDetailResponseTest {
-  @Test public void serializesCorrectly() throws Exception {
-    GroupDetailResponse groupDetailResponse = new GroupDetailResponse(
-        234,
-        "group-name",
-        "",
-        ApiDate.parse("2012-08-01T13:15:30.000Z"),
-        ApiDate.parse("2012-09-10T03:15:30.000Z"),
-        "creator-user",
-        "updater-user",
-        ImmutableMap.of("app", "keywhiz"),
-        ImmutableList.of(),
-        ImmutableList.of());
+  private GroupDetailResponse groupDetailResponse = new GroupDetailResponse(
+      234,
+      "group-name",
+      "",
+      ApiDate.parse("2012-08-01T13:15:30.000Z"),
+      ApiDate.parse("2012-09-10T03:15:30.000Z"),
+      "creator-user",
+      "updater-user",
+      ImmutableMap.of("app", "keywhiz"),
+      ImmutableList.of(),
+      ImmutableList.of());
 
-    assertThat(asJson(groupDetailResponse))
-        .isEqualTo(jsonFixture("fixtures/groupDetailResponse.json"));
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(groupDetailResponse), GroupDetailResponse.class)).isEqualTo(
+        groupDetailResponse);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
+    assertThat(fromJson(jsonFixture("fixtures/groupDetailResponse.json"),
+        GroupDetailResponse.class)).isEqualTo(groupDetailResponse);
   }
 }

--- a/api/src/test/java/keywhiz/api/LoginRequestTest.java
+++ b/api/src/test/java/keywhiz/api/LoginRequestTest.java
@@ -18,13 +18,20 @@ package keywhiz.api;
 
 import org.junit.Test;
 
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LoginRequestTest {
+  private LoginRequest loginRequest = LoginRequest.from("keywhizAdmin", "adminPass".toCharArray());
+
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(loginRequest), LoginRequest.class))
+        .isEqualTo(loginRequest);
+  }
+
   @Test public void deserializesCorrectly() throws Exception {
-    LoginRequest loginRequest = LoginRequest.from("keywhizAdmin", "adminPass".toCharArray());
     assertThat(fromJson(jsonFixture("fixtures/loginRequest.json"), LoginRequest.class))
         .isEqualTo(loginRequest);
   }

--- a/api/src/test/java/keywhiz/api/SecretDetailResponseTest.java
+++ b/api/src/test/java/keywhiz/api/SecretDetailResponseTest.java
@@ -22,34 +22,39 @@ import keywhiz.api.model.Group;
 import org.junit.Test;
 
 import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SecretDetailResponseTest {
-  @Test public void serializesCorrectly() throws Exception {
-    SecretDetailResponse secretDetailResponse = new SecretDetailResponse(
-        1000,
-        "secretName",
-        "desc",
-        ApiDate.parse("2013-03-28T21:23:00.000Z"),
-        "keywhizAdmin",
-        ApiDate.parse("2013-03-28T21:23:04.159Z"),
-        "keywhizAdmin",
-        ImmutableMap.of("mode", "0660"),
-        ImmutableList.of(
-            new Group(2000,
-                      "someGroup",
-                      "groupDesc",
-                      ApiDate.parse("2013-03-28T21:29:27.465Z"),
-                      "keywhizAdmin",
-                      ApiDate.parse("2013-03-28T21:29:27.465Z"),
-                      "keywhizAdmin",
-                      ImmutableMap.of("app", "keywhiz"))
-        ),
-        ImmutableList.of());
+  private SecretDetailResponse secretDetailResponse = new SecretDetailResponse(
+      1000,
+      "secretName",
+      "desc",
+      ApiDate.parse("2013-03-28T21:23:00.000Z"),
+      "keywhizAdmin",
+      ApiDate.parse("2013-03-28T21:23:04.159Z"),
+      "keywhizAdmin",
+      ImmutableMap.of("mode", "0660"),
+      ImmutableList.of(
+          new Group(2000,
+              "someGroup",
+              "groupDesc",
+              ApiDate.parse("2013-03-28T21:29:27.465Z"),
+              "keywhizAdmin",
+              ApiDate.parse("2013-03-28T21:29:27.465Z"),
+              "keywhizAdmin",
+              ImmutableMap.of("app", "keywhiz"))
+      ),
+      ImmutableList.of());
 
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(secretDetailResponse), SecretDetailResponse.class)).isEqualTo(
+        secretDetailResponse);
+  }
 
-    assertThat(asJson(secretDetailResponse))
-        .isEqualTo(jsonFixture("fixtures/secretDetailResponse.json"));
+  @Test public void deserializesCorrectly() throws Exception {
+    assertThat(fromJson(jsonFixture("fixtures/secretDetailResponse.json"),
+        SecretDetailResponse.class)).isEqualTo(secretDetailResponse);
   }
 }

--- a/api/src/test/java/keywhiz/api/automation/v2/ClientDetailResponseV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/ClientDetailResponseV2Test.java
@@ -23,27 +23,33 @@ import keywhiz.api.model.Client;
 import org.junit.Test;
 
 import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClientDetailResponseV2Test {
-  @Test public void serializesCorrectly() throws Exception {
-    ClientDetailResponseV2 clientDetailResponse = new AutoValue_ClientDetailResponseV2(
-        "Client Name",
-        "Client Description",
-        "spiffe//example.org/client-name",
-        OffsetDateTime.parse("2012-08-01T13:15:30Z").toEpochSecond(),
-        OffsetDateTime.parse("2012-09-10T03:15:30Z").toEpochSecond(),
-        "creator-user",
-        "updater-user",
-        Optional.of(OffsetDateTime.parse("2012-09-10T03:15:30Z").toEpochSecond())
-    );
+  private ClientDetailResponseV2 clientDetailResponse = new AutoValue_ClientDetailResponseV2(
+      "Client Name",
+      "Client Description",
+      "spiffe//example.org/client-name",
+      OffsetDateTime.parse("2012-08-01T13:15:30Z").toEpochSecond(),
+      OffsetDateTime.parse("2012-09-10T03:15:30Z").toEpochSecond(),
+      "creator-user",
+      "updater-user",
+      Optional.of(OffsetDateTime.parse("2012-09-10T03:15:30Z").toEpochSecond())
+  );
 
-    assertThat(asJson(clientDetailResponse))
-        .isEqualTo(jsonFixture("fixtures/v2/clientDetailResponse.json"));
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(clientDetailResponse), ClientDetailResponseV2.class)).isEqualTo(
+        clientDetailResponse);
   }
 
-  @Test public void serializesNullLastSeenCorrectly() throws Exception {
+  @Test public void deserializesCorrectly() throws Exception {
+    assertThat(fromJson(jsonFixture("fixtures/v2/clientDetailResponse.json"),
+        ClientDetailResponseV2.class)).isEqualTo(clientDetailResponse);
+  }
+
+  @Test public void deserializesNullLastSeenCorrectly() throws Exception {
     ApiDate createdAt = new ApiDate(1343826930);
     ApiDate updatedAt = new ApiDate(1347246930);
 
@@ -52,7 +58,9 @@ public class ClientDetailResponseV2Test {
     );
     ClientDetailResponseV2 clientDetailResponse = ClientDetailResponseV2.fromClient(client);
 
-    assertThat(asJson(clientDetailResponse))
-        .isEqualTo(jsonFixture("fixtures/v2/clientDetailResponse_LastSeenNull.json"));
+    assertThat(fromJson(jsonFixture("fixtures/v2/clientDetailResponse_LastSeenNull.json"),
+        ClientDetailResponseV2.class)).isEqualTo(clientDetailResponse);
+    assertThat(fromJson(asJson(clientDetailResponse), ClientDetailResponseV2.class)).isEqualTo(
+        clientDetailResponse);
   }
 }

--- a/api/src/test/java/keywhiz/api/automation/v2/CreateClientRequestV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/CreateClientRequestV2Test.java
@@ -18,26 +18,32 @@ package keywhiz.api.automation.v2;
 
 import org.junit.Test;
 
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CreateClientRequestV2Test {
-  @Test public void deserializesCorrectly() throws Exception {
-    CreateClientRequestV2 createClientRequest = CreateClientRequestV2.builder()
-        .name("client-name")
-        .description("client-description")
-        .groups("client-group1", "client-group2")
-        .build();
+  private CreateClientRequestV2 createClientRequest = CreateClientRequestV2.builder()
+      .name("client-name")
+      .description("client-description")
+      .groups("client-group1", "client-group2")
+      .build();
 
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(createClientRequest), CreateClientRequestV2.class)).isEqualTo(
+        createClientRequest);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
     assertThat(fromJson(
         jsonFixture("fixtures/v2/createClientRequest.json"), CreateClientRequestV2.class))
         .isEqualTo(createClientRequest);
   }
 
   @Test(expected = IllegalStateException.class)
-  public void emptyNameFailsValidation() throws Exception {
-     CreateClientRequestV2.builder()
+  public void emptyNameFailsValidation() {
+    CreateClientRequestV2.builder()
         .name("")
         .build();
   }

--- a/api/src/test/java/keywhiz/api/automation/v2/CreateGroupRequestV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/CreateGroupRequestV2Test.java
@@ -19,25 +19,31 @@ package keywhiz.api.automation.v2;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CreateGroupRequestV2Test {
-  @Test public void deserializesCorrectly() throws Exception {
-    CreateGroupRequestV2 createGroupRequest = CreateGroupRequestV2.builder()
-        .name("group-name")
-        .description("group-description")
-        .metadata(ImmutableMap.of("app", "group-app"))
-        .build();
+  private CreateGroupRequestV2 createGroupRequest = CreateGroupRequestV2.builder()
+      .name("group-name")
+      .description("group-description")
+      .metadata(ImmutableMap.of("app", "group-app"))
+      .build();
 
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(createGroupRequest), CreateGroupRequestV2.class)).isEqualTo(
+        createGroupRequest);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
     assertThat(fromJson(
         jsonFixture("fixtures/v2/createGroupRequest.json"), CreateGroupRequestV2.class))
         .isEqualTo(createGroupRequest);
   }
 
   @Test(expected = IllegalStateException.class)
-  public void emptyNameFailsValidation() throws Exception {
+  public void emptyNameFailsValidation() {
     CreateGroupRequestV2.builder()
         .name("")
         .build();

--- a/api/src/test/java/keywhiz/api/automation/v2/CreateSecretRequestV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/CreateSecretRequestV2Test.java
@@ -19,29 +19,35 @@ package keywhiz.api.automation.v2;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CreateSecretRequestV2Test {
-  @Test public void deserializesCorrectly() throws Exception {
-    CreateSecretRequestV2 createSecretRequest = CreateSecretRequestV2.builder()
-        .name("secret-name")
-        .content("YXNkZGFz")
-        .description("secret-description")
-        .metadata(ImmutableMap.of("owner", "root"))
-        .expiry(0)
-        .type("text/plain")
-        .groups("secret-group1", "secret-group2")
-        .build();
+  private CreateSecretRequestV2 createSecretRequest = CreateSecretRequestV2.builder()
+      .name("secret-name")
+      .content("YXNkZGFz")
+      .description("secret-description")
+      .metadata(ImmutableMap.of("owner", "root"))
+      .expiry(0)
+      .type("text/plain")
+      .groups("secret-group1", "secret-group2")
+      .build();
 
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(createSecretRequest), CreateSecretRequestV2.class)).isEqualTo(
+        createSecretRequest);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
     assertThat(fromJson(
         jsonFixture("fixtures/v2/createSecretRequest.json"), CreateSecretRequestV2.class))
         .isEqualTo(createSecretRequest);
   }
 
   @Test(expected = IllegalStateException.class)
-  public void emptyNameFailsValidation() throws Exception {
+  public void emptyNameFailsValidation() {
     CreateSecretRequestV2.builder()
         .name("")
         .content("")

--- a/api/src/test/java/keywhiz/api/automation/v2/GroupDetailResponseV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/GroupDetailResponseV2Test.java
@@ -22,24 +22,30 @@ import java.time.OffsetDateTime;
 import org.junit.Test;
 
 import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GroupDetailResponseV2Test {
-  @Test public void serializesCorrectly() throws Exception {
-    GroupDetailResponseV2 groupDetailResponse = GroupDetailResponseV2.builder()
-        .name("group-name")
-        .description("group-description")
-        .createdAtSeconds(OffsetDateTime.parse("2012-08-01T13:15:30Z").toEpochSecond())
-        .updatedAtSeconds(OffsetDateTime.parse("2012-09-10T03:15:30Z").toEpochSecond())
-        .createdBy("creator-user")
-        .updatedBy("updater-user")
-        .secrets(ImmutableSet.of("secret1", "secret2"))
-        .clients(ImmutableSet.of("client1", "client2"))
-        .metadata(ImmutableMap.of("app", "keywhiz"))
-        .build();
+  private GroupDetailResponseV2 groupDetailResponse = GroupDetailResponseV2.builder()
+      .name("group-name")
+      .description("group-description")
+      .createdAtSeconds(OffsetDateTime.parse("2012-08-01T13:15:30Z").toEpochSecond())
+      .updatedAtSeconds(OffsetDateTime.parse("2012-09-10T03:15:30Z").toEpochSecond())
+      .createdBy("creator-user")
+      .updatedBy("updater-user")
+      .secrets(ImmutableSet.of("secret1", "secret2"))
+      .clients(ImmutableSet.of("client1", "client2"))
+      .metadata(ImmutableMap.of("app", "keywhiz"))
+      .build();
 
-    assertThat(asJson(groupDetailResponse))
-        .isEqualTo(jsonFixture("fixtures/v2/groupDetailResponse.json"));
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(groupDetailResponse), GroupDetailResponseV2.class)).isEqualTo(
+        groupDetailResponse);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
+    assertThat(fromJson(jsonFixture("fixtures/v2/groupDetailResponse.json"),
+        GroupDetailResponseV2.class)).isEqualTo(groupDetailResponse);
   }
 }

--- a/api/src/test/java/keywhiz/api/automation/v2/ModifyClientRequestV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/ModifyClientRequestV2Test.java
@@ -18,14 +18,20 @@ package keywhiz.api.automation.v2;
 
 import org.junit.Test;
 
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ModifyClientRequestV2Test {
-  @Test public void deserializesCorrectly() throws Exception {
-    ModifyClientRequestV2 modifyClientRequest = ModifyClientRequestV2.forName("client-name");
+  private ModifyClientRequestV2 modifyClientRequest = ModifyClientRequestV2.forName("client-name");
 
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(modifyClientRequest), ModifyClientRequestV2.class)).isEqualTo(
+        modifyClientRequest);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
     assertThat(
         fromJson(jsonFixture("fixtures/v2/modifyClientRequest.json"), ModifyClientRequestV2.class))
         .isEqualTo(modifyClientRequest);

--- a/api/src/test/java/keywhiz/api/automation/v2/ModifyGroupsRequestV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/ModifyGroupsRequestV2Test.java
@@ -18,17 +18,23 @@ package keywhiz.api.automation.v2;
 
 import org.junit.Test;
 
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ModifyGroupsRequestV2Test {
-  @Test public void deserializesCorrectly() throws Exception {
-    ModifyGroupsRequestV2 modifyGroupsRequest = ModifyGroupsRequestV2.builder()
-        .addGroups("group1", "group2")
-        .removeGroups("group3", "group4")
-        .build();
+  private ModifyGroupsRequestV2 modifyGroupsRequest = ModifyGroupsRequestV2.builder()
+      .addGroups("group1", "group2")
+      .removeGroups("group3", "group4")
+      .build();
 
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(modifyGroupsRequest), ModifyGroupsRequestV2.class)).isEqualTo(
+        modifyGroupsRequest);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
     assertThat(
         fromJson(jsonFixture("fixtures/v2/modifyGroupsRequest.json"), ModifyGroupsRequestV2.class))
         .isEqualTo(modifyGroupsRequest);

--- a/api/src/test/java/keywhiz/api/automation/v2/SecretContentsRequestV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/SecretContentsRequestV2Test.java
@@ -18,16 +18,22 @@ package keywhiz.api.automation.v2;
 
 import org.junit.Test;
 
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SecretContentsRequestV2Test {
-  @Test public void deserializesCorrectly() throws Exception {
-    SecretContentsRequestV2 secretContentsRequest = SecretContentsRequestV2.builder()
-        .secrets("secret1", "secret2", "secret3")
-        .build();
+  private SecretContentsRequestV2 secretContentsRequest = SecretContentsRequestV2.builder()
+      .secrets("secret1", "secret2", "secret3")
+      .build();
 
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(secretContentsRequest), SecretContentsRequestV2.class)).isEqualTo(
+        secretContentsRequest);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
     assertThat(fromJson(
         jsonFixture("fixtures/v2/secretContentsRequest.json"), SecretContentsRequestV2.class))
         .isEqualTo(secretContentsRequest);

--- a/api/src/test/java/keywhiz/api/automation/v2/SecretContentsResponseV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/SecretContentsResponseV2Test.java
@@ -20,17 +20,24 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
+import static keywhiz.testing.JsonHelpers.asJson;
 import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SecretContentsResponseV2Test {
-  @Test public void deserializesCorrectly() throws Exception {
-    SecretContentsResponseV2 secretContentsResponse = SecretContentsResponseV2.builder()
-        .successSecrets(ImmutableMap.of("secret1", "supersecretcontent1", "secret2", "supersecretcontent2"))
-        .missingSecrets(ImmutableList.of("secret3"))
-        .build();
+  private SecretContentsResponseV2 secretContentsResponse = SecretContentsResponseV2.builder()
+      .successSecrets(
+          ImmutableMap.of("secret1", "supersecretcontent1", "secret2", "supersecretcontent2"))
+      .missingSecrets(ImmutableList.of("secret3"))
+      .build();
 
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(secretContentsResponse), SecretContentsResponseV2.class)).isEqualTo(
+        secretContentsResponse);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
     assertThat(fromJson(
         jsonFixture("fixtures/v2/secretContentsResponse.json"), SecretContentsResponseV2.class))
         .isEqualTo(secretContentsResponse);

--- a/api/src/test/java/keywhiz/api/automation/v2/SecretDetailResponseV2Test.java
+++ b/api/src/test/java/keywhiz/api/automation/v2/SecretDetailResponseV2Test.java
@@ -26,32 +26,38 @@ import keywhiz.api.model.SecretSeriesAndContent;
 import org.junit.Test;
 
 import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SecretDetailResponseV2Test {
-  @Test public void serializesCorrectly() throws Exception {
-    SecretDetailResponseV2 secretDetailResponse = SecretDetailResponseV2.builder()
-        .name("secret-name")
-        .version(1L)
-        .description("secret-description")
-        .checksum("checksum")
-        .createdAtSeconds(OffsetDateTime.parse("2013-03-28T21:23:04.159Z").toEpochSecond())
-        .createdBy("creator-user")
-        .updatedAtSeconds(OffsetDateTime.parse("2014-03-28T21:23:04.159Z").toEpochSecond())
-        .updatedBy("updater-user")
-        .type("text/plain")
-        .metadata(ImmutableMap.of("owner", "root"))
-        .expiry(1136214245)
-        .contentCreatedAtSeconds(OffsetDateTime.parse("2014-03-28T21:23:04.159Z").toEpochSecond())
-        .contentCreatedBy("updater-user")
-        .build();
+  private SecretDetailResponseV2 secretDetailResponse = SecretDetailResponseV2.builder()
+      .name("secret-name")
+      .version(1L)
+      .description("secret-description")
+      .checksum("checksum")
+      .createdAtSeconds(OffsetDateTime.parse("2013-03-28T21:23:04.159Z").toEpochSecond())
+      .createdBy("creator-user")
+      .updatedAtSeconds(OffsetDateTime.parse("2014-03-28T21:23:04.159Z").toEpochSecond())
+      .updatedBy("updater-user")
+      .type("text/plain")
+      .metadata(ImmutableMap.of("owner", "root"))
+      .expiry(1136214245)
+      .contentCreatedAtSeconds(OffsetDateTime.parse("2014-03-28T21:23:04.159Z").toEpochSecond())
+      .contentCreatedBy("updater-user")
+      .build();
 
-    assertThat(asJson(secretDetailResponse))
-        .isEqualTo(jsonFixture("fixtures/v2/secretDetailResponse.json"));
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(secretDetailResponse), SecretDetailResponseV2.class)).isEqualTo(
+        secretDetailResponse);
   }
 
-  @Test public void formsCorrectlyFromSecretSeriesAndContent() throws Exception {
+  @Test public void deserializesCorrectly() throws Exception {
+    assertThat(fromJson(jsonFixture("fixtures/v2/secretDetailResponse.json"),
+        SecretDetailResponseV2.class)).isEqualTo(secretDetailResponse);
+  }
+
+  @Test public void formsCorrectlyFromSecretSeriesAndContent() {
     SecretSeries series = SecretSeries.of(1, "secret-name", "secret-description",
         ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
         ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user", "text/plain", null,
@@ -61,26 +67,24 @@ public class SecretDetailResponseV2Test {
         ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user",
         ImmutableMap.of("owner", "root"), 1136214245);
     SecretSeriesAndContent seriesAndContent = SecretSeriesAndContent.of(series, content);
-    SecretDetailResponseV2 secretDetailResponse = SecretDetailResponseV2.builder()
+    SecretDetailResponseV2 fromSeriesAndContent = SecretDetailResponseV2.builder()
         .seriesAndContent(seriesAndContent)
         .build();
 
-    assertThat(asJson(secretDetailResponse))
-        .isEqualTo(jsonFixture("fixtures/v2/secretDetailResponse.json"));
+    assertThat(fromSeriesAndContent).isEqualTo(secretDetailResponse);
   }
 
-  @Test public void formsCorrectlyFromSanitizedSecret() throws Exception {
-    SanitizedSecret sanitizedSecret = SanitizedSecret.of(1, "secret-name", "secret-description", "checksum",
-        ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
-        ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user",
-        ImmutableMap.of("owner", "root"), "text/plain", null,
-        1136214245, 1L,
-        ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user");
-    SecretDetailResponseV2 secretDetailResponse = SecretDetailResponseV2.builder()
+  @Test public void formsCorrectlyFromSanitizedSecret() {
+    SanitizedSecret sanitizedSecret =
+        SanitizedSecret.of(1, "secret-name", "secret-description", "checksum",
+            ApiDate.parse("2013-03-28T21:23:04.159Z"), "creator-user",
+            ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user",
+            ImmutableMap.of("owner", "root"), "text/plain", null,
+            1136214245, 1L, ApiDate.parse("2014-03-28T21:23:04.159Z"), "updater-user");
+    SecretDetailResponseV2 fromSanitizedSecret = SecretDetailResponseV2.builder()
         .sanitizedSecret(sanitizedSecret)
         .build();
 
-    assertThat(asJson(secretDetailResponse))
-        .isEqualTo(jsonFixture("fixtures/v2/secretDetailResponse.json"));
+    assertThat(fromSanitizedSecret).isEqualTo(secretDetailResponse);
   }
 }

--- a/api/src/test/java/keywhiz/api/model/ClientTest.java
+++ b/api/src/test/java/keywhiz/api/model/ClientTest.java
@@ -20,25 +20,30 @@ import keywhiz.api.ApiDate;
 import org.junit.Test;
 
 import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClientTest {
-  @Test public void serializesCorrectly() throws Exception {
-    Client client = new Client(200,
-        "someClient",
-        "clientDesc",
-        null,
-        ApiDate.parse("2013-03-28T21:29:27.465Z"),
-        "keywhizAdmin",
-        ApiDate.parse("2013-03-28T21:29:27.465Z"),
-        "keywhizAdmin",
-        null,
-        null,
-        true,
-        false
-    );
+  private Client client = new Client(200,
+      "someClient",
+      "clientDesc",
+      null,
+      ApiDate.parse("2013-03-28T21:29:27.465Z"),
+      "keywhizAdmin",
+      ApiDate.parse("2013-03-28T21:29:27.465Z"),
+      "keywhizAdmin",
+      null,
+      null,
+      true,
+      false
+  );
 
-    assertThat(asJson(client)).isEqualTo(jsonFixture("fixtures/client.json"));
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(client), Client.class)).isEqualTo(client);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
+    assertThat(fromJson(jsonFixture("fixtures/client.json"), Client.class)).isEqualTo(client);
   }
 }

--- a/api/src/test/java/keywhiz/api/model/GroupTest.java
+++ b/api/src/test/java/keywhiz/api/model/GroupTest.java
@@ -21,20 +21,25 @@ import keywhiz.api.ApiDate;
 import org.junit.Test;
 
 import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.fromJson;
 import static keywhiz.testing.JsonHelpers.jsonFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GroupTest {
-  @Test public void serializesCorrectly() throws Exception {
-    Group group = new Group(330,
-                            "someGroup",
-                            "groupDesc",
-                            ApiDate.parse("2013-03-28T21:29:27.465Z"),
-                            "keywhizAdmin",
-                            ApiDate.parse("2013-03-28T21:29:27.465Z"),
-                            "keywhizAdmin",
-                            ImmutableMap.of("app", "keywhiz"));
+  private Group group = new Group(330,
+      "someGroup",
+      "groupDesc",
+      ApiDate.parse("2013-03-28T21:29:27.465Z"),
+      "keywhizAdmin",
+      ApiDate.parse("2013-03-28T21:29:27.465Z"),
+      "keywhizAdmin",
+      ImmutableMap.of("app", "keywhiz"));
 
-    assertThat(asJson(group)).isEqualTo(jsonFixture("fixtures/group.json"));
+  @Test public void roundTripSerialization() throws Exception {
+    assertThat(fromJson(asJson(group), Group.class)).isEqualTo(group);
+  }
+
+  @Test public void deserializesCorrectly() throws Exception {
+    assertThat(fromJson(jsonFixture("fixtures/group.json"), Group.class)).isEqualTo(group);
   }
 }

--- a/api/src/test/java/keywhiz/api/model/SecretRetrievalCursorTest.java
+++ b/api/src/test/java/keywhiz/api/model/SecretRetrievalCursorTest.java
@@ -3,18 +3,25 @@ package keywhiz.api.model;
 import org.junit.Test;
 
 import static keywhiz.testing.JsonHelpers.asJson;
+import static keywhiz.testing.JsonHelpers.fromJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SecretRetrievalCursorTest {
   @Test
-  public void serializesCorrectly() throws Exception {
+  public void roundTripSerialization() throws Exception {
     SecretRetrievalCursor cursor = SecretRetrievalCursor.of("test-secret", 1234567);
-    assertThat(asJson(cursor))
-        .isEqualTo("{\"name\":\"test-secret\",\"expiry\":1234567}");
+    assertThat(fromJson(asJson(cursor), SecretRetrievalCursor.class)).isEqualTo(cursor);
   }
 
   @Test
-  public void roundTrip() throws Exception {
+  public void deserializesCorrectly() throws Exception {
+    SecretRetrievalCursor cursor = SecretRetrievalCursor.of("test-secret", 1234567);
+    assertThat(fromJson("{\"name\":\"test-secret\",\"expiry\":1234567}",
+        SecretRetrievalCursor.class)).isEqualTo(cursor);
+  }
+
+  @Test
+  public void roundTripUrlEncoded() throws Exception {
     SecretRetrievalCursor cursor = SecretRetrievalCursor.of("test_secret-123.crt", 1234567);
     SecretRetrievalCursor roundtripped =
         SecretRetrievalCursor.fromUrlEncodedString(


### PR DESCRIPTION
Since the ordering of fields in a serialized JSON object
is not deterministic, tests which serialize an object
and compare it to a fixed file will be flaky. This replaces
such tests with 1) a test that a fixed file deserializes
to the expected object and 2) a test that a round-trip
serialization and deserialization results in the original
object.

This PR is currently based on https://github.com/square/keywhiz/pull/766, since that PR exposed this flakiness and fixing some of the tests was necessary to make 766 pass its tests.