### PR TITLE
Compare HMACs with MessageDigest to avoid timing attacks

### DIFF
--- a/server/src/main/java/keywhiz/service/crypto/RowHmacGenerator.java
+++ b/server/src/main/java/keywhiz/service/crypto/RowHmacGenerator.java
@@ -42,7 +42,7 @@ public class RowHmacGenerator {
    *
    * Uses MessageDigest to prevent timing attacks.
    * */
-  public boolean compareHmacs(String left, String right) {
+  public static boolean compareHmacs(String left, String right) {
     return MessageDigest.isEqual(
         left.getBytes(UTF_8),
         right.getBytes(UTF_8)

--- a/server/src/main/java/keywhiz/service/crypto/RowHmacGenerator.java
+++ b/server/src/main/java/keywhiz/service/crypto/RowHmacGenerator.java
@@ -1,6 +1,7 @@
 package keywhiz.service.crypto;
 
 import java.nio.ByteBuffer;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.List;
 import java.util.Objects;
@@ -34,6 +35,18 @@ public class RowHmacGenerator {
         .collect(Collectors.joining("|"));
     String hmacContent = table + "|" + joinedFields;
     return cryptographer.computeHmacWithSecretKey(hmacContent.getBytes(UTF_8), hmacKey);
+  }
+
+  /**
+   * Checks whether two HMACs are equal.
+   *
+   * Uses MessageDigest to prevent timing attacks.
+   * */
+  public boolean compareHmacs(String left, String right) {
+    return MessageDigest.isEqual(
+        left.getBytes(UTF_8),
+        right.getBytes(UTF_8)
+    );
   }
 
   /**

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -370,7 +370,7 @@ public class AclDAO {
     String secretHmac = rowHmacGenerator.computeRowHmac(
         SECRETS.getName(), List.of(row.getValue(SECRETS.NAME), row.getValue(SECRETS.ID))
     );
-    if (!rowHmacGenerator.compareHmacs(secretHmac, row.getValue(SECRETS.ROW_HMAC))) {
+    if (!RowHmacGenerator.compareHmacs(secretHmac, row.getValue(SECRETS.ROW_HMAC))) {
       String errorMessage = String.format(
           "Secret HMAC verification failed for secret: %s", row.getValue(SECRETS.NAME));
       if (rowHmacLog) {
@@ -384,7 +384,7 @@ public class AclDAO {
     String clientHmac = rowHmacGenerator.computeRowHmac(
         CLIENTS.getName(), List.of(client.getName(), client.getId())
     );
-    if (!rowHmacGenerator.compareHmacs(clientHmac, row.getValue(CLIENTS.ROW_HMAC))) {
+    if (!RowHmacGenerator.compareHmacs(clientHmac, row.getValue(CLIENTS.ROW_HMAC))) {
       String errorMessage = String.format(
           "Client HMAC verification failed for client: %s", client.getName());
       if (rowHmacLog) {
@@ -397,7 +397,7 @@ public class AclDAO {
 
     String membershipsHmac = rowHmacGenerator.computeRowHmac(
         MEMBERSHIPS.getName(), List.of(client.getId(), row.getValue(MEMBERSHIPS.GROUPID)));
-    if (!rowHmacGenerator.compareHmacs(membershipsHmac, row.getValue(MEMBERSHIPS.ROW_HMAC))) {
+    if (!RowHmacGenerator.compareHmacs(membershipsHmac, row.getValue(MEMBERSHIPS.ROW_HMAC))) {
       String errorMessage = String.format(
           "Memberships HMAC verification failed for clientId: %d in groupId: %d",
           client.getId(), row.getValue(MEMBERSHIPS.GROUPID));
@@ -412,7 +412,7 @@ public class AclDAO {
     String accessgrantsHmac = rowHmacGenerator.computeRowHmac(
         ACCESSGRANTS.getName(),
         List.of(row.getValue(MEMBERSHIPS.GROUPID), row.getValue(SECRETS.ID)));
-    if (!rowHmacGenerator.compareHmacs(accessgrantsHmac, row.getValue(ACCESSGRANTS.ROW_HMAC))) {
+    if (!RowHmacGenerator.compareHmacs(accessgrantsHmac, row.getValue(ACCESSGRANTS.ROW_HMAC))) {
       String errorMessage = String.format(
           "Access Grants HMAC verification failed for groupId: %d in secretId: %d",
           row.getValue(MEMBERSHIPS.GROUPID), row.getValue(SECRETS.ID));

--- a/server/src/main/java/keywhiz/service/daos/AclDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/AclDAO.java
@@ -370,7 +370,7 @@ public class AclDAO {
     String secretHmac = rowHmacGenerator.computeRowHmac(
         SECRETS.getName(), List.of(row.getValue(SECRETS.NAME), row.getValue(SECRETS.ID))
     );
-    if (!secretHmac.equals(row.getValue(SECRETS.ROW_HMAC))) {
+    if (!rowHmacGenerator.compareHmacs(secretHmac, row.getValue(SECRETS.ROW_HMAC))) {
       String errorMessage = String.format(
           "Secret HMAC verification failed for secret: %s", row.getValue(SECRETS.NAME));
       if (rowHmacLog) {
@@ -384,7 +384,7 @@ public class AclDAO {
     String clientHmac = rowHmacGenerator.computeRowHmac(
         CLIENTS.getName(), List.of(client.getName(), client.getId())
     );
-    if (!clientHmac.equals(row.getValue(CLIENTS.ROW_HMAC))) {
+    if (!rowHmacGenerator.compareHmacs(clientHmac, row.getValue(CLIENTS.ROW_HMAC))) {
       String errorMessage = String.format(
           "Client HMAC verification failed for client: %s", client.getName());
       if (rowHmacLog) {
@@ -397,7 +397,7 @@ public class AclDAO {
 
     String membershipsHmac = rowHmacGenerator.computeRowHmac(
         MEMBERSHIPS.getName(), List.of(client.getId(), row.getValue(MEMBERSHIPS.GROUPID)));
-    if (!membershipsHmac.equals(row.getValue(MEMBERSHIPS.ROW_HMAC))) {
+    if (!rowHmacGenerator.compareHmacs(membershipsHmac, row.getValue(MEMBERSHIPS.ROW_HMAC))) {
       String errorMessage = String.format(
           "Memberships HMAC verification failed for clientId: %d in groupId: %d",
           client.getId(), row.getValue(MEMBERSHIPS.GROUPID));
@@ -412,7 +412,7 @@ public class AclDAO {
     String accessgrantsHmac = rowHmacGenerator.computeRowHmac(
         ACCESSGRANTS.getName(),
         List.of(row.getValue(MEMBERSHIPS.GROUPID), row.getValue(SECRETS.ID)));
-    if (!accessgrantsHmac.equals(row.getValue(ACCESSGRANTS.ROW_HMAC))) {
+    if (!rowHmacGenerator.compareHmacs(accessgrantsHmac, row.getValue(ACCESSGRANTS.ROW_HMAC))) {
       String errorMessage = String.format(
           "Access Grants HMAC verification failed for groupId: %d in secretId: %d",
           row.getValue(MEMBERSHIPS.GROUPID), row.getValue(SECRETS.ID));


### PR DESCRIPTION
String.equals is vulnerable to timing attacks.