### PR TITLE
Fix bugs leading to server-start and AES-generation fail

### DIFF
--- a/server/src/main/java/keywhiz/commands/GenerateAesKeyCommand.java
+++ b/server/src/main/java/keywhiz/commands/GenerateAesKeyCommand.java
@@ -68,7 +68,7 @@ public class GenerateAesKeyCommand extends Command {
 
   @Override public void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
     char[] password = namespace.getString("storepass").toCharArray();
-    Path destination = Paths.get(namespace.get("keystore"));
+    Path destination = Paths.get(namespace.getString("keystore"));
     int keySize = namespace.getInt("keysize");
     String alias = namespace.getString("alias");
 

--- a/server/src/main/resources/keywhiz-development.yaml
+++ b/server/src/main/resources/keywhiz-development.yaml
@@ -109,6 +109,6 @@ contentKeyStore:
   password: CHANGE
   alias: basekey
 
-rowHmacCheck: logging
+rowHmacCheck: DISABLED_BUT_LOG
 
 flywaySchemaTable: schema_version


### PR DESCRIPTION
1. The **keystore** parameter should be a String rather than an URI.
2. Keyword "logging" cannot be recognized by **rowHmacCheck**, the right one is DISABLED_BUT_LOG.