### PR TITLE
Print deleted secret info

### DIFF
--- a/cli/src/main/java/keywhiz/cli/Printing.java
+++ b/cli/src/main/java/keywhiz/cli/Printing.java
@@ -161,8 +161,41 @@ public class Printing {
     int deletedCount = deletedSecrets == null ? 0 : deletedSecrets.size();
     System.out.println(String.format("Deleted Secrets: found %d", deletedCount));
     if (deletedSecrets != null) {
-      deletedSecrets.forEach(series -> this.printSecretWithDetails(series.id()));
+      deletedSecrets.forEach(series -> this.printDeletedSecretWithDetails(series));
     }
+  }
+
+  private void printDeletedSecretWithDetails(SecretSeries secret) {
+    System.out.println(secret.name());
+
+    System.out.println(INDENT + "Internal ID:");
+    System.out.println(DOUBLE_INDENT + secret.id());
+
+    System.out.println(INDENT + "Owner:");
+    if (secret.owner() != null && !secret.owner().isEmpty()) {
+      System.out.println(DOUBLE_INDENT + secret.owner());
+    }
+
+    if (!secret.description().isEmpty()) {
+      System.out.println(INDENT + "Description:");
+      System.out.println(DOUBLE_INDENT + secret.description());
+    }
+
+    if (!secret.createdBy().isEmpty()) {
+      System.out.println(INDENT + "Created by:");
+      System.out.println(DOUBLE_INDENT + secret.createdBy());
+    }
+
+    System.out.println(INDENT + "Created at:");
+    System.out.println(DOUBLE_INDENT + apiDateToString(secret.createdAt()));
+
+    if (!secret.updatedBy().isEmpty()) {
+      System.out.println(INDENT + "Updated by:");
+      System.out.println(DOUBLE_INDENT + secret.updatedBy());
+    }
+
+    System.out.println(INDENT + "Updated at:");
+    System.out.println(DOUBLE_INDENT + apiDateToString(secret.updatedAt()));
   }
 
   public void printNonDeletedSecretWithDetails(@Nullable SanitizedSecret secret) {


### PR DESCRIPTION
Followup to [#1193](https://github.com/square/keywhiz/pull/1193).

We can't actually use `/admin/secrets/{id}` for deleted secrets because that endpoint only works for non-deleted secrets. Furthermore, it's impossible to modify that endpoint to work for deleted secrets, at least preserving its current behavior. This is because it fetches information about the current version of a secret. However, deleted secrets have their "current" field nulled out when they're deleted.

Given that there is information lost when the secret is deleted, I'm no longer trying to treat deleted secrets and non-deleted secrets equally when printing information about them.

I was able to test the CLI with this change on a canary node and verify that information about deleted secrets is successfully fetched and printed:

```
> keywhiz.cli describe secret --name test-secret --include-deleted
password for '{username}': 
No non-deleted secret found.
Deleted Secrets: found 1
.test-secret.deleted.{timestamp}.{uuid}
	Internal ID:
		{id}
	Created by:
		{username}
	Created at:
		{timestamp}
	Updated by:
		{username}
	Updated at:
		{timestamp}
```