### PR TITLE
Add AUTO_INCREMENT to deleted_accessgrants.id

### DIFF
--- a/model/src-generated/main/java/keywhiz/jooq/tables/DeletedAccessgrants.java
+++ b/model/src-generated/main/java/keywhiz/jooq/tables/DeletedAccessgrants.java
@@ -14,6 +14,7 @@ import keywhiz.jooq.tables.records.DeletedAccessgrantsRecord;
 
 import org.jooq.Field;
 import org.jooq.ForeignKey;
+import org.jooq.Identity;
 import org.jooq.Index;
 import org.jooq.Name;
 import org.jooq.Record;
@@ -53,7 +54,7 @@ public class DeletedAccessgrants extends TableImpl<DeletedAccessgrantsRecord> {
     /**
      * The column <code>keywhizdb_test.deleted_accessgrants.id</code>.
      */
-    public final TableField<DeletedAccessgrantsRecord, Long> ID = createField(DSL.name("id"), SQLDataType.BIGINT.nullable(false), this, "");
+    public final TableField<DeletedAccessgrantsRecord, Long> ID = createField(DSL.name("id"), SQLDataType.BIGINT.nullable(false).identity(true), this, "");
 
     /**
      * The column <code>keywhizdb_test.deleted_accessgrants.groupid</code>.
@@ -123,6 +124,11 @@ public class DeletedAccessgrants extends TableImpl<DeletedAccessgrantsRecord> {
     @Override
     public List<Index> getIndexes() {
         return Arrays.asList(Indexes.DELETED_ACCESSGRANTS_DAG_GROUPID_SECRETID_IDX, Indexes.DELETED_ACCESSGRANTS_DAG_SECRETID_IDX);
+    }
+
+    @Override
+    public Identity<DeletedAccessgrantsRecord, Long> getIdentity() {
+        return (Identity<DeletedAccessgrantsRecord, Long>) super.getIdentity();
     }
 
     @Override

--- a/server/src/main/resources/db/mysql/migration/V19__add_auto_increment_to_deleted_access_grants_id.sql
+++ b/server/src/main/resources/db/mysql/migration/V19__add_auto_increment_to_deleted_access_grants_id.sql
@@ -1,0 +1,13 @@
+DROP TABLE deleted_accessgrants;
+
+CREATE TABLE `deleted_accessgrants` (
+    `id` bigint(20) NOT NULL AUTO_INCREMENT,
+    `groupid` bigint(20) NOT NULL,
+    `secretid` bigint(20) NOT NULL,
+    `updatedat` bigint(20) NOT NULL,
+    `createdat` bigint(20) NOT NULL,
+    `row_hmac` varchar(64) NOT NULL DEFAULT '',
+    PRIMARY KEY (`id`),
+    KEY `dag_groupid_secretid_idx` (`groupid`,`secretid`),
+    KEY `dag_secretid_idx` (`secretid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/server/src/main/resources/db/mysql/migration/V19__add_auto_increment_to_deleted_access_grants_id.sql
+++ b/server/src/main/resources/db/mysql/migration/V19__add_auto_increment_to_deleted_access_grants_id.sql
@@ -1,13 +1,1 @@
-DROP TABLE deleted_accessgrants;
-
-CREATE TABLE `deleted_accessgrants` (
-    `id` bigint(20) NOT NULL AUTO_INCREMENT,
-    `groupid` bigint(20) NOT NULL,
-    `secretid` bigint(20) NOT NULL,
-    `updatedat` bigint(20) NOT NULL,
-    `createdat` bigint(20) NOT NULL,
-    `row_hmac` varchar(64) NOT NULL DEFAULT '',
-    PRIMARY KEY (`id`),
-    KEY `dag_groupid_secretid_idx` (`groupid`,`secretid`),
-    KEY `dag_secretid_idx` (`secretid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+ALTER TABLE `deleted_accessgrants` MODIFY `id` bigint(20) NOT NULL AUTO_INCREMENT;


### PR DESCRIPTION
Since deleted_accessgrants needs to be able to have its own ID space independent of accessgrants, we should add AUTO_INCREMENT here. 

This should be safe because the table is empty in staging and production (and I can manually empty it in staging-test), so there shouldn't be any problems with duplicate primary key errors when the auto-assigned values conflict with the existing values in the table (as mentioned [here](https://stackoverflow.com/questions/5035836/how-to-add-auto-increment-to-an-existing-column)).

Why do the IDs of rows in deleted_accessgrants need to be independent of the IDs of rows in accessgrants? If a row with ID=1 is deleted from accessgrants and copied to deleted_accessgrants with ID=1, a new row could later be created in accessgrants reusing the ID 1. If we attempted to copy that row over to deleted_accessgrants, there would be a duplicate entry error.

See [design](https://docs.google.com/presentation/d/1V-yGQ5ZkPuSuHiM_EpbUpdhrndf9So7xPOydYd8OYt4/edit#slide=id.g20e518955da_0_641) for expected behavior (note that the IDs change when moving data between accessgrants and deleted_accessgrants.)