### PR TITLE
Optimizing fetching list of secret names which a group has access to

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -529,6 +529,12 @@ public class AclDAO {
         .execute();
   }
 
+  public ImmutableSet<SecretSeries> getSecretSeriesFor(Group group) {
+    checkNotNull(group);
+
+    return dslContext.transactionResult(configuration -> getSecretSeriesFor(configuration, group));
+  }
+
   protected ImmutableSet<SecretSeries> getSecretSeriesFor(Configuration configuration, Group group) {
     List<SecretSeries> r = DSL.using(configuration)
         .select(SECRETS.fields())

--- a/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
@@ -30,6 +30,7 @@ import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
 import keywhiz.api.model.SanitizedSecret;
 import keywhiz.api.model.SanitizedSecretWithGroups;
+import keywhiz.api.model.SecretSeries;
 import keywhiz.log.AuditLog;
 import keywhiz.log.Event;
 import keywhiz.log.EventTag;
@@ -141,8 +142,8 @@ public class GroupResource {
     Group group = groupDAOReadOnly.getGroup(name)
         .orElseThrow(NotFoundException::new);
 
-    Set<String> secrets = aclDAOReadOnly.getSanitizedSecretsFor(group).stream()
-        .map(SanitizedSecret::name)
+    Set<String> secrets = aclDAOReadOnly.getSecretSeriesFor(group).stream()
+        .map(SecretSeries::name)
         .collect(toSet());
 
     Set<String> clients = aclDAOReadOnly.getClientsFor(group).stream()


### PR DESCRIPTION
GroupResource was unnecessarily fetching secret contents individually when it only needed the names from the secret series