### PR TITLE
Ignore jOOQ 3.17 or higher

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,18 +61,19 @@ updates:
   - dependency-name: mysql:mysql-connector-java
     versions:
     - 8.0.23
+  # jOOQ 3.17 requires Java 17
   - dependency-name: org.jooq:jooq-codegen-maven
     versions:
-    - 3.14.6
+    - ">= 3.17"
   - dependency-name: org.jooq:jooq-codegen
     versions:
-    - 3.14.6
+    - ">= 3.17"
   - dependency-name: org.jooq:jooq-meta
     versions:
-    - 3.14.6
+    - ">= 3.17"
   - dependency-name: org.jooq:jooq
     versions:
-    - 3.14.6
+    - ">= 3.17"
   - dependency-name: org.bouncycastle:bcprov-jdk15on
     versions:
     - "1.68"


### PR DESCRIPTION
We need to switch to Java 17 first according to the release notes https://blog.jooq.org/3-17-0-release-with-computed-columns-audit-columns-pattern-matching-reactive-transactions-and-kotlin-coroutine-support/