### PR TITLE
Add a custom header to parse the caller Spiffe Id from

### DIFF
--- a/server/src/main/java/keywhiz/auth/mutualssl/SpiffePrincipal.java
+++ b/server/src/main/java/keywhiz/auth/mutualssl/SpiffePrincipal.java
@@ -1,0 +1,29 @@
+package keywhiz.auth.mutualssl;
+
+import java.net.URI;
+import java.security.Principal;
+
+public class SpiffePrincipal implements Principal {
+  private final URI spiffeId;
+
+  public SpiffePrincipal(URI spiffeId) {
+    this.spiffeId = spiffeId;
+  }
+
+  @Override public String getName() {
+    return spiffeId.toString();
+  }
+
+  public URI getSpiffeId() {
+    return spiffeId;
+  }
+
+  /**
+   * Use the workload id of a Spiffe Id as the client name.
+   */
+  public String getClientName() {
+    String path = spiffeId.getPath();
+    // Drop the leading '/' character.
+    return path.isEmpty() ? path : path.substring(1);
+  }
+}

--- a/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
+++ b/server/src/main/java/keywhiz/service/config/XfccSourceConfig.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Configuration for x-forwarded-client-cert header support, as set by the Envoy proxy
@@ -30,8 +31,10 @@ public abstract class XfccSourceConfig {
   @JsonCreator public static XfccSourceConfig of(
       @JsonProperty("port") Integer port,
       @JsonProperty("allowedClientNames") List<String> allowedClientNames,
-      @JsonProperty("allowedSpiffeIds") List<String> allowedSpiffeIds) {
-    return new AutoValue_XfccSourceConfig(port, allowedClientNames, allowedSpiffeIds);
+      @JsonProperty("allowedSpiffeIds") List<String> allowedSpiffeIds,
+      @JsonProperty("callerSpiffeIdHeader") String callerSpiffeIdHeader) {
+    return new AutoValue_XfccSourceConfig(port, allowedClientNames, allowedSpiffeIds,
+        callerSpiffeIdHeader);
   }
 
   /**
@@ -49,4 +52,16 @@ public abstract class XfccSourceConfig {
   public abstract List<String> allowedClientNames();
 
   public abstract List<String> allowedSpiffeIds();
+
+  /**
+   * An optional custom header identifies the "caller" who sent the original request. If present,
+   * we attempt to parse the client Spiffe Id from this header instead of the XFCC header.
+   *
+   * It is to support a scenario where a real client is behind a proxy. The Spiffe Id extracted from
+   * the XFCC header may or may not match the one set in this custom header. For example,
+   * considering a request flow like this: client -> proxy -> Envoy -> Keywhiz. In this case, the
+   * XFCC header set by the envoy instance contains the proxy cert, while the custom Spiffe Id
+   * header contains the client information behind the proxy.
+   */
+  @Nullable public abstract String callerSpiffeIdHeader();
 }


### PR DESCRIPTION
Add an optional custom header identifies the "caller" who sent the
original request. If present, we attempt to parse the client Spiffe
Id from this header instead of the XFCC header.

It is to support a scenario where a real client is behind a proxy.
The Spiffe Id extracted from the XFCC header may or may not match
the one set in this custom header. For example, considering a
request flow like this: client -> proxy -> Envoy -> Keywhiz. In
this case, the XFCC header set by the envoy instance contains the
proxy cert, while the custom Spiffe Id header contains the client
information behind the proxy.