### PR TITLE
Add minimum expiration to endpoint which retrieves expiring secrets

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/SecretController.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretController.java
@@ -127,12 +127,14 @@ public class SecretController {
   }
 
   /**
+   * @param expireMinTime timestamp for closest expiry to include (may be overridden by cursor)
    * @param expireMaxTime timestamp for farthest expiry to include
    * @param limit         limit on number of results to return
    * @param cursor        cursor to be used to enforce pagination
    * @return all existing sanitized secrets and their groups matching criteria.
    */
   public SanitizedSecretWithGroupsListAndCursor getSanitizedSecretsWithGroupsAndCursor(
+      @Nullable Long expireMinTime,
       @Nullable Long expireMaxTime,
       @Nullable Integer limit,
       @Nullable SecretRetrievalCursor cursor) {
@@ -146,7 +148,7 @@ public class SecretController {
     }
 
     if (cursor == null) {
-      secrets = secretDAO.getSecrets(expireMaxTime, null, null, null, updatedLimit);
+      secrets = secretDAO.getSecrets(expireMaxTime, null, expireMinTime, null, updatedLimit);
     } else {
       secrets = secretDAO.getSecrets(expireMaxTime, null, cursor.expiry(), cursor.name(),
           updatedLimit);

--- a/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretSeriesDAO.java
@@ -224,7 +224,7 @@ public class SecretSeriesDAO {
           .on(SECRETS.CURRENT.equal(SECRETS_CONTENT.ID))
           .where(SECRETS.CURRENT.isNotNull())
           .getQuery();
-    select.addOrderBy(SECRETS_CONTENT.EXPIRY.asc().nullsLast(), SECRETS.NAME.asc().nullsLast());
+    select.addOrderBy(SECRETS_CONTENT.EXPIRY.asc(), SECRETS.NAME.asc());
 
     // Set an upper bound on expiration dates
     if (expireMaxTime != null && expireMaxTime > 0) {

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/SecretResource.java
@@ -354,6 +354,7 @@ public class SecretResource {
    * If this method returns a cursor, that cursor should be passed back into this method until the
    * returned cursor is null.  This allows pagination.
    *
+   * @param minTime timestamp for nearest expiry to include; if null, defaults to current time
    * @param maxTime timestamp for farthest expiry to include (exclusive)
    * @param limit   maximum number of secrets and groups to return
    * @param cursor  input allowing the server to return paginated output (as returned from this
@@ -369,6 +370,7 @@ public class SecretResource {
   @Produces(APPLICATION_JSON)
   public SanitizedSecretWithGroupsListAndCursor secretListingExpiringV4(
       @Auth AutomationClient automationClient,
+      @QueryParam("minTime")  Long minTime,
       @QueryParam("maxTime") Long maxTime,
       @QueryParam("limit") Integer limit,
       @QueryParam("cursor") String cursor) {
@@ -376,7 +378,7 @@ public class SecretResource {
     if (cursor != null) {
       cursorDecoded = SecretRetrievalCursor.fromUrlEncodedString(cursor);
     }
-    return secretControllerReadOnly.getSanitizedSecretsWithGroupsAndCursor(maxTime, limit,
+    return secretControllerReadOnly.getSanitizedSecretsWithGroupsAndCursor(minTime, maxTime, limit,
         cursorDecoded);
   }
 

--- a/server/src/test/java/keywhiz/service/daos/SecretControllerTest.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretControllerTest.java
@@ -132,7 +132,7 @@ public class SecretControllerTest {
     SecretRetrievalCursor cursor = null;
     do {
       SanitizedSecretWithGroupsListAndCursor retrievedSecretsAndCursor =
-          secretController.getSanitizedSecretsWithGroupsAndCursor(expireMaxTime, limit, cursor);
+          secretController.getSanitizedSecretsWithGroupsAndCursor(null, expireMaxTime, limit, cursor);
       cursor = retrievedSecretsAndCursor.decodedCursor();
 
       List<SanitizedSecretWithGroups> secrets = retrievedSecretsAndCursor.secrets();


### PR DESCRIPTION
This allows further limits on the number of secrets to be retrieved.