### PR TITLE
Log owner during secret creation

### DIFF
--- a/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
+++ b/server/src/main/java/keywhiz/service/resources/admin/SecretsResource.java
@@ -211,7 +211,16 @@ public class SecretsResource {
   @Consumes(APPLICATION_JSON)
   public Response createSecret(@Auth User user, @Valid CreateSecretRequestV2 request) {
 
-    logger.info("User '{}' creating secret '{}'.", user, request.name());
+    {
+      String ownerPart = request.owner() == null
+          ? "with no owner"
+          : String.format("with owner '%s'", request.owner());
+      logger.info(
+          "User '{}' creating secret '{}' {}.",
+          user,
+          request.name(),
+          ownerPart);
+    }
 
     Secret secret;
     try {


### PR DESCRIPTION
We already log the owner in the audit logs, but we should put it in the regular logs as well