### PR TITLE
Adding CLI option to the "describe secrets" action to include deleted secrets

### DIFF
--- a/cli/src/main/java/keywhiz/cli/Printing.java
+++ b/cli/src/main/java/keywhiz/cli/Printing.java
@@ -154,6 +154,15 @@ public class Printing {
     System.out.println(DOUBLE_INDENT + DateFormat.getDateTimeInstance().format(d));
   }
 
+  public void printDeletedSecretsWithDetails(List<SanitizedSecret> deletedSecrets) {
+    System.out.println("Deleted Secrets:");
+    if (deletedSecrets.isEmpty()) {
+      System.out.println("None found");
+    } else {
+      deletedSecrets.forEach(this::printSanitizedSecretWithDetails);
+    }
+  }
+
   public void printSanitizedSecretWithDetails(SanitizedSecret secret) {
     System.out.println(SanitizedSecret.displayName(secret));
     SecretDetailResponse secretDetails;
@@ -162,6 +171,9 @@ public class Printing {
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }
+
+    System.out.println(INDENT + "Internal Identifier:");
+    System.out.println(DOUBLE_INDENT + secret.id());
 
     System.out.println(INDENT + "Owner:");
     if (secret.owner() != null) {

--- a/cli/src/main/java/keywhiz/cli/Printing.java
+++ b/cli/src/main/java/keywhiz/cli/Printing.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import keywhiz.api.ClientDetailResponse;
 import keywhiz.api.GroupDetailResponse;
@@ -154,12 +155,19 @@ public class Printing {
     System.out.println(DOUBLE_INDENT + DateFormat.getDateTimeInstance().format(d));
   }
 
-  public void printDeletedSecretsWithDetails(List<SanitizedSecret> deletedSecrets) {
-    System.out.println("Deleted Secrets:");
-    if (deletedSecrets.isEmpty()) {
-      System.out.println("None found");
-    } else {
+  public void printDeletedSecretsWithDetails(@Nullable List<SanitizedSecret> deletedSecrets) {
+    int deletedCount = deletedSecrets == null ? 0 : deletedSecrets.size();
+    System.out.println(String.format("Deleted Secrets: found %d", deletedCount));
+    if (deletedSecrets != null) {
       deletedSecrets.forEach(this::printSanitizedSecretWithDetails);
+    }
+  }
+
+  public void printNonDeletedSecretWithDetails(@Nullable SanitizedSecret secret) {
+    if (secret == null) {
+      System.out.println("No non-deleted secret found.");
+    } else {
+      printSanitizedSecretWithDetails(secret);
     }
   }
 
@@ -172,7 +180,7 @@ public class Printing {
       throw Throwables.propagate(e);
     }
 
-    System.out.println(INDENT + "Internal Identifier:");
+    System.out.println(INDENT + "Internal ID:");
     System.out.println(DOUBLE_INDENT + secret.id());
 
     System.out.println(INDENT + "Owner:");

--- a/cli/src/main/java/keywhiz/cli/configs/DescribeActionConfig.java
+++ b/cli/src/main/java/keywhiz/cli/configs/DescribeActionConfig.java
@@ -28,4 +28,7 @@ public class DescribeActionConfig {
 
   @Parameter(names = "--name", description = "Name of the item to describe", required = true)
   public String name;
+
+  @Parameter(names = { "-d", "--include-deleted" }, description = "Whether to include any deleted secret(s) that match the provided name")
+  public Boolean includeDeleted = false;
 }

--- a/cli/src/main/java/keywhiz/cli/configs/DescribeActionConfig.java
+++ b/cli/src/main/java/keywhiz/cli/configs/DescribeActionConfig.java
@@ -30,5 +30,5 @@ public class DescribeActionConfig {
   public String name;
 
   @Parameter(names = { "-d", "--include-deleted" }, description = "Whether to include any deleted secret(s) that match the provided name")
-  public Boolean includeDeleted = false;
+  public boolean includeDeleted = false;
 }

--- a/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
@@ -19,7 +19,6 @@ package keywhiz.cli.commands;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 import keywhiz.api.ApiDate;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
@@ -32,15 +31,12 @@ import keywhiz.client.KeywhizClient.NotFoundException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
@@ -113,7 +113,7 @@ public class DescribeActionTest {
 
     describeAction.run();
 
-    verify(printing).printSanitizedSecretWithDetails(sanitizedSecret);
+    verify(printing).printNonDeletedSecretWithDetails(sanitizedSecret);
     verify(printing, never()).printDeletedSecretsWithDetails(deletedSecrets);
   }
 
@@ -128,7 +128,7 @@ public class DescribeActionTest {
 
     describeAction.run();
 
-    verify(printing).printSanitizedSecretWithDetails(sanitizedSecretABC);
+    verify(printing).printNonDeletedSecretWithDetails(sanitizedSecretABC);
     verify(printing).printDeletedSecretsWithDetails(deletedSecrets);
   }
 
@@ -143,7 +143,7 @@ public class DescribeActionTest {
 
     describeAction.run();
 
-    verify(printing).printSanitizedSecretWithDetails(sanitizedSecretABC);
+    verify(printing).printNonDeletedSecretWithDetails(sanitizedSecretABC);
     verify(printing).printDeletedSecretsWithDetails(emptyDeletedSecrets);
   }
 
@@ -158,7 +158,7 @@ public class DescribeActionTest {
 
     describeAction.run();
 
-    verify(printing, never()).printSanitizedSecretWithDetails(sanitizedSecretABC);
+    verify(printing, never()).printNonDeletedSecretWithDetails(sanitizedSecretABC);
     verify(printing).printDeletedSecretsWithDetails(deletedSecrets);
   }
 
@@ -173,7 +173,7 @@ public class DescribeActionTest {
 
     describeAction.run();
 
-    verify(printing, never()).printSanitizedSecretWithDetails(sanitizedSecretABC);
+    verify(printing, never()).printNonDeletedSecretWithDetails(sanitizedSecretABC);
     verify(printing).printDeletedSecretsWithDetails(emptyDeletedSecrets);
   }
 
@@ -199,7 +199,7 @@ public class DescribeActionTest {
     describeAction.run();
   }
 
-  @Test(expected = AssertionError.class)
+  @Test(expected = RuntimeException.class)
   public void describeThrowsIfSecretDoesNotExist() throws Exception {
     describeActionConfig.describeType = Arrays.asList("secret");
     describeActionConfig.name = "nonexistent-secret-name";

--- a/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
+++ b/cli/src/test/java/keywhiz/cli/commands/DescribeActionTest.java
@@ -18,6 +18,8 @@ package keywhiz.cli.commands;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 import keywhiz.api.ApiDate;
 import keywhiz.api.model.Client;
 import keywhiz.api.model.Group;
@@ -30,11 +32,15 @@ import keywhiz.client.KeywhizClient.NotFoundException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +57,25 @@ public class DescribeActionTest {
   Secret secret = new Secret(0, "secret", null, null, () ->  "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
       ImmutableMap.of(), 0, 1L, NOW, null);
   SanitizedSecret sanitizedSecret = SanitizedSecret.fromSecret(secret);
+
+  Secret secretABC = new Secret(1, "ABC", null, null, () ->  "c2VjcmV0MQ==", "checksum", NOW, null, NOW, null, null, null,
+      ImmutableMap.of(), 0, 1L, NOW, null);
+  SanitizedSecret sanitizedSecretABC = SanitizedSecret.fromSecret(secretABC);
+
+  Secret deletedSecretABC1 =
+      new Secret(2, ".ABC.deleted.1674155945.237e9877-e79b-12d4-a765-321741963000", null, null,
+          () -> "c2VjcmV0NQ==", "checksum", NOW, null, NOW, null, null, null, ImmutableMap.of(), 0,
+          1L, NOW, null);
+  SanitizedSecret sanitizedDeletedSecretABC1 = SanitizedSecret.fromSecret(deletedSecretABC1);
+
+  Secret deletedSecretABC2 =
+      new Secret(3, ".ABC.deleted.2674155946.348e9877-e79b-12d4-a765-432741963111", null, null,
+          () -> "c2VjcmV0NQ==", "checksum", NOW, null, NOW, null, null, null, ImmutableMap.of(), 0,
+          1L, NOW, null);
+  SanitizedSecret sanitizedDeletedSecretABC2 = SanitizedSecret.fromSecret(deletedSecretABC2);
+
+  List<SanitizedSecret> deletedSecrets = List.of(sanitizedDeletedSecretABC1, sanitizedDeletedSecretABC2);
+  List<SanitizedSecret> emptyDeletedSecrets = List.of();
 
   @Before
   public void setUp() {
@@ -84,14 +109,76 @@ public class DescribeActionTest {
   }
 
   @Test
-  public void describeCallsPrintForSecret() throws Exception {
+  public void describeCallsPrintForNonDeletedSecret() throws Exception {
     describeActionConfig.describeType = Arrays.asList("secret");
     describeActionConfig.name = "General_Password";
 
     when(keywhizClient.getSanitizedSecretByName(anyString())).thenReturn(sanitizedSecret);
 
     describeAction.run();
+
     verify(printing).printSanitizedSecretWithDetails(sanitizedSecret);
+    verify(printing, never()).printDeletedSecretsWithDetails(deletedSecrets);
+  }
+
+  @Test
+  public void describeCallsPrintForNonDeletedSecretAndDeletedSecrets() throws Exception {
+    describeActionConfig.describeType = Arrays.asList("secret");
+    describeActionConfig.name = "ABC";
+    describeActionConfig.includeDeleted = true;
+
+    when(keywhizClient.getSanitizedSecretByName("ABC")).thenReturn(sanitizedSecretABC);
+    when(keywhizClient.getDeletedSecretsByName("ABC")).thenReturn(deletedSecrets);
+
+    describeAction.run();
+
+    verify(printing).printSanitizedSecretWithDetails(sanitizedSecretABC);
+    verify(printing).printDeletedSecretsWithDetails(deletedSecrets);
+  }
+
+  @Test
+  public void describeCallsPrintForNonDeletedSecretAndEmptyDeletedSecrets() throws Exception {
+    describeActionConfig.describeType = Arrays.asList("secret");
+    describeActionConfig.name = "ABC";
+    describeActionConfig.includeDeleted = true;
+
+    when(keywhizClient.getSanitizedSecretByName("ABC")).thenReturn(sanitizedSecretABC);
+    when(keywhizClient.getDeletedSecretsByName("ABC")).thenReturn(emptyDeletedSecrets);
+
+    describeAction.run();
+
+    verify(printing).printSanitizedSecretWithDetails(sanitizedSecretABC);
+    verify(printing).printDeletedSecretsWithDetails(emptyDeletedSecrets);
+  }
+
+  @Test
+  public void describeCallsPrintForDeletedSecrets() throws Exception {
+    describeActionConfig.describeType = Arrays.asList("secret");
+    describeActionConfig.name = "ABC";
+    describeActionConfig.includeDeleted = true;
+
+    when(keywhizClient.getSanitizedSecretByName("ABC")).thenThrow(new NotFoundException());
+    when(keywhizClient.getDeletedSecretsByName("ABC")).thenReturn(deletedSecrets);
+
+    describeAction.run();
+
+    verify(printing, never()).printSanitizedSecretWithDetails(sanitizedSecretABC);
+    verify(printing).printDeletedSecretsWithDetails(deletedSecrets);
+  }
+
+  @Test
+  public void describeCallsPrintForEmptyDeletedSecrets() throws Exception {
+    describeActionConfig.describeType = Arrays.asList("secret");
+    describeActionConfig.name = "ABC";
+    describeActionConfig.includeDeleted = true;
+
+    when(keywhizClient.getSanitizedSecretByName("ABC")).thenThrow(new NotFoundException());
+    when(keywhizClient.getDeletedSecretsByName("ABC")).thenReturn(emptyDeletedSecrets);
+
+    describeAction.run();
+
+    verify(printing, never()).printSanitizedSecretWithDetails(sanitizedSecretABC);
+    verify(printing).printDeletedSecretsWithDetails(emptyDeletedSecrets);
   }
 
   @Test(expected = AssertionError.class)
@@ -120,6 +207,17 @@ public class DescribeActionTest {
   public void describeThrowsIfSecretDoesNotExist() throws Exception {
     describeActionConfig.describeType = Arrays.asList("secret");
     describeActionConfig.name = "nonexistent-secret-name";
+
+    when(keywhizClient.getSanitizedSecretByName(anyString())).thenThrow(new NotFoundException());
+
+    describeAction.run();
+  }
+
+  @Test
+  public void describeDoesNotThrowIfSecretDoesNotExistButIncludeDeletedIsSet() throws Exception {
+    describeActionConfig.describeType = Arrays.asList("secret");
+    describeActionConfig.name = "nonexistent-secret-name";
+    describeActionConfig.includeDeleted = true;
 
     when(keywhizClient.getSanitizedSecretByName(anyString())).thenThrow(new NotFoundException());
 

--- a/client/src/main/java/keywhiz/client/KeywhizClient.java
+++ b/client/src/main/java/keywhiz/client/KeywhizClient.java
@@ -350,6 +350,14 @@ public class KeywhizClient {
     return mapper.readValue(response, SanitizedSecret.class);
   }
 
+  public List<SanitizedSecret> getDeletedSecretsByName(String name) throws IOException {
+    checkArgument(!name.isEmpty());
+    String response =
+        httpGet(baseUrl.resolve(format("/admin/secrets/deleted/%s", name)).newBuilder().build());
+    return mapper.readValue(response, new TypeReference<>() {
+    });
+  }
+
   public boolean isLoggedIn() throws IOException {
     HttpUrl url = baseUrl.resolve("/admin/me");
     Call call = client.newCall(new Request.Builder().get().url(url).build());

--- a/client/src/main/java/keywhiz/client/KeywhizClient.java
+++ b/client/src/main/java/keywhiz/client/KeywhizClient.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.ws.rs.core.HttpHeaders;
 import keywhiz.api.ClientDetailResponse;
 import keywhiz.api.GroupDetailResponse;
@@ -350,10 +351,16 @@ public class KeywhizClient {
     return mapper.readValue(response, SanitizedSecret.class);
   }
 
+  @Nullable
   public List<SanitizedSecret> getDeletedSecretsByName(String name) throws IOException {
     checkArgument(!name.isEmpty());
     String response =
-        httpGet(baseUrl.resolve(format("/admin/secrets/deleted/%s", name)).newBuilder().build());
+        httpGet(baseUrl.newBuilder()
+            .addPathSegment("admin")
+            .addPathSegment("secrets")
+            .addPathSegment("deleted")
+            .addPathSegment(name)
+            .build());
     return mapper.readValue(response, new TypeReference<>() {
     });
   }


### PR DESCRIPTION
Usage:

```
$ keywhiz.cli describe secret --name="foo" --include-deleted
```

Added unit tests to test the new behavior.