### PR TITLE
remove AlwaysAllow safety check

### DIFF
--- a/server/src/main/java/keywhiz/service/permissions/PermissionCheckModule.java
+++ b/server/src/main/java/keywhiz/service/permissions/PermissionCheckModule.java
@@ -14,7 +14,7 @@ public class PermissionCheckModule extends AbstractModule {
   public PermissionCheck createPermissionCheck(MetricRegistry metricRegistry,
       AutomationClientPermissionCheck automationClientCheck,
       OwnershipPermissionCheck ownershipCheck) {
-    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(List.of(ownershipCheck, automationClientCheck));
-    return new AlwaysAllowDelegatingPermissionCheck(metricRegistry, anyPermissionCheck);
+    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(metricRegistry, List.of(ownershipCheck, automationClientCheck));
+    return anyPermissionCheck;
   }
 }

--- a/server/src/test/java/keywhiz/service/permission/AnyPermissionCheckTest.java
+++ b/server/src/test/java/keywhiz/service/permission/AnyPermissionCheckTest.java
@@ -1,10 +1,12 @@
 package keywhiz.service.permission;
 
+import com.codahale.metrics.MetricRegistry;
 import java.util.Collections;
 import java.util.List;
 import keywhiz.service.permissions.Action;
 import keywhiz.service.permissions.AnyPermissionCheck;
 import keywhiz.service.permissions.PermissionCheck;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -26,40 +28,47 @@ public class AnyPermissionCheckTest {
   private static Object source;
   private static Object target;
 
+  private MetricRegistry metricRegistry;
+
+  @Before
+  public void setUp() {
+    metricRegistry = new MetricRegistry();
+  }
+
   @Test public void isAllowedReturnsFalseWithEmptyCheckList() {
-    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(Collections.emptyList());
+    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(metricRegistry, Collections.emptyList());
 
     assertFalse(anyPermissionCheck.isAllowed(source, Action.ADD, target));
   }
 
   @Test public void isAllowedReturnsFalseWhenAllDelegatesReturnFalse() {
-    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(createDelegatesList(false, false));
+    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(metricRegistry, createDelegatesList(false, false));
 
     assertFalse(anyPermissionCheck.isAllowed(source, Action.ADD, target));
   }
 
   @Test public void isAllowedReturnsTrueWhenOneDelegateReturnsTrue() {
-    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(createDelegatesList(true, false));
+    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(metricRegistry, createDelegatesList(true, false));
 
     assertTrue(anyPermissionCheck.isAllowed(source, Action.ADD, target));
   }
 
   @Test public void checkAllowedOrThrowThrowsExceptionWithEmptyCheckList() {
-    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(Collections.emptyList());
+    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(metricRegistry, Collections.emptyList());
 
     assertThatThrownBy(() -> anyPermissionCheck.checkAllowedOrThrow(source, Action.ADD, target))
         .isInstanceOf(RuntimeException.class);
   }
 
   @Test public void checkAllowedOrThrowThrowsExceptionWhenAllDelegatesReturnFalse() {
-    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(createDelegatesList(false, false));
+    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(metricRegistry, createDelegatesList(false, false));
 
     assertThatThrownBy(() -> anyPermissionCheck.checkAllowedOrThrow(source, Action.ADD, target))
         .isInstanceOf(RuntimeException.class);
   }
 
   @Test public void checkAllowedOrThrowReturnsVoidWhenOneDelegateReturnsTrue() {
-    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(createDelegatesList(true, false));
+    PermissionCheck anyPermissionCheck = new AnyPermissionCheck(metricRegistry, createDelegatesList(true, false));
 
     anyPermissionCheck.checkAllowedOrThrow(source, Action.ADD, target);
   }


### PR DESCRIPTION
The permission check right now is wrapped by an AlwaysAllow permission check as a safety net so that none of the calls succeeding right now will fail. Since the functions integrated with the permission checks can only be called by automation client and one of the permission checks implemented is the automation client check, removing the AlwaysAllow safety net should have no effect.