### PR TITLE
Added owned secrets and groups endpoint

### DIFF
--- a/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
+++ b/server/src/main/java/keywhiz/service/resources/automation/v2/GroupResource.java
@@ -210,6 +210,38 @@ public class GroupResource {
   }
 
   /**
+   * Retrieve metadata for owned secrets of a particular group, including all
+   * groups linked to each secret.
+   *
+   * @param name Group name
+   *
+   * responseMessage 200 Group information retrieved
+   * responseMessage 404 Group not found
+   */
+  @Timed @ExceptionMetered
+  @GET
+  @Path("{name}/ownedsecretsandgroups")
+  @Produces(APPLICATION_JSON)
+  public Set<SanitizedSecretWithGroups> ownedSecretsWithGroupsForGroup(@Auth AutomationClient automationClient,
+      @PathParam("name") String name) {
+    Group group = groupDAOReadOnly.getGroup(name)
+        .orElseThrow(NotFoundException::new);
+
+    Set<SanitizedSecret> secrets =  aclDAOReadOnly.getOwnedSanitizedSecretsFor(group);
+
+    Map<Long, List<Group>> groupsForSecrets = aclDAOReadOnly.getGroupsForSecrets(secrets.stream().map(SanitizedSecret::id).collect(
+        Collectors.toUnmodifiableSet()));
+
+    return secrets.stream().map(s -> {
+      List<Group> groups = groupsForSecrets.get(s.id());
+      if (groups == null) {
+        groups = ImmutableList.of();
+      }
+      return SanitizedSecretWithGroups.of(s, groups);
+    }).collect(Collectors.toUnmodifiableSet());
+  }
+
+  /**
    * Retrieve metadata for clients in a particular group.
    *
    * @param name Group name

--- a/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
+++ b/server/src/test/java/keywhiz/service/daos/AclDAOTest.java
@@ -48,6 +48,7 @@ import static keywhiz.jooq.tables.Memberships.MEMBERSHIPS;
 import static keywhiz.jooq.tables.Secrets.SECRETS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(KeywhizTestRunner.class)
 public class AclDAOTest {
@@ -90,8 +91,8 @@ public class AclDAOTest {
     group3 = groupDAO.getGroupById(id).get();
 
     SecretFixtures secretFixtures = SecretFixtures.using(secretDAOFactory.readwrite());
-    secret1 = secretFixtures.createSecret("secret1", "c2VjcmV0MQ==");
-    secret2 = secretFixtures.createSecret("secret2", "c2VjcmV0Mg==");
+    secret1 = secretFixtures.createSecret("secret1", "c2VjcmV0MQ==", "group1");
+    secret2 = secretFixtures.createSecret("secret2", "c2VjcmV0Mg==", "group1");
   }
 
   @Test public void listingRenamedSecretDoesNotFailHmacCheck() {
@@ -205,6 +206,19 @@ public class AclDAOTest {
         assertThat(secret).isEqualToIgnoringGivenFields(sanitizedSecret2, "id", "version");
       }
     }
+  }
+
+  @Test public void getOwnedSanitizedSecretsForGroupWithSecrets() {
+    SanitizedSecret sanitizedSecret1 = SanitizedSecret.fromSecret(secret1);
+    SanitizedSecret sanitizedSecret2 = SanitizedSecret.fromSecret(secret2);
+
+    Set<SanitizedSecret> secrets = aclDAO.getOwnedSanitizedSecretsFor(group1);
+    assertEquals(Set.of(sanitizedSecret1, sanitizedSecret2), secrets);
+  }
+
+  @Test public void getOwnedSanitizedSecretsForGroupWithoutSecrets() {
+    Set<SanitizedSecret> secrets = aclDAO.getOwnedSanitizedSecretsFor(group2);
+    assertThat(secrets).isEmpty();
   }
 
   @Test public void getGroupsForSecret() {

--- a/server/src/test/java/keywhiz/service/daos/SecretFixtures.java
+++ b/server/src/test/java/keywhiz/service/daos/SecretFixtures.java
@@ -53,13 +53,13 @@ public class SecretFixtures {
    * @param content secret content
    * @return created secret model
    */
-  public Secret createSecret(String name, String content) {
+  public Secret createSecret(String name, String content, String ownerName) {
     String hmac = cryptographer.computeHmac(content.getBytes(UTF_8), "hmackey");
     if (hmac == null) {
       throw new ContentEncodingException("Error encoding content in SecretFixture!");
     }
     String encryptedContent = cryptographer.encryptionKeyDerivedFrom(name).encrypt(content);
-    long id = secretDAO.createSecret(name, null, encryptedContent, hmac, "creator", ImmutableMap.of(), 0, "", null,
+    long id = secretDAO.createSecret(name, ownerName, encryptedContent, hmac, "creator", ImmutableMap.of(), 0, "", null,
         ImmutableMap.of());
     return transformer.transform(secretDAO.getSecretById(id).get());
   }


### PR DESCRIPTION
https://jira.sqprod.co/browse/CISM-4094

To list the owned secrets, Console currently calls Secrets Authority through [this endpoint](https://github.com/squareup/square-console/blob/cd94122c71a9b56376fa8f4373cc3df11cab84b5/subapps/sqc-subapp-security/src/features/secrets/services/SecretsAuthorityService.ts#L66). In Secrets Authority, [this method](https://github.com/squareup/go-square/blob/eb1e866abb9557a44d5a5377cf3722f616f0020f/secrets-authority/sa/authority.go#L839) is called which uses this [keywhiz endpoint](https://github.com/squareup/go-square/blob/eb1e866abb9557a44d5a5377cf3722f616f0020f/client/keywhiz/client.go#L554). In order to reuse the code for GetAppSecrets() in Secrets Authority, I've added a similar keywhiz endpoint for owned secrets.