### PR TITLE
Instruction on how to provide secret content

### DIFF
--- a/cli/src/main/java/keywhiz/cli/commands/AddAction.java
+++ b/cli/src/main/java/keywhiz/cli/commands/AddAction.java
@@ -139,6 +139,7 @@ public class AddAction implements Runnable {
 
   private byte[] readSecretContent() {
     try {
+      System.out.print("Enter secret content, Ctrl+D when done: ");
       byte[] content = ByteStreams.toByteArray(stream);
       if (content.length == 0) {
         throw new RuntimeException("Secret content empty!");


### PR DESCRIPTION
When creating a new secret with add CLI, the user needs to enter the secret content then Ctrl+D to signal end of input. Otherwise, the command cannot finish and secret cannot be created.