### PR TITLE
Add permission checks to SecretResource

### DIFF
--- a/server/src/main/java/keywhiz/service/daos/SecretController.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretController.java
@@ -108,12 +108,6 @@ public class SecretController {
         .collect(toList());
   }
 
-  public List<SanitizedSecret> getSanitizedSecrets(@Nullable Long expireMaxTime, @Nullable Group group, Object principal) {
-    return secretDAO.getSecrets(expireMaxTime, group, null, null, null, principal).stream()
-        .map(SanitizedSecret::fromSecretSeriesAndContent)
-        .collect(toList());
-  }
-
   /**
    * @param expireMaxTime timestamp for farthest expiry to include
    * @return all existing sanitized secrets and their groups matching criteria.
@@ -213,14 +207,6 @@ public class SecretController {
     checkArgument(idx >= 0, "Index must be positive when getting batched secret names!");
     checkArgument(num >= 0, "Num must be positive when getting batched secret names!");
     return secretDAO.getSecretsBatched(idx, num, newestFirst).stream()
-        .map(SanitizedSecret::fromSecretSeriesAndContent)
-        .collect(toList());
-  }
-
-  public List<SanitizedSecret> getSecretsBatched(int idx, int num, boolean newestFirst, Object principal) {
-    checkArgument(idx >= 0, "Index must be positive when getting batched secret names!");
-    checkArgument(num >= 0, "Num must be positive when getting batched secret names!");
-    return secretDAO.getSecretsBatched(idx, num, newestFirst, principal).stream()
         .map(SanitizedSecret::fromSecretSeriesAndContent)
         .collect(toList());
   }
@@ -348,22 +334,6 @@ public class SecretController {
         return transformer.transform(secretDAO.getSecretByName(name).get());
     }
 
-    public Secret create(Object principal) {
-      secretDAO.createSecret(
-          name,
-          ownerName,
-          encryptedSecret,
-          hmac,
-          creator,
-          metadata,
-          expiry,
-          description,
-          type,
-          generationOptions,
-          principal);
-      return transformer.transform(secretDAO.getSecretByName(name, principal).get());
-    }
-
     public Secret createOrUpdate() {
       secretDAO.createOrUpdateSecret(
           name,
@@ -377,22 +347,6 @@ public class SecretController {
           type,
           generationOptions);
       return transformer.transform(secretDAO.getSecretByName(name).get());
-    }
-
-    public Secret createOrUpdate(Object principal) {
-      secretDAO.createOrUpdateSecret(
-          name,
-          ownerName,
-          encryptedSecret,
-          hmac,
-          creator,
-          metadata,
-          expiry,
-          description,
-          type,
-          generationOptions,
-          principal);
-      return transformer.transform(secretDAO.getSecretByName(name, principal).get());
     }
   }
 }

--- a/server/src/main/java/keywhiz/service/daos/SecretDAO.java
+++ b/server/src/main/java/keywhiz/service/daos/SecretDAO.java
@@ -162,23 +162,6 @@ public class SecretDAO {
     });
   }
 
-  public long createSecret(
-      String name,
-      String ownerName,
-      String encryptedSecret,
-      String hmac,
-      String creator,
-      Map<String, String> metadata,
-      long expiry,
-      String description,
-      @Nullable String type,
-      @Nullable Map<String, String> generationOptions,
-      Object principal) {
-    permissionCheck.checkAllowedOrThrow(principal, Action.CREATE);
-
-    return createSecret(name, ownerName, encryptedSecret, hmac, creator, metadata, expiry, description, type, generationOptions);
-  }
-
   @VisibleForTesting
   public long createOrUpdateSecret(
       String name,
@@ -236,29 +219,6 @@ public class SecretDAO {
 
       return secretId;
     });
-  }
-
-  public long createOrUpdateSecret(
-      String name,
-      String owner,
-      String encryptedSecret,
-      String hmac,
-      String creator,
-      Map<String, String> metadata,
-      long expiry,
-      String description,
-      @Nullable String type,
-      @Nullable Map<String, String> generationOptions,
-      Object principal) {
-    Optional<SecretSeries> maybeSecretSeries = secretSeriesDAOFactory.using(dslContext.configuration())
-        .getSecretSeriesByName(name);
-    if (maybeSecretSeries.isPresent()) {
-      permissionCheck.checkAllowedOrThrow(principal, Action.UPDATE, maybeSecretSeries.get());
-    } else {
-      permissionCheck.checkAllowedOrThrow(principal, Action.CREATE);
-    }
-
-    return createOrUpdateSecret(name, owner, encryptedSecret, hmac, creator, metadata, expiry, description, type, generationOptions);
   }
 
   @VisibleForTesting
@@ -404,14 +364,6 @@ public class SecretDAO {
     return Optional.empty();
   }
 
-  public Optional<SecretSeriesAndContent> getSecretByName(String name, Object principal) {
-    Optional<SecretSeries> maybeSecretSeries = secretSeriesDAOFactory.using(dslContext.configuration())
-        .getSecretSeriesByName(name);
-    permissionCheck.checkAllowedOrThrow(principal, Action.READ, maybeSecretSeries.orElse(null));
-
-    return getSecretByName(name);
-  }
-
   /**
    * @param names of secrets series to look up secrets by.
    * @return Secrets matching input parameters.
@@ -472,14 +424,6 @@ public class SecretDAO {
     });
   }
 
-  public ImmutableList<SecretSeriesAndContent> getSecrets(@Nullable Long expireMaxTime,
-      @Nullable Group group, @Nullable Long expireMinTime, @Nullable String minName,
-      @Nullable Integer limit, Object principal) {
-    permissionCheck.checkAllowedOrThrow(principal, Action.READ);
-
-    return getSecrets(expireMaxTime, group, expireMinTime, minName, limit);
-  }
-
   /**
    * @return A list of id, name
    */
@@ -515,13 +459,6 @@ public class SecretDAO {
 
       return secretsBuilder.build();
     });
-  }
-
-  public ImmutableList<SecretSeriesAndContent> getSecretsBatched(int idx, int num,
-      boolean newestFirst, Object principal) {
-      permissionCheck.checkAllowedOrThrow(principal, Action.READ);
-
-      return getSecretsBatched(idx, num, newestFirst);
   }
 
   /**
@@ -626,14 +563,6 @@ public class SecretDAO {
 
     secretSeriesDAOFactory.using(dslContext.configuration())
         .deleteSecretSeriesByName(name);
-  }
-
-  public void deleteSecretsByName(String name, Object principal) {
-    Optional<SecretSeries> maybeSecretSeries = secretSeriesDAOFactory.using(dslContext.configuration())
-        .getSecretSeriesByName(name);
-    permissionCheck.checkAllowedOrThrow(principal, Action.DELETE, maybeSecretSeries.orElse(null));
-
-    deleteSecretsByName(name);
   }
 
   /**


### PR DESCRIPTION
https://jira.sqprod.co/browse/CISM-3876

Instead of adding permission checks at the DAO level with overloaded methods like in https://github.com/square/keywhiz/pull/1094, I decided to move all the permission checks to the Resource level so the principal (automation client) didn't need to be passed down. It also simplified the code because most of the resource methods already retrieved Secrets from the DAO, so a permission check could be added right after.